### PR TITLE
Fix importing of css files

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -4435,6 +4435,7 @@ class Compiler
                     $full = $dir . $separator . $full;
 
                     if (is_file($file = $full . '.scss') ||
+                        is_file($file = $full . '.css') ||
                         ($hasExtension && is_file($file = $full))
                     ) {
                         return $file;


### PR DESCRIPTION
According to https://sass-lang.com/documentation/at-rules/import#importing-css a plain old css file can be imported providing the file name without extension. This patch fixes this feature.