### PR TITLE
Implemented passing Arguments to Content Blocks

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -383,9 +383,12 @@ class Parser
                     ($this->argValues($argValues) || true) &&
                     $this->matchChar(')') || true) &&
                 ($this->end() ||
+                    ($this->literal('using', 5) &&
+                        $this->argumentDef($argUsing) &&
+                        ($this->end() || $this->matchChar('{') && $hasBlock = true)) ||
                     $this->matchChar('{') && $hasBlock = true)
             ) {
-                $child = [Type::T_INCLUDE, $mixinName, isset($argValues) ? $argValues : null, null];
+                $child = [Type::T_INCLUDE, $mixinName, isset($argValues) ? $argValues : null, null, isset($argUsing) ? $argUsing : null];
 
                 if (! empty($hasBlock)) {
                     $include = $this->pushSpecialBlock(Type::T_INCLUDE, $s);
@@ -577,8 +580,15 @@ class Parser
 
             $this->seek($s);
 
-            if ($this->literal('@content', 8) && $this->end()) {
-                $this->append([Type::T_MIXIN_CONTENT], $s);
+            #if ($this->literal('@content', 8))
+
+            if ($this->literal('@content', 8) &&
+                ($this->end() ||
+                    $this->matchChar('(') &&
+                        $this->argValues($argContent) &&
+                        $this->matchChar(')') &&
+                    $this->end())) {
+                $this->append([Type::T_MIXIN_CONTENT, isset($argContent) ? $argContent : null], $s);
 
                 return true;
             }

--- a/tests/inputs/mixins.scss
+++ b/tests/inputs/mixins.scss
@@ -88,7 +88,7 @@ div {
 
         .top {
             top: 0;
-            
+
             div {
                 color: red;
             }
@@ -120,7 +120,7 @@ div {
     color: red;
 }
 
-@include content-with-arg($background: purple) { 
+@include content-with-arg($background: purple) {
     @include hello_world;
 }
 
@@ -132,11 +132,11 @@ div {
     @include something(orange);
 }
 
-@include content-with-arg($background: purple) { 
+@include content-with-arg($background: purple) {
     @include cool(10px, 12px, 21px);
 }
 
-@include content-with-arg($background: purple) { 
+@include content-with-arg($background: purple) {
     @include something(orange);
 }
 
@@ -208,3 +208,68 @@ div.parameter-name-scope {
   }
 }
 
+
+@mixin content-with-using() {
+  $some-color: black;
+  @content($some-color, left);
+}
+
+@mixin content-with-using-and-args($other-color) {
+  $some-color: black;
+  @content($some-color, left, $other-color);
+}
+
+@mixin content-with-using-nested($other-color) {
+  $some-color: red;
+  .content-with-using-nested-outside {
+    @include content-with-using-and-args($other-color) using ($color, $align, $background) {
+      background-color: $background;
+      color: $color;
+      text-align: $align;
+    }
+    @content($some-color, right, $other-color);
+  }
+}
+
+@include content-with-using() using ($using-color, $using-align) {
+  .content-with-using-scope-test-before {
+    border-color: $using-color;
+    color: $color;
+    text-align: $using-align;
+  }
+}
+
+@include content-with-using() using ($color, $align) {
+  .content-with-using {
+    color: $color;
+    text-align: $align;
+  }
+}
+
+@include content-with-using() using ($using-color, $using-align) {
+  .content-with-using-scope-test-after {
+    background-color: $using-color;
+    color: $color;
+    text-align: $using-align;
+  }
+}
+
+.content-with-using-scope-test-outside {
+  color: $color;
+}
+
+@include content-with-using-and-args($color) using ($color, $align, $background) {
+  .content-with-using-and-args {
+    background-color: $background;
+    color: $color;
+    text-align: $align;
+  }
+}
+
+@include content-with-using-nested($color) using ($color, $align, $background) {
+  .content-with-using-nested-inside {
+    background-color: $background;
+    color: $color;
+    text-align: $align;
+  }
+}

--- a/tests/outputs/mixins.css
+++ b/tests/outputs/mixins.css
@@ -101,3 +101,34 @@ div {
   div p {
     content: "p";
     content: "p"; }
+
+.content-with-using-scope-test-before {
+  border-color: black;
+  color: white;
+  text-align: left; }
+
+.content-with-using {
+  color: black;
+  text-align: left; }
+
+.content-with-using-scope-test-after {
+  background-color: black;
+  color: white;
+  text-align: left; }
+
+.content-with-using-scope-test-outside {
+  color: white; }
+
+.content-with-using-and-args {
+  background-color: white;
+  color: black;
+  text-align: left; }
+
+.content-with-using-nested-outside {
+  background-color: white;
+  color: black;
+  text-align: left; }
+  .content-with-using-nested-outside .content-with-using-nested-inside {
+    background-color: white;
+    color: red;
+    text-align: right; }

--- a/tests/outputs_numbered/mixins.css
+++ b/tests/outputs_numbered/mixins.css
@@ -144,3 +144,42 @@ div {
 div p {
   content: "p";
   content: "p"; }
+
+/* line 235, inputs/mixins.scss */
+.content-with-using-scope-test-before {
+  border-color: black;
+  color: white;
+  text-align: left; }
+
+/* line 243, inputs/mixins.scss */
+.content-with-using {
+  color: black;
+  text-align: left; }
+
+/* line 250, inputs/mixins.scss */
+.content-with-using-scope-test-after {
+  background-color: black;
+  color: white;
+  text-align: left; }
+
+/* line 257, inputs/mixins.scss */
+.content-with-using-scope-test-outside {
+  color: white; }
+
+/* line 262, inputs/mixins.scss */
+.content-with-using-and-args {
+  background-color: white;
+  color: black;
+  text-align: left; }
+
+/* line 224, inputs/mixins.scss */
+.content-with-using-nested-outside {
+  background-color: white;
+  color: black;
+  text-align: left; }
+
+/* line 270, inputs/mixins.scss */
+.content-with-using-nested-outside .content-with-using-nested-inside {
+  background-color: white;
+  color: red;
+  text-align: right; }


### PR DESCRIPTION
Due to personal requirement I implemented the option to pass variables into the content block provided to mixins. See the official documentation about this feature for details:

https://sass-lang.com/documentation/at-rules/mixin#passing-arguments-to-content-blocks

Since I'm really new to this project the will most likely be less well done parts about this implementation, that should be improved when adding it to the project. Especially the following two places:
- Compiler.php Line 2520 / Passing the argument list with a special variable similar to the content part. (Can this be avoided?)
- Compiler.php Line 2553 and 2572 / Extracting the required variables (I assume there's a simpler way I did not find) and applying those to the contents scope.

Unfortunally I am lacking the insight into the library to figure out a better solution or even tell if there is one. (especially the exact relations for env / storeEnv / scope part, which is really hard to get behind)

Feel free to optimize those parts, or help me understand the possible better solutions and I will adjust and make another pull request afterwards.