### PR TITLE
Fix zip function to allow all types as arguments #32

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -6318,7 +6318,13 @@ class Compiler
 
     protected function libZip($args)
     {
-        foreach ($args as $arg) {
+        foreach ($args as $key => $arg) {
+            // if the args are not lists, put them into lists of one element each
+            if($arg[0] != Type::T_LIST) {
+                // manually convert the type
+                $arg = [Type::T_LIST, '', [$arg]];
+                $args[$key] = $arg;
+            }
             $this->assertList($arg);
         }
 

--- a/tests/inputs/builtins.scss
+++ b/tests/inputs/builtins.scss
@@ -252,3 +252,8 @@ div.unquote-test {
     transition: join($one, $two, comma);
     transition: join((value1 value2), (value3 value4), comma);
 }
+
+.list-zip-types {
+  zip: zip(2px, (solid dashed));
+  zip: zip(3px, "bold", blue);
+}

--- a/tests/outputs/builtins.css
+++ b/tests/outputs/builtins.css
@@ -180,3 +180,7 @@ div.unquote-test {
   transition: value1 value2, value3, value4;
   transition: value1, value2, value3, value4;
   transition: value1, value2, value3, value4; }
+
+.list-zip-types {
+  zip: 2px solid;
+  zip: 3px "bold" blue; }

--- a/tests/outputs_numbered/builtins.css
+++ b/tests/outputs_numbered/builtins.css
@@ -200,3 +200,8 @@ div.unquote-test {
   transition: value1 value2, value3, value4;
   transition: value1, value2, value3, value4;
   transition: value1, value2, value3, value4; }
+
+/* line 256, inputs/builtins.scss */
+.list-zip-types {
+  zip: 2px solid;
+  zip: 3px "bold" blue; }


### PR DESCRIPTION
Fixes #32

Compiles latest version of Bootstrap: https://github.com/twbs/bootstrap/commit/b02bae769e989838229c13a7c97d5af4c338601d