### PR TITLE
Fix #21 : Support whitespaces inside :not()

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -2608,7 +2608,7 @@ class Parser
                     if ($nameParts === ['not'] || $nameParts === ['is'] ||
                         $nameParts === ['has'] || $nameParts === ['where']
                     ) {
-                        if ($this->matchChar('(') &&
+                        if ($this->matchChar('(', true) &&
                           ($this->selectors($subs, true) || true) &&
                           $this->matchChar(')')
                         ) {

--- a/tests/inputs/scss_css.scss
+++ b/tests/inputs/scss_css.scss
@@ -562,6 +562,10 @@ foo|* {
   a: b; }
 
 
+:not( .blah ) {
+  a: b; }
+
+
 :not([foo]) {
   a: b; }
 
@@ -591,6 +595,10 @@ foo|* {
 
 
 :not(#foo .bar > baz) {
+  a: b; }
+
+
+:not( #foo .bar > baz ) {
   a: b; }
 
 

--- a/tests/outputs/scss_css.css
+++ b/tests/outputs/scss_css.css
@@ -449,6 +449,9 @@ foo|* {
 :not(.blah) {
   a: b; }
 
+:not(.blah) {
+  a: b; }
+
 :not([foo]) {
   a: b; }
 
@@ -468,6 +471,9 @@ foo|* {
   a: b; }
 
 :not(a#foo.bar) {
+  a: b; }
+
+:not(#foo .bar > baz) {
   a: b; }
 
 :not(#foo .bar > baz) {

--- a/tests/outputs_numbered/scss_css.css
+++ b/tests/outputs_numbered/scss_css.css
@@ -556,98 +556,106 @@ foo|* {
   a: b; }
 
 /* line 565, inputs/scss_css.scss */
-:not([foo]) {
+:not(.blah) {
   a: b; }
 
 /* line 569, inputs/scss_css.scss */
-:not([foo^="bar"]) {
+:not([foo]) {
   a: b; }
 
 /* line 573, inputs/scss_css.scss */
-:not([baz|foo~="bar"]) {
+:not([foo^="bar"]) {
   a: b; }
 
 /* line 577, inputs/scss_css.scss */
-:not(:hover) {
+:not([baz|foo~="bar"]) {
   a: b; }
 
 /* line 581, inputs/scss_css.scss */
-:not(:nth-child(2n + 3)) {
+:not(:hover) {
   a: b; }
 
 /* line 585, inputs/scss_css.scss */
-:not(:not(#foo)) {
+:not(:nth-child(2n + 3)) {
   a: b; }
 
 /* line 589, inputs/scss_css.scss */
-:not(a#foo.bar) {
+:not(:not(#foo)) {
   a: b; }
 
 /* line 593, inputs/scss_css.scss */
-:not(#foo .bar > baz) {
+:not(a#foo.bar) {
   a: b; }
 
 /* line 597, inputs/scss_css.scss */
-:not(h1, h2, h3) {
+:not(#foo .bar > baz) {
+  a: b; }
+
+/* line 601, inputs/scss_css.scss */
+:not(#foo .bar > baz) {
   a: b; }
 
 /* line 605, inputs/scss_css.scss */
-foo {
-  a: "bang 1 bar  bip"; }
-
-/* line 609, inputs/scss_css.scss */
-:nth-child(-n) {
+:not(h1, h2, h3) {
   a: b; }
 
 /* line 613, inputs/scss_css.scss */
-:nth-child(+n) {
-  a: b; }
+foo {
+  a: "bang 1 bar  bip"; }
 
 /* line 617, inputs/scss_css.scss */
-:nth-child(even) {
+:nth-child(-n) {
   a: b; }
 
 /* line 621, inputs/scss_css.scss */
-:nth-child(odd) {
+:nth-child(+n) {
   a: b; }
 
 /* line 625, inputs/scss_css.scss */
-:nth-child(50) {
+:nth-child(even) {
   a: b; }
 
 /* line 629, inputs/scss_css.scss */
-:nth-child(-50) {
+:nth-child(odd) {
   a: b; }
 
 /* line 633, inputs/scss_css.scss */
-:nth-child(+50) {
+:nth-child(50) {
   a: b; }
 
 /* line 637, inputs/scss_css.scss */
-:nth-child(2n+3) {
+:nth-child(-50) {
   a: b; }
 
 /* line 641, inputs/scss_css.scss */
-:nth-child(2n-3) {
+:nth-child(+50) {
   a: b; }
 
 /* line 645, inputs/scss_css.scss */
-:nth-child(+2n-3) {
+:nth-child(2n+3) {
   a: b; }
 
 /* line 649, inputs/scss_css.scss */
-:nth-child(-2n+3) {
+:nth-child(2n-3) {
   a: b; }
 
 /* line 653, inputs/scss_css.scss */
-:nth-child(-2n+ 3) {
+:nth-child(+2n-3) {
   a: b; }
 
 /* line 657, inputs/scss_css.scss */
-:nth-child( 2n + 3) {
+:nth-child(-2n+3) {
   a: b; }
 
 /* line 661, inputs/scss_css.scss */
+:nth-child(-2n+ 3) {
+  a: b; }
+
+/* line 665, inputs/scss_css.scss */
+:nth-child( 2n + 3) {
+  a: b; }
+
+/* line 669, inputs/scss_css.scss */
 foo {
   a: foo bar baz;
   b: foo, #abc, -12;
@@ -666,306 +674,306 @@ foo {
 @page flap:first {
   prop1: val;
   prop2: val; }
-/* line 688, inputs/scss_css.scss */
+/* line 696, inputs/scss_css.scss */
 .foo {
   /* Foo */
   a: b; }
 
-/* line 693, inputs/scss_css.scss */
+/* line 701, inputs/scss_css.scss */
 .foo {
   /* Foo
    * Bar */
   a: b; }
 
 /* Foo */
-/* line 699, inputs/scss_css.scss */
+/* line 707, inputs/scss_css.scss */
 .foo {
   a: b; }
 
 /* Foo
  * Bar */
-/* line 704, inputs/scss_css.scss */
+/* line 712, inputs/scss_css.scss */
 .foo {
   a: b; }
 
-/* line 708, inputs/scss_css.scss */
+/* line 716, inputs/scss_css.scss */
 .foo #bar:baz(/* bang )*/ bip) {
   /* .a #foo */
   a: b; }
 
-/* line 712, inputs/scss_css.scss */
+/* line 720, inputs/scss_css.scss */
 > E {
   a: b; }
 
-/* line 716, inputs/scss_css.scss */
+/* line 724, inputs/scss_css.scss */
 + E {
   a: b; }
 
-/* line 720, inputs/scss_css.scss */
+/* line 728, inputs/scss_css.scss */
 ~ E {
   a: b; }
 
-/* line 724, inputs/scss_css.scss */
+/* line 732, inputs/scss_css.scss */
 > > E {
   a: b; }
 
-/* line 728, inputs/scss_css.scss */
+/* line 736, inputs/scss_css.scss */
 >> E {
   a: b; }
 
-/* line 732, inputs/scss_css.scss */
+/* line 740, inputs/scss_css.scss */
 E* {
   a: b; }
 
-/* line 736, inputs/scss_css.scss */
+/* line 744, inputs/scss_css.scss */
 E*.foo {
   a: b; }
 
-/* line 740, inputs/scss_css.scss */
+/* line 748, inputs/scss_css.scss */
 E*:hover {
   a: b; }
 
-/* line 744, inputs/scss_css.scss */
+/* line 752, inputs/scss_css.scss */
 E, F {
   a: b; }
 
-/* line 749, inputs/scss_css.scss */
+/* line 757, inputs/scss_css.scss */
 E F {
   a: b; }
 
-/* line 754, inputs/scss_css.scss */
+/* line 762, inputs/scss_css.scss */
 E, F G, H {
   a: b; }
 
-/* line 759, inputs/scss_css.scss */
+/* line 767, inputs/scss_css.scss */
 body {
   /*
    //comment here
    */ }
 
-/* line 766, inputs/scss_css.scss */
+/* line 774, inputs/scss_css.scss */
 E > F {
-  a: b; }
-
-/* line 768, inputs/scss_css.scss */
-E ~ F {
-  a: b; }
-
-/* line 770, inputs/scss_css.scss */
-E + F {
-  a: b; }
-
-/* line 772, inputs/scss_css.scss */
-* {
   a: b; }
 
 /* line 776, inputs/scss_css.scss */
-E {
+E ~ F {
   a: b; }
 
-/* line 780, inputs/scss_css.scss */
-E[foo] {
-  a: b; }
-
-/* line 784, inputs/scss_css.scss */
-E[foo="bar"] {
-  a: b; }
-
-/* line 788, inputs/scss_css.scss */
-E[foo~="bar"] {
-  a: b; }
-
-/* line 792, inputs/scss_css.scss */
-E[foo^="bar"] {
-  a: b; }
-
-/* line 796, inputs/scss_css.scss */
-E[foo$="bar"] {
-  a: b; }
-
-/* line 800, inputs/scss_css.scss */
-E[foo*="bar"] {
-  a: b; }
-
-/* line 804, inputs/scss_css.scss */
-E[foo|="en"] {
-  a: b; }
-
-/* line 808, inputs/scss_css.scss */
-E:root {
-  a: b; }
-
-/* line 812, inputs/scss_css.scss */
-E:nth-child(n) {
-  a: b; }
-
-/* line 816, inputs/scss_css.scss */
-E:nth-last-child(n) {
-  a: b; }
-
-/* line 820, inputs/scss_css.scss */
-E:nth-of-type(n) {
-  a: b; }
-
-/* line 824, inputs/scss_css.scss */
-E:nth-last-of-type(n) {
-  a: b; }
-
-/* line 828, inputs/scss_css.scss */
-E:first-child {
-  a: b; }
-
-/* line 832, inputs/scss_css.scss */
-E:last-child {
-  a: b; }
-
-/* line 836, inputs/scss_css.scss */
-E:first-of-type {
-  a: b; }
-
-/* line 840, inputs/scss_css.scss */
-E:last-of-type {
-  a: b; }
-
-/* line 844, inputs/scss_css.scss */
-E:only-child {
-  a: b; }
-
-/* line 848, inputs/scss_css.scss */
-E:only-of-type {
-  a: b; }
-
-/* line 852, inputs/scss_css.scss */
-E:empty {
-  a: b; }
-
-/* line 856, inputs/scss_css.scss */
-E:link {
-  a: b; }
-
-/* line 860, inputs/scss_css.scss */
-E:visited {
-  a: b; }
-
-/* line 864, inputs/scss_css.scss */
-E:active {
-  a: b; }
-
-/* line 868, inputs/scss_css.scss */
-E:hover {
-  a: b; }
-
-/* line 872, inputs/scss_css.scss */
-E:focus {
-  a: b; }
-
-/* line 876, inputs/scss_css.scss */
-E:target {
-  a: b; }
-
-/* line 880, inputs/scss_css.scss */
-E:lang(fr) {
-  a: b; }
-
-/* line 884, inputs/scss_css.scss */
-E:enabled {
-  a: b; }
-
-/* line 888, inputs/scss_css.scss */
-E:disabled {
-  a: b; }
-
-/* line 892, inputs/scss_css.scss */
-E:checked {
-  a: b; }
-
-/* line 896, inputs/scss_css.scss */
-E::first-line {
-  a: b; }
-
-/* line 900, inputs/scss_css.scss */
-E::first-letter {
-  a: b; }
-
-/* line 904, inputs/scss_css.scss */
-E::before {
-  a: b; }
-
-/* line 908, inputs/scss_css.scss */
-E::after {
-  a: b; }
-
-/* line 912, inputs/scss_css.scss */
-E.warning {
-  a: b; }
-
-/* line 916, inputs/scss_css.scss */
-E#myid {
-  a: b; }
-
-/* line 920, inputs/scss_css.scss */
-E:not(s) {
-  a: b; }
-
-/* line 924, inputs/scss_css.scss */
-E F {
-  a: b; }
-
-/* line 928, inputs/scss_css.scss */
-E > F {
-  a: b; }
-
-/* line 932, inputs/scss_css.scss */
+/* line 778, inputs/scss_css.scss */
 E + F {
   a: b; }
 
+/* line 780, inputs/scss_css.scss */
+* {
+  a: b; }
+
+/* line 784, inputs/scss_css.scss */
+E {
+  a: b; }
+
+/* line 788, inputs/scss_css.scss */
+E[foo] {
+  a: b; }
+
+/* line 792, inputs/scss_css.scss */
+E[foo="bar"] {
+  a: b; }
+
+/* line 796, inputs/scss_css.scss */
+E[foo~="bar"] {
+  a: b; }
+
+/* line 800, inputs/scss_css.scss */
+E[foo^="bar"] {
+  a: b; }
+
+/* line 804, inputs/scss_css.scss */
+E[foo$="bar"] {
+  a: b; }
+
+/* line 808, inputs/scss_css.scss */
+E[foo*="bar"] {
+  a: b; }
+
+/* line 812, inputs/scss_css.scss */
+E[foo|="en"] {
+  a: b; }
+
+/* line 816, inputs/scss_css.scss */
+E:root {
+  a: b; }
+
+/* line 820, inputs/scss_css.scss */
+E:nth-child(n) {
+  a: b; }
+
+/* line 824, inputs/scss_css.scss */
+E:nth-last-child(n) {
+  a: b; }
+
+/* line 828, inputs/scss_css.scss */
+E:nth-of-type(n) {
+  a: b; }
+
+/* line 832, inputs/scss_css.scss */
+E:nth-last-of-type(n) {
+  a: b; }
+
+/* line 836, inputs/scss_css.scss */
+E:first-child {
+  a: b; }
+
+/* line 840, inputs/scss_css.scss */
+E:last-child {
+  a: b; }
+
+/* line 844, inputs/scss_css.scss */
+E:first-of-type {
+  a: b; }
+
+/* line 848, inputs/scss_css.scss */
+E:last-of-type {
+  a: b; }
+
+/* line 852, inputs/scss_css.scss */
+E:only-child {
+  a: b; }
+
+/* line 856, inputs/scss_css.scss */
+E:only-of-type {
+  a: b; }
+
+/* line 860, inputs/scss_css.scss */
+E:empty {
+  a: b; }
+
+/* line 864, inputs/scss_css.scss */
+E:link {
+  a: b; }
+
+/* line 868, inputs/scss_css.scss */
+E:visited {
+  a: b; }
+
+/* line 872, inputs/scss_css.scss */
+E:active {
+  a: b; }
+
+/* line 876, inputs/scss_css.scss */
+E:hover {
+  a: b; }
+
+/* line 880, inputs/scss_css.scss */
+E:focus {
+  a: b; }
+
+/* line 884, inputs/scss_css.scss */
+E:target {
+  a: b; }
+
+/* line 888, inputs/scss_css.scss */
+E:lang(fr) {
+  a: b; }
+
+/* line 892, inputs/scss_css.scss */
+E:enabled {
+  a: b; }
+
+/* line 896, inputs/scss_css.scss */
+E:disabled {
+  a: b; }
+
+/* line 900, inputs/scss_css.scss */
+E:checked {
+  a: b; }
+
+/* line 904, inputs/scss_css.scss */
+E::first-line {
+  a: b; }
+
+/* line 908, inputs/scss_css.scss */
+E::first-letter {
+  a: b; }
+
+/* line 912, inputs/scss_css.scss */
+E::before {
+  a: b; }
+
+/* line 916, inputs/scss_css.scss */
+E::after {
+  a: b; }
+
+/* line 920, inputs/scss_css.scss */
+E.warning {
+  a: b; }
+
+/* line 924, inputs/scss_css.scss */
+E#myid {
+  a: b; }
+
+/* line 928, inputs/scss_css.scss */
+E:not(s) {
+  a: b; }
+
+/* line 932, inputs/scss_css.scss */
+E F {
+  a: b; }
+
 /* line 936, inputs/scss_css.scss */
+E > F {
+  a: b; }
+
+/* line 940, inputs/scss_css.scss */
+E + F {
+  a: b; }
+
+/* line 944, inputs/scss_css.scss */
 E ~ F {
   a: b; }
 
 @supports (a: b) and (c: d) or (not (d: e)) and ((not (f: g)) or (not ((h: i) and (j: k)))) {
-/* line 941, inputs/scss_css.scss */
+/* line 949, inputs/scss_css.scss */
   .foo {
     a: b; } }
 @-prefix-supports (a: b) and (c: d) or (not (d: e)) and ((not (f: g)) or (not ((h: i) and (j: k)))) {
-/* line 948, inputs/scss_css.scss */
+/* line 956, inputs/scss_css.scss */
   .foo {
     a: b; } }
-/* line 954, inputs/scss_css.scss */
+/* line 962, inputs/scss_css.scss */
 foo {
   foo: bar;
   #baz: bang;
   #bip: bop; }
 
-/* line 960, inputs/scss_css.scss */
+/* line 968, inputs/scss_css.scss */
 foo {
   a: -2;
   b: -2.3em;
   c: -50%;
   d: -foo(bar baz); }
 
-/* line 967, inputs/scss_css.scss */
+/* line 975, inputs/scss_css.scss */
 foo {
   a: -0.5em;
   b: 0.5em;
   c: -foo(12px);
   d: +foo(12px); }
 
-/* line 977, inputs/scss_css.scss */
+/* line 985, inputs/scss_css.scss */
 foo {
   -moz-foo-bar: blat;
   -o-flat-blang: wibble; }
 
-/* line 981, inputs/scss_css.scss */
+/* line 989, inputs/scss_css.scss */
 foo {
   a: foo();
   b: bar baz-bang() bip; }
 
-/* line 985, inputs/scss_css.scss */
+/* line 993, inputs/scss_css.scss */
 .alpha {
   color: rgba(31, 37, 38, 0.749);
   background-color: #1f2526; }
 
-/* line 991, inputs/scss_css.scss */
+/* line 999, inputs/scss_css.scss */
 .shortcode-4c29f540779d8549daf934275faea11 {
   color: red; }


### PR DESCRIPTION
Enable eatWhitespaces in matchChar() and update unit tests.

Closes #21 