### PR TITLE
Init $libName before using it

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -4811,6 +4811,7 @@ class Compiler
         if (isset($this->userFunctions[$name])) {
             // see if we can find a user function
             list($f, $prototype) = $this->userFunctions[$name];
+            $libName = 'lib' . str_replace(' ', '', ucwords(str_replace(['-', '_'], ' ', $name)));
         } elseif (($f = $this->getBuiltinFunction($name)) && is_callable($f)) {
             $libName   = $f[1];
             $prototype = isset(static::$$libName) ? static::$$libName : null;


### PR DESCRIPTION
We have a bunch of custom functions, registered via the `$compiler->registerFunction()`.

When scssphp calls the `->callNativeFunction()`, the code gets the custom function, but it fails some line afterwords, because it tries to use the var `$libName`, which is not initialised if the function is a custom one.
The code fails with this error:
> Undefined variable: libName

As you can see from the code, if you enter the first `if`, the var `$libName` never gets initialized.

This PR fixes this wrong behaviour.