### PR TITLE
Qualify function calls when the compiler can optimize them

### DIFF
--- a/src/Cache.php
+++ b/src/Cache.php
@@ -102,13 +102,13 @@ class Cache
         ) {
             $cacheTime = filemtime($fileCache);
 
-            if ((is_null($lastModified) || $cacheTime > $lastModified) &&
+            if ((\is_null($lastModified) || $cacheTime > $lastModified) &&
                 $cacheTime + self::$gcLifetime > time()
             ) {
                 $c = file_get_contents($fileCache);
                 $c = unserialize($c);
 
-                if (is_array($c) && isset($c['value'])) {
+                if (\is_array($c) && isset($c['value'])) {
                     return $c['value'];
                 }
             }

--- a/src/Colors.php
+++ b/src/Colors.php
@@ -186,7 +186,7 @@ class Colors
      */
     public static function colorNameToRGBa($colorName)
     {
-        if (is_string($colorName) && isset(static::$cssColors[$colorName])) {
+        if (\is_string($colorName) && isset(static::$cssColors[$colorName])) {
             $rgba = explode(',', static::$cssColors[$colorName]);
 
             // only case with opacity is transparent, with opacity=0, so we can intval on opacity also
@@ -225,20 +225,20 @@ class Colors
             return null;
         }
 
-        if (is_null($reverseColorTable)) {
+        if (\is_null($reverseColorTable)) {
             $reverseColorTable = [];
 
             foreach (static::$cssColors as $name => $rgb_str) {
                 $rgb_str = explode(',', $rgb_str);
 
-                if (count($rgb_str) == 3) {
-                    $reverseColorTable[intval($rgb_str[0])][intval($rgb_str[1])][intval($rgb_str[2])] = $name;
+                if (\count($rgb_str) == 3) {
+                    $reverseColorTable[\intval($rgb_str[0])][\intval($rgb_str[1])][\intval($rgb_str[2])] = $name;
                 }
             }
         }
 
-        if (isset($reverseColorTable[intval($r)][intval($g)][intval($b)])) {
-            return $reverseColorTable[intval($r)][intval($g)][intval($b)];
+        if (isset($reverseColorTable[\intval($r)][\intval($g)][\intval($b)])) {
+            return $reverseColorTable[\intval($r)][\intval($g)][\intval($b)];
         }
 
         return null;

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -228,7 +228,7 @@ class Compiler
             $compileOptions = $this->getCompileOptions();
             $cache          = $this->cache->getCache("compile", $cacheKey, $compileOptions);
 
-            if (is_array($cache) && isset($cache['dependencies']) && isset($cache['out'])) {
+            if (\is_array($cache) && isset($cache['dependencies']) && isset($cache['out'])) {
                 // check if any dependency file changed before accepting the cache
                 foreach ($cache['dependencies'] as $file => $mtime) {
                     if (! is_file($file) || filemtime($file) !== $mtime) {
@@ -271,7 +271,7 @@ class Compiler
         $sourceMapGenerator = null;
 
         if ($this->sourceMap) {
-            if (is_object($this->sourceMap) && $this->sourceMap instanceof SourceMapGenerator) {
+            if (\is_object($this->sourceMap) && $this->sourceMap instanceof SourceMapGenerator) {
                 $sourceMapGenerator = $this->sourceMap;
                 $this->sourceMap = self::SOURCE_MAP_FILE;
             } elseif ($this->sourceMap !== self::SOURCE_MAP_NONE) {
@@ -328,7 +328,7 @@ class Compiler
         if (substr($path, '-4') === '.css') {
             $cssOnly = true;
         }
-        $parser = new Parser($path, count($this->sourceNames), $this->encoding, $this->cache, $cssOnly);
+        $parser = new Parser($path, \count($this->sourceNames), $this->encoding, $this->cache, $cssOnly);
 
         $this->sourceNames[] = $path;
         $this->addParsedFile($path);
@@ -347,7 +347,7 @@ class Compiler
     protected function isSelfExtend($target, $origin)
     {
         foreach ($origin as $sel) {
-            if (in_array($target, $sel)) {
+            if (\in_array($target, $sel)) {
                 return true;
             }
         }
@@ -368,7 +368,7 @@ class Compiler
             return;
         }
 
-        $i = count($this->extends);
+        $i = \count($this->extends);
         $this->extends[] = [$target, $origin, $block];
 
         foreach ($target as $part) {
@@ -464,7 +464,7 @@ class Compiler
             foreach ($block->selectors as $s) {
                 $selectors[] = $s;
 
-                if (! is_array($s)) {
+                if (! \is_array($s)) {
                     continue;
                 }
 
@@ -497,7 +497,7 @@ class Compiler
                 $block->selectors[] = $this->compileSelector($selector);
             }
 
-            if ($placeholderSelector && 0 === count($block->selectors) && null !== $parentKey) {
+            if ($placeholderSelector && 0 === \count($block->selectors) && null !== $parentKey) {
                 unset($block->parent->children[$parentKey]);
 
                 return;
@@ -521,19 +521,19 @@ class Compiler
         $new = [];
 
         foreach ($parts as $part) {
-            if (is_array($part)) {
+            if (\is_array($part)) {
                 $part = $this->glueFunctionSelectors($part);
                 $new[] = $part;
             } else {
                 // a selector part finishing with a ) is the last part of a :not( or :nth-child(
                 // and need to be joined to this
-                if (count($new) && is_string($new[count($new) - 1]) &&
-                    strlen($part) && substr($part, -1) === ')' && strpos($part, '(') === false
+                if (\count($new) && \is_string($new[\count($new) - 1]) &&
+                    \strlen($part) && substr($part, -1) === ')' && strpos($part, '(') === false
                 ) {
-                    while (count($new)>1 && substr($new[count($new) - 1], -1) !== '(') {
+                    while (\count($new)>1 && substr($new[\count($new) - 1], -1) !== '(') {
                         $part = array_pop($new) . $part;
                     }
-                    $new[count($new) - 1] .= $part;
+                    $new[\count($new) - 1] .= $part;
                 } else {
                     $new[] = $part;
                 }
@@ -556,7 +556,7 @@ class Compiler
         static $partsPile = [];
         $selector = $this->glueFunctionSelectors($selector);
 
-        if (count($selector) == 1 && in_array(reset($selector), $partsPile)) {
+        if (\count($selector) == 1 && \in_array(reset($selector), $partsPile)) {
             return;
         }
 
@@ -568,9 +568,9 @@ class Compiler
 
             // check that we are not building an infinite loop of extensions
             // if the new part is just including a previous part don't try to extend anymore
-            if (count($part) > 1) {
+            if (\count($part) > 1) {
                 foreach ($partsPile as $previousPart) {
-                    if (! count(array_diff($previousPart, $part))) {
+                    if (! \count(array_diff($previousPart, $part))) {
                         continue 2;
                     }
                 }
@@ -578,31 +578,31 @@ class Compiler
 
             $partsPile[] = $part;
             if ($this->matchExtendsSingle($part, $origin, $initial)) {
-                $after       = array_slice($selector, $i + 1);
-                $before      = array_slice($selector, 0, $i);
+                $after       = \array_slice($selector, $i + 1);
+                $before      = \array_slice($selector, 0, $i);
                 list($before, $nonBreakableBefore) = $this->extractRelationshipFromFragment($before);
 
                 foreach ($origin as $new) {
                     $k = 0;
 
                     // remove shared parts
-                    if (count($new) > 1) {
+                    if (\count($new) > 1) {
                         while ($k < $i && isset($new[$k]) && $selector[$k] === $new[$k]) {
                             $k++;
                         }
                     }
-                    if (count($nonBreakableBefore) and $k == count($new)) {
+                    if (\count($nonBreakableBefore) and $k == \count($new)) {
                         $k--;
                     }
 
                     $replacement = [];
-                    $tempReplacement = $k > 0 ? array_slice($new, $k) : $new;
+                    $tempReplacement = $k > 0 ? \array_slice($new, $k) : $new;
 
-                    for ($l = count($tempReplacement) - 1; $l >= 0; $l--) {
+                    for ($l = \count($tempReplacement) - 1; $l >= 0; $l--) {
                         $slice = [];
 
                         foreach ($tempReplacement[$l] as $chunk) {
-                            if (! in_array($chunk, $slice)) {
+                            if (! \in_array($chunk, $slice)) {
                                 $slice[] = $chunk;
                             }
                         }
@@ -614,7 +614,7 @@ class Compiler
                         }
                     }
 
-                    $afterBefore = $l != 0 ? array_slice($tempReplacement, 0, $l) : [];
+                    $afterBefore = $l != 0 ? \array_slice($tempReplacement, 0, $l) : [];
 
                     // Merge shared direct relationships.
                     $mergedBefore = $this->mergeDirectRelationships($afterBefore, $nonBreakableBefore);
@@ -633,17 +633,17 @@ class Compiler
                     $this->pushOrMergeExtentedSelector($out, $result);
 
                     // recursively check for more matches
-                    $startRecurseFrom = count($before) + min(count($nonBreakableBefore), count($mergedBefore));
-                    if (count($origin) > 1) {
+                    $startRecurseFrom = \count($before) + min(\count($nonBreakableBefore), \count($mergedBefore));
+                    if (\count($origin) > 1) {
                         $this->matchExtends($result, $out, $startRecurseFrom, false);
                     } else {
                         $this->matchExtends($result, $outRecurs, $startRecurseFrom, false);
                     }
 
                     // selector sequence merging
-                    if (! empty($before) && count($new) > 1) {
-                        $preSharedParts = $k > 0 ? array_slice($before, 0, $k) : [];
-                        $postSharedParts = $k > 0 ? array_slice($before, $k) : $before;
+                    if (! empty($before) && \count($new) > 1) {
+                        $preSharedParts = $k > 0 ? \array_slice($before, 0, $k) : [];
+                        $postSharedParts = $k > 0 ? \array_slice($before, $k) : $before;
 
                         list($betweenSharedParts, $nonBreakabl2) = $this->extractRelationshipFromFragment($afterBefore);
 
@@ -663,7 +663,7 @@ class Compiler
             }
             array_pop($partsPile);
         }
-        while (count($outRecurs)) {
+        while (\count($outRecurs)) {
             $result = array_shift($outRecurs);
             $this->pushOrMergeExtentedSelector($out, $result);
         }
@@ -695,14 +695,14 @@ class Compiler
      */
     protected function pushOrMergeExtentedSelector(&$out, $extended)
     {
-        if (count($out) && count($extended) === 1 && count(reset($extended)) === 1) {
+        if (\count($out) && \count($extended) === 1 && \count(reset($extended)) === 1) {
             $single = reset($extended);
             $part = reset($single);
             if ($this->isPseudoSelector($part, $matchesExtended)
-              && in_array($matchesExtended[1], [ 'slotted' ])) {
+              && \in_array($matchesExtended[1], [ 'slotted' ])) {
                 $prev = end($out);
                 $prev = $this->glueFunctionSelectors($prev);
-                if (count($prev) === 1 && count(reset($prev)) === 1) {
+                if (\count($prev) === 1 && \count(reset($prev)) === 1) {
                     $single = reset($prev);
                     $part = reset($single);
                     if ($this->isPseudoSelector($part, $matchesPrev)
@@ -734,18 +734,18 @@ class Compiler
         $single = [];
 
         // simple usual cases, no need to do the whole trick
-        if (in_array($rawSingle, [['>'],['+'],['~']])) {
+        if (\in_array($rawSingle, [['>'],['+'],['~']])) {
             return false;
         }
 
         foreach ($rawSingle as $part) {
             // matches Number
-            if (! is_string($part)) {
+            if (! \is_string($part)) {
                 return false;
             }
 
-            if (! preg_match('/^[\[.:#%]/', $part) && count($single)) {
-                $single[count($single) - 1] .= $part;
+            if (! preg_match('/^[\[.:#%]/', $part) && \count($single)) {
+                $single[\count($single) - 1] .= $part;
             } else {
                 $single[] = $part;
             }
@@ -753,7 +753,7 @@ class Compiler
 
         $extendingDecoratedTag = false;
 
-        if (count($single) > 1) {
+        if (\count($single) > 1) {
             $matches = null;
             $extendingDecoratedTag = preg_match('/^[a-z0-9]+$/i', $single[0], $matches) ? $matches[0] : false;
         }
@@ -769,7 +769,7 @@ class Compiler
             }
             if ($initial
                 && $this->isPseudoSelector($part, $matches)
-                && ! in_array($matches[1], [ 'not' ])) {
+                && ! \in_array($matches[1], [ 'not' ])) {
                 $buffer    = $matches[2];
                 $parser    = $this->parserFactory(__METHOD__);
                 if ($parser->parseSelector($buffer, $subSelectors)) {
@@ -799,7 +799,7 @@ class Compiler
             $origin = $this->glueFunctionSelectors($origin);
 
             // check count
-            if ($count !== count($target)) {
+            if ($count !== \count($target)) {
                 continue;
             }
 
@@ -825,8 +825,8 @@ class Compiler
 
                 $combined = $this->combineSelectorSingle($replacement, $rem);
 
-                if (count(array_diff($combined, $origin[$j][count($origin[$j]) - 1]))) {
-                    $origin[$j][count($origin[$j]) - 1] = $combined;
+                if (\count(array_diff($combined, $origin[$j][\count($origin[$j]) - 1]))) {
+                    $origin[$j][\count($origin[$j]) - 1] = $combined;
                 }
             }
 
@@ -855,11 +855,11 @@ class Compiler
         $parents = [];
         $children = [];
 
-        $j = $i = count($fragment);
+        $j = $i = \count($fragment);
 
         for (;;) {
-            $children = $j != $i ? array_slice($fragment, $j, $i - $j) : [];
-            $parents  = array_slice($fragment, 0, $j);
+            $children = $j != $i ? \array_slice($fragment, $j, $i - $j) : [];
+            $parents  = \array_slice($fragment, 0, $j);
             $slice    = end($parents);
 
             if (empty($slice) || ! $this->isImmediateRelationshipCombinator($slice[0])) {
@@ -887,7 +887,7 @@ class Compiler
         $wasTag = false;
         $pseudo = [];
 
-        while (count($other) && strpos(end($other), ':')===0) {
+        while (\count($other) && strpos(end($other), ':')===0) {
             array_unshift($pseudo, array_pop($other));
         }
 
@@ -903,17 +903,17 @@ class Compiler
                     $tag[] = $part;
                     $wasTag = true;
                 } elseif ($wasTag) {
-                    $tag[count($tag) - 1] .= $part;
+                    $tag[\count($tag) - 1] .= $part;
                 } else {
                     $out[] = $part;
                 }
             }
         }
 
-        if (count($tag)) {
+        if (\count($tag)) {
             array_unshift($out, $tag[0]);
         }
-        while (count($pseudo)) {
+        while (\count($pseudo)) {
             $out[] = array_shift($pseudo);
         }
 
@@ -1032,7 +1032,7 @@ class Compiler
      */
     protected function compileDirective($directive, OutputBlock $out)
     {
-        if (is_array($directive)) {
+        if (\is_array($directive)) {
             $s = '@' . $directive[0];
             if (! empty($directive[1])) {
                 $s .= ' ' . $this->compileValue($directive[1]);
@@ -1146,7 +1146,7 @@ class Compiler
                 $filteredScopes[] = $s;
             }
 
-            if (count($childStash)) {
+            if (\count($childStash)) {
                 $scope = array_shift($childStash);
             } elseif ($scope->children) {
                 $scope = end($scope->children);
@@ -1155,7 +1155,7 @@ class Compiler
             }
         }
 
-        if (! count($filteredScopes)) {
+        if (! \count($filteredScopes)) {
             return $this->rootBlock;
         }
 
@@ -1166,7 +1166,7 @@ class Compiler
 
         $p = &$newScope;
 
-        while (count($filteredScopes)) {
+        while (\count($filteredScopes)) {
             $s = array_shift($filteredScopes);
             $s->parent = $p;
             $p->children[] = $s;
@@ -1188,7 +1188,7 @@ class Compiler
      */
     protected function completeScope($scope, $previousScope)
     {
-        if (! $scope->type && (! $scope->selectors || ! count($scope->selectors)) && count($scope->lines)) {
+        if (! $scope->type && (! $scope->selectors || ! \count($scope->selectors)) && \count($scope->lines)) {
             $scope->selectors = $this->findScopeSelectors($previousScope, $scope->depth);
         }
 
@@ -1321,14 +1321,14 @@ class Compiler
             }
         } elseif (isset($block->selectors)) {
             // a selector starting with number is a keyframe rule
-            if (count($block->selectors)) {
+            if (\count($block->selectors)) {
                 $s = reset($block->selectors);
 
-                while (is_array($s)) {
+                while (\is_array($s)) {
                     $s = reset($s);
                 }
 
-                if (is_object($s) && $s instanceof Node\Number) {
+                if (\is_object($s) && $s instanceof Node\Number) {
                     return $this->testWithWithout('keyframes', $with, $without);
                 }
             }
@@ -1353,7 +1353,7 @@ class Compiler
     {
 
         // if without, reject only if in the list (or 'all' is in the list)
-        if (count($without)) {
+        if (\count($without)) {
             return (isset($without[$what]) || isset($without['all'])) ? false : true;
         }
 
@@ -1498,7 +1498,7 @@ class Compiler
 
         $out = $this->makeOutputBlock(null);
 
-        if (isset($this->lineNumberStyle) && count($env->selectors) && count($block->children)) {
+        if (isset($this->lineNumberStyle) && \count($env->selectors) && \count($block->children)) {
             $annotation = $this->makeOutputBlock(Type::T_COMMENT);
             $annotation->depth = 0;
 
@@ -1524,7 +1524,7 @@ class Compiler
 
         $this->scope->children[] = $out;
 
-        if (count($block->children)) {
+        if (\count($block->children)) {
             $out->selectors = $this->multiplySelectors($env, $block->selfParent);
 
             // propagate selfParent to the children where they still can be useful
@@ -1640,14 +1640,14 @@ class Compiler
     protected function evalSelectorPart($part)
     {
         foreach ($part as &$p) {
-            if (is_array($p) && ($p[0] === Type::T_INTERPOLATE || $p[0] === Type::T_STRING)) {
+            if (\is_array($p) && ($p[0] === Type::T_INTERPOLATE || $p[0] === Type::T_STRING)) {
                 $p = $this->compileValue($p);
 
                 // force re-evaluation
                 if (strpos($p, '&') !== false || strpos($p, ',') !== false) {
                     $this->shouldEvaluate = true;
                 }
-            } elseif (is_string($p) && strlen($p) >= 2 &&
+            } elseif (\is_string($p) && \strlen($p) >= 2 &&
                 ($first = $p[0]) && ($first === '"' || $first === "'") &&
                 substr($p, -1) === $first
             ) {
@@ -1687,15 +1687,15 @@ class Compiler
                 );
 
                 if ($selectorFormat && $this->isImmediateRelationshipCombinator($compound)) {
-                    if (count($output)) {
-                        $output[count($output) - 1] .= ' ' . $compound;
+                    if (\count($output)) {
+                        $output[\count($output) - 1] .= ' ' . $compound;
                     } else {
                         $output[] = $compound;
                     }
 
                     $glueNext = true;
                 } elseif ($glueNext) {
-                    $output[count($output) - 1] .= ' ' . $compound;
+                    $output[\count($output) - 1] .= ' ' . $compound;
                     $glueNext = false;
                 } else {
                     $output[] = $compound;
@@ -1734,7 +1734,7 @@ class Compiler
     protected function revertSelfSelector($selectors)
     {
         foreach ($selectors as &$part) {
-            if (is_array($part)) {
+            if (\is_array($part)) {
                 if ($part === [Type::T_SELF]) {
                     $part = '&';
                 } else {
@@ -1759,17 +1759,17 @@ class Compiler
 
         foreach ($single as $part) {
             if (empty($joined) ||
-                ! is_string($part) ||
+                ! \is_string($part) ||
                 preg_match('/[\[.:#%]/', $part)
             ) {
                 $joined[] = $part;
                 continue;
             }
 
-            if (is_array(end($joined))) {
+            if (\is_array(end($joined))) {
                 $joined[] = $part;
             } else {
-                $joined[count($joined) - 1] .= $part;
+                $joined[\count($joined) - 1] .= $part;
             }
         }
 
@@ -1785,7 +1785,7 @@ class Compiler
      */
     protected function compileSelector($selector)
     {
-        if (! is_array($selector)) {
+        if (! \is_array($selector)) {
             return $selector; // media and the like
         }
 
@@ -1808,7 +1808,7 @@ class Compiler
     protected function compileSelectorPart($piece)
     {
         foreach ($piece as &$p) {
-            if (! is_array($p)) {
+            if (! \is_array($p)) {
                 continue;
             }
 
@@ -1835,13 +1835,13 @@ class Compiler
      */
     protected function hasSelectorPlaceholder($selector)
     {
-        if (! is_array($selector)) {
+        if (! \is_array($selector)) {
             return false;
         }
 
         foreach ($selector as $parts) {
             foreach ($parts as $part) {
-                if (strlen($part) && '%' === $part[0]) {
+                if (\strlen($part) && '%' === $part[0]) {
                     return true;
                 }
             }
@@ -1860,7 +1860,7 @@ class Compiler
         ];
 
         // infinite calling loop
-        if (count($this->callStack) > 25000) {
+        if (\count($this->callStack) > 25000) {
             // not displayed but you can var_dump it to deep debug
             $msg = $this->callStackMessage(true, 100);
             $msg = "Infinite calling loop";
@@ -1915,11 +1915,11 @@ class Compiler
         $this->pushCallStack($traceName);
 
         foreach ($stms as $stm) {
-            if ($selfParent && isset($stm[1]) && is_object($stm[1]) && $stm[1] instanceof Block) {
+            if ($selfParent && isset($stm[1]) && \is_object($stm[1]) && $stm[1] instanceof Block) {
                 $stm[1]->selfParent = $selfParent;
                 $ret = $this->compileChild($stm, $out);
                 $stm[1]->selfParent = null;
-            } elseif ($selfParent && in_array($stm[0], [TYPE::T_INCLUDE, TYPE::T_EXTEND])) {
+            } elseif ($selfParent && \in_array($stm[0], [TYPE::T_INCLUDE, TYPE::T_EXTEND])) {
                 $stm['selfParent'] = $selfParent;
                 $ret = $this->compileChild($stm, $out);
                 unset($stm['selfParent']);
@@ -1955,7 +1955,7 @@ class Compiler
             $shouldReparse = false;
 
             foreach ($query as $kq => $q) {
-                for ($i = 1; $i < count($q); $i++) {
+                for ($i = 1; $i < \count($q); $i++) {
                     $value = $this->compileValue($q[$i]);
 
                     // the parser had no mean to know if media type or expression if it was an interpolation
@@ -1974,7 +1974,7 @@ class Compiler
             }
 
             if ($shouldReparse) {
-                if (is_null($parser)) {
+                if (\is_null($parser)) {
                     $parser = $this->parserFactory(__METHOD__);
                 }
 
@@ -1988,7 +1988,7 @@ class Compiler
                     if ($parser->parseMediaQueryList($queryString, $queries)) {
                         $queries = $this->evaluateMediaQuery($queries[2]);
 
-                        while (count($queries)) {
+                        while (\count($queries)) {
                             $outQueryList[] = array_shift($queries);
                         }
 
@@ -2033,17 +2033,17 @@ class Compiler
             foreach ($query as $q) {
                 switch ($q[0]) {
                     case Type::T_MEDIA_TYPE:
-                        $newType = array_map([$this, 'compileValue'], array_slice($q, 1));
+                        $newType = array_map([$this, 'compileValue'], \array_slice($q, 1));
 
                         // combining not and anything else than media type is too risky and should be avoided
                         if (! $mediaTypeOnly) {
-                            if (in_array(Type::T_NOT, $newType) || ($type && in_array(Type::T_NOT, $type) )) {
+                            if (\in_array(Type::T_NOT, $newType) || ($type && \in_array(Type::T_NOT, $type) )) {
                                 if ($type) {
                                     array_unshift($parts, implode(' ', array_filter($type)));
                                 }
 
                                 if (! empty($parts)) {
-                                    if (strlen($current)) {
+                                    if (\strlen($current)) {
                                         $current .= $this->formatter->tagSeparator;
                                     }
 
@@ -2106,7 +2106,7 @@ class Compiler
             }
 
             if (! empty($parts)) {
-                if (strlen($current)) {
+                if (\strlen($current)) {
                     $current .= $this->formatter->tagSeparator;
                 }
 
@@ -2188,7 +2188,7 @@ class Compiler
             return $type1;
         }
 
-        if (count($type1) > 1) {
+        if (\count($type1) > 1) {
             $m1 = strtolower($type1[0]);
             $t1 = strtolower($type1[1]);
         } else {
@@ -2196,7 +2196,7 @@ class Compiler
             $t1 = strtolower($type1[0]);
         }
 
-        if (count($type2) > 1) {
+        if (\count($type2) > 1) {
             $m2 = strtolower($type2[0]);
             $t2 = strtolower($type2[1]);
         } else {
@@ -2247,7 +2247,7 @@ class Compiler
             $path = $this->compileStringContent($rawPath);
 
             if ($path = $this->findImport($path)) {
-                if (! $once || ! in_array($path, $this->importedFiles)) {
+                if (! $once || ! \in_array($path, $this->importedFiles)) {
                     $this->importFile($path, $out);
                     $this->importedFiles[] = $path;
                 }
@@ -2262,7 +2262,7 @@ class Compiler
 
         if ($rawPath[0] === Type::T_LIST) {
             // handle a list of strings
-            if (count($rawPath[2]) === 0) {
+            if (\count($rawPath[2]) === 0) {
                 return false;
             }
 
@@ -2305,8 +2305,8 @@ class Compiler
 
         $i = 0;
 
-        while ($i < count($root->children)) {
-            if (! isset($root->children[$i]->type) || ! in_array($root->children[$i]->type, $allowed)) {
+        while ($i < \count($root->children)) {
+            if (! isset($root->children[$i]->type) || ! \in_array($root->children[$i]->type, $allowed)) {
                 break;
             }
 
@@ -2316,7 +2316,7 @@ class Compiler
         // remove incompatible children from the bottom of the list
         $saveChildren = [];
 
-        while ($i < count($root->children)) {
+        while ($i < \count($root->children)) {
             $saveChildren[] = array_pop($root->children);
         }
 
@@ -2330,7 +2330,7 @@ class Compiler
         $root->children[] = $child;
 
         // repush children
-        while (count($saveChildren)) {
+        while (\count($saveChildren)) {
             $root->children[] = array_pop($saveChildren);
         }
     }
@@ -2351,15 +2351,15 @@ class Compiler
             $parent = $out->parent;
 
             if (end($parent->children) !== $out) {
-                $outWrite = &$parent->children[count($parent->children) - 1];
+                $outWrite = &$parent->children[\count($parent->children) - 1];
             }
         }
 
         // check if it's a flat output or not
-        if (count($out->children)) {
-            $lastChild = &$out->children[count($out->children) - 1];
+        if (\count($out->children)) {
+            $lastChild = &$out->children[\count($out->children) - 1];
 
-            if ($lastChild->depth === $out->depth && is_null($lastChild->selectors) && ! count($lastChild->children)) {
+            if ($lastChild->depth === $out->depth && \is_null($lastChild->selectors) && ! \count($lastChild->children)) {
                 $outWrite = $lastChild;
             } else {
                 $nextLines = $this->makeOutputBlock($type);
@@ -2388,7 +2388,7 @@ class Compiler
             $this->sourceIndex  = isset($child[Parser::SOURCE_INDEX]) ? $child[Parser::SOURCE_INDEX] : null;
             $this->sourceLine   = isset($child[Parser::SOURCE_LINE]) ? $child[Parser::SOURCE_LINE] : -1;
             $this->sourceColumn = isset($child[Parser::SOURCE_COLUMN]) ? $child[Parser::SOURCE_COLUMN] : -1;
-        } elseif (is_array($child) && isset($child[1]->sourceLine)) {
+        } elseif (\is_array($child) && isset($child[1]->sourceLine)) {
             $this->sourceIndex  = $child[1]->sourceIndex;
             $this->sourceLine   = $child[1]->sourceLine;
             $this->sourceColumn = $child[1]->sourceColumn;
@@ -2467,8 +2467,8 @@ class Compiler
 
                 if ($name[0] === Type::T_VARIABLE) {
                     $flags     = isset($child[3]) ? $child[3] : [];
-                    $isDefault = in_array('!default', $flags);
-                    $isGlobal  = in_array('!global', $flags);
+                    $isDefault = \in_array('!default', $flags);
+                    $isGlobal  = \in_array('!global', $flags);
 
                     if ($isGlobal) {
                         $this->set($name[1], $this->reduce($value), false, $this->rootEnv, $value);
@@ -2476,7 +2476,7 @@ class Compiler
                     }
 
                     $shouldSet = $isDefault &&
-                        (is_null($result = $this->get($name[1], false)) ||
+                        (\is_null($result = $this->get($name[1], false)) ||
                         $result === static::$null);
 
                     if (! $isDefault || $shouldSet) {
@@ -2488,7 +2488,7 @@ class Compiler
                 $compiledName = $this->compileValue($name);
 
                 // handle shorthand syntaxes : size / line-height...
-                if (in_array($compiledName, ['font', 'grid-row', 'grid-column', 'border-radius'])) {
+                if (\in_array($compiledName, ['font', 'grid-row', 'grid-column', 'border-radius'])) {
                     if ($value[0] === Type::T_VARIABLE) {
                         // if the font value comes from variable, the content is already reduced
                         // (i.e., formulas were already calculated), so we need the original unreduced value
@@ -2520,11 +2520,11 @@ class Compiler
                         if ($shorthandDividerNeedsUnit) {
                             $divider = $shorthandValue[3];
 
-                            if (is_array($divider)) {
+                            if (\is_array($divider)) {
                                 $divider = $this->reduce($divider, true);
                             }
 
-                            if (intval($divider->dimension) and !count($divider->units)) {
+                            if (\intval($divider->dimension) and !\count($divider->units)) {
                                 $revert = false;
                             }
                         }
@@ -2539,15 +2539,15 @@ class Compiler
                                     $revert = true;
                                     // if the list of values is too long, this has to be a shorthand,
                                     // otherwise it could be a real division
-                                    if (is_null($maxListElements) or count($shorthandValue[2]) <= $maxListElements) {
+                                    if (\is_null($maxListElements) or \count($shorthandValue[2]) <= $maxListElements) {
                                         if ($shorthandDividerNeedsUnit) {
                                             $divider = $item[3];
 
-                                            if (is_array($divider)) {
+                                            if (\is_array($divider)) {
                                                 $divider = $this->reduce($divider, true);
                                             }
 
-                                            if (intval($divider->dimension) and !count($divider->units)) {
+                                            if (\intval($divider->dimension) and !\count($divider->units)) {
                                                 $revert = false;
                                             }
                                         }
@@ -2576,7 +2576,7 @@ class Compiler
                 $compiledValue = $this->compileValue($value);
 
                 // ignore empty value
-                if (strlen($compiledValue)) {
+                if (\strlen($compiledValue)) {
                     $line = $this->formatter->property(
                         $compiledName,
                         $compiledValue
@@ -2645,7 +2645,7 @@ class Compiler
                 $this->pushEnv();
 
                 foreach ($list[2] as $item) {
-                    if (count($each->vars) === 1) {
+                    if (\count($each->vars) === 1) {
                         $this->set($each->vars[0], $item, true);
                     } else {
                         list(,, $values) = $this->coerceList($item);
@@ -2791,7 +2791,7 @@ class Compiler
                         $parent->selectors = $parentSelectors;
 
                         foreach ($mixin->children as $k => $child) {
-                            if (isset($child[1]) && is_object($child[1]) && $child[1] instanceof Block) {
+                            if (isset($child[1]) && \is_object($child[1]) && $child[1] instanceof Block) {
                                 $mixin->children[$k][1]->parent = $parent;
                             }
                         }
@@ -2990,7 +2990,7 @@ class Compiler
      */
     protected function reduce($value, $inExp = false)
     {
-        if (is_null($value)) {
+        if (\is_null($value)) {
             return null;
         }
 
@@ -3030,12 +3030,12 @@ class Compiler
                 // 3. op[op name]
                 $fn = "op${ucOpName}${ucLType}${ucRType}";
 
-                if (is_callable([$this, $fn]) ||
+                if (\is_callable([$this, $fn]) ||
                     (($fn = "op${ucLType}${ucRType}") &&
-                        is_callable([$this, $fn]) &&
+                        \is_callable([$this, $fn]) &&
                         $passOp = true) ||
                     (($fn = "op${ucOpName}") &&
-                        is_callable([$this, $fn]) &&
+                        \is_callable([$this, $fn]) &&
                         $genOp = true)
                 ) {
                     $coerceUnit = false;
@@ -3150,7 +3150,7 @@ class Compiler
 
             case Type::T_STRING:
                 foreach ($value[2] as &$item) {
-                    if (is_array($item) || $item instanceof \ArrayAccess) {
+                    if (\is_array($item) || $item instanceof \ArrayAccess) {
                         $item = $this->reduce($item);
                     }
                 }
@@ -3692,13 +3692,13 @@ class Compiler
                 $g = $this->compileRGBAValue($g);
                 $b = $this->compileRGBAValue($b);
 
-                if (count($value) === 5) {
+                if (\count($value) === 5) {
                     $alpha = $this->compileRGBAValue($value[4], true);
 
                     if (! is_numeric($alpha) || $alpha < 1) {
                         $colorName = Colors::RGBaToColorName($r, $g, $b, $alpha);
 
-                        if (! is_null($colorName)) {
+                        if (! \is_null($colorName)) {
                             return $colorName;
                         }
 
@@ -3718,7 +3718,7 @@ class Compiler
 
                 $colorName = Colors::RGBaToColorName($r, $g, $b);
 
-                if (! is_null($colorName)) {
+                if (! \is_null($colorName)) {
                     return $colorName;
                 }
 
@@ -3782,20 +3782,20 @@ class Compiler
                     }
 
                     $compiled = $this->compileValue($item);
-                    if ($prefix_value && strlen($compiled)) {
+                    if ($prefix_value && \strlen($compiled)) {
                         $compiled = $prefix_value . $compiled;
                     }
                     $filtered[] = $compiled;
                 }
 
-                return $pre . substr(implode("$delim", $filtered), strlen($prefix_value)) . $post;
+                return $pre . substr(implode("$delim", $filtered), \strlen($prefix_value)) . $post;
 
             case Type::T_MAP:
                 $keys     = $value[1];
                 $values   = $value[2];
                 $filtered = [];
 
-                for ($i = 0, $s = count($keys); $i < $s; $i++) {
+                for ($i = 0, $s = \count($keys); $i < $s; $i++) {
                     $filtered[$this->compileValue($keys[$i])] = $this->compileValue($values[$i]);
                 }
 
@@ -3816,7 +3816,7 @@ class Compiler
                     $delim .= ' ';
                 }
 
-                $left = count($left[2]) > 0 ?
+                $left = \count($left[2]) > 0 ?
                     $this->compileValue($left) . $delim . $whiteLeft: '';
 
                 $delim = $right[1];
@@ -3825,7 +3825,7 @@ class Compiler
                     $delim .= ' ';
                 }
 
-                $right = count($right[2]) > 0 ?
+                $right = \count($right[2]) > 0 ?
                     $whiteRight . $delim . $this->compileValue($right) : '';
 
                 return $left . $this->compileValue($interpolate) . $right;
@@ -3914,7 +3914,7 @@ class Compiler
         $parts = [];
 
         foreach ($string[2] as $part) {
-            if (is_array($part) || $part instanceof \ArrayAccess) {
+            if (\is_array($part) || $part instanceof \ArrayAccess) {
                 $parts[] = $this->compileValue($part);
             } else {
                 $parts[] = $part;
@@ -3937,8 +3937,8 @@ class Compiler
 
         foreach ($items as $i => $item) {
             if ($item[0] === Type::T_INTERPOLATE) {
-                $before = [Type::T_LIST, $list[1], array_slice($items, 0, $i)];
-                $after  = [Type::T_LIST, $list[1], array_slice($items, $i + 1)];
+                $before = [Type::T_LIST, $list[1], \array_slice($items, 0, $i)];
+                $after  = [Type::T_LIST, $list[1], \array_slice($items, $i + 1)];
 
                 return [Type::T_INTERPOLATED, $item, $before, $after];
             }
@@ -3963,7 +3963,7 @@ class Compiler
 
         $selfParentSelectors = null;
 
-        if (! is_null($selfParent) && $selfParent->selectors) {
+        if (! \is_null($selfParent) && $selfParent->selectors) {
             $selfParentSelectors = $this->evalSelectors($selfParent->selectors);
         }
 
@@ -4030,7 +4030,7 @@ class Compiler
                 if ($p === static::$selfSelector && ! $setSelf) {
                     $setSelf = true;
 
-                    if (is_null($selfParentSelectors)) {
+                    if (\is_null($selfParentSelectors)) {
                         $selfParentSelectors = $parent;
                     }
 
@@ -4041,7 +4041,7 @@ class Compiler
                         }
 
                         foreach ($parentPart as $pp) {
-                            if (is_array($pp)) {
+                            if (\is_array($pp)) {
                                 $flatten = [];
 
                                 array_walk_recursive($pp, function ($a) use (&$flatten) {
@@ -4098,7 +4098,7 @@ class Compiler
 
         list($this->env, $this->storeEnv) = $store;
 
-        if (is_null($childQueries)) {
+        if (\is_null($childQueries)) {
             $childQueries = $parentQueries;
         } else {
             $originalQueries = $childQueries;
@@ -4190,7 +4190,7 @@ class Compiler
     protected function backPropagateEnv($store, $excludedVars = null)
     {
         foreach ($store as $key => $value) {
-            if (empty($excludedVars) || !in_array($key, $excludedVars)) {
+            if (empty($excludedVars) || !\in_array($key, $excludedVars)) {
                 $this->set($key, $value, true);
             }
         }
@@ -4252,7 +4252,7 @@ class Compiler
                 break;
             }
 
-            if (array_key_exists($name, $env->store)) {
+            if (\array_key_exists($name, $env->store)) {
                 break;
             }
 
@@ -4335,7 +4335,7 @@ class Compiler
                 break;
             }
 
-            if (array_key_exists($normalizedName, $env->store)) {
+            if (\array_key_exists($normalizedName, $env->store)) {
                 if ($unreduced && isset($env->storeUnreduced[$normalizedName])) {
                     return $env->storeUnreduced[$normalizedName];
                 }
@@ -4384,7 +4384,7 @@ class Compiler
      */
     protected function has($name, Environment $env = null)
     {
-        return ! is_null($this->get($name, false, $env));
+        return ! \is_null($this->get($name, false, $env));
     }
 
     /**
@@ -4484,7 +4484,7 @@ class Compiler
      */
     public function addImportPath($path)
     {
-        if (! in_array($path, $this->importPaths)) {
+        if (! \in_array($path, $this->importPaths)) {
             $this->importPaths[] = $path;
         }
     }
@@ -4661,7 +4661,7 @@ class Compiler
         }
 
         foreach ($this->importPaths as $dir) {
-            if (is_string($dir)) {
+            if (\is_string($dir)) {
                 // check urls for normal import paths
                 foreach ($urls as $full) {
                     $separator = (
@@ -4675,11 +4675,11 @@ class Compiler
                         return $file;
                     }
                 }
-            } elseif (is_callable($dir)) {
+            } elseif (\is_callable($dir)) {
                 // check custom callback for import path
-                $file = call_user_func($dir, $url);
+                $file = \call_user_func($dir, $url);
 
-                if (! is_null($file)) {
+                if (! \is_null($file)) {
                     return $file;
                 }
             }
@@ -4744,8 +4744,8 @@ class Compiler
              ? $this->sourceNames[$this->sourceIndex] . " on line $line, at column $column"
              : "line: $line, column: $column";
 
-        if (func_num_args() > 1) {
-            $msg = call_user_func_array('sprintf', func_get_args());
+        if (\func_num_args() > 1) {
+            $msg = \call_user_func_array('sprintf', \func_get_args());
         }
 
         $msg = "$msg: $loc";
@@ -4783,7 +4783,7 @@ class Compiler
 
                     $callStackMsg[] = $msg;
 
-                    if (! is_null($limit) && $ncall > $limit) {
+                    if (! \is_null($limit) && $ncall > $limit) {
                         break;
                     }
                 }
@@ -4879,7 +4879,7 @@ class Compiler
         if (isset($this->userFunctions[$name])) {
             // see if we can find a user function
             list($f, $prototype) = $this->userFunctions[$name];
-        } elseif (($f = $this->getBuiltinFunction($name)) && is_callable($f)) {
+        } elseif (($f = $this->getBuiltinFunction($name)) && \is_callable($f)) {
             $libName   = $f[1];
             $prototype = isset(static::$$libName) ? static::$$libName : null;
         } else {
@@ -4900,7 +4900,7 @@ class Compiler
             }
         }
 
-        $returnValue = call_user_func($f, $sorted, $kwargs);
+        $returnValue = \call_user_func($f, $sorted, $kwargs);
 
         if (! isset($returnValue)) {
             return false;
@@ -4965,10 +4965,10 @@ class Compiler
         }
 
         // specific cases ?
-        if (in_array($functionName, ['libRgb', 'libRgba', 'libHsl', 'libHsla'])) {
+        if (\in_array($functionName, ['libRgb', 'libRgba', 'libHsl', 'libHsla'])) {
             // notation 100 127 255 / 0 is in fact a simple list of 4 values
             foreach ($args as $k => $arg) {
-                if ($arg[1][0] === Type::T_LIST && count($arg[1][2]) === 3) {
+                if ($arg[1][0] === Type::T_LIST && \count($arg[1][2]) === 3) {
                     $last = end($arg[1][2]);
 
                     if ($last[0] === Type::T_EXPRESSION && $last[1] === '/') {
@@ -4983,7 +4983,7 @@ class Compiler
 
         $finalArgs = [];
 
-        if (! is_array(reset($prototypes))) {
+        if (! \is_array(reset($prototypes))) {
             $prototypes = [$prototypes];
         }
 
@@ -5001,14 +5001,14 @@ class Compiler
                 $p       = explode(':', $p, 2);
                 $name    = array_shift($p);
 
-                if (count($p)) {
+                if (\count($p)) {
                     $p = trim(reset($p));
 
                     if ($p === 'null') {
                         // differentiate this null from the static::$null
                         $default = [Type::T_KEYWORD, 'null'];
                     } else {
-                        if (is_null($parser)) {
+                        if (\is_null($parser)) {
                             $parser = $this->parserFactory(__METHOD__);
                         }
 
@@ -5088,7 +5088,7 @@ class Compiler
     protected function applyArguments($argDef, $argValues, $storeInEnv = true, $reduce = true)
     {
         $output = [];
-        if (is_array($argValues) && count($argValues) && end($argValues) === static::$null) {
+        if (\is_array($argValues) && \count($argValues) && end($argValues) === static::$null) {
             array_pop($argValues);
         }
 
@@ -5136,7 +5136,7 @@ class Compiler
                         $this->throwError("Mixin or function doesn't have an argument named $%s.", $arg[0][1]);
                         break;
                     }
-                } elseif ($args[$name][0] < count($remaining)) {
+                } elseif ($args[$name][0] < \count($remaining)) {
                     $this->throwError("The argument $%s was passed both by position and by name.", $arg[0][1]);
                     break;
                 } else {
@@ -5163,7 +5163,7 @@ class Compiler
                                 $keywordArgs[$name] = $item;
                             }
                         } else {
-                            if (is_null($splatSeparator)) {
+                            if (\is_null($splatSeparator)) {
                                 $splatSeparator = $val[1];
                             }
 
@@ -5191,7 +5191,7 @@ class Compiler
                                 $keywordArgs[$name] = $item;
                             }
                         } else {
-                            if (is_null($splatSeparator)) {
+                            if (\is_null($splatSeparator)) {
                                 $splatSeparator = $val[1];
                             }
 
@@ -5213,9 +5213,9 @@ class Compiler
             list($i, $name, $default, $isVariable) = $arg;
 
             if ($isVariable) {
-                $val = [Type::T_LIST, is_null($splatSeparator) ? ',' : $splatSeparator , [], $isVariable];
+                $val = [Type::T_LIST, \is_null($splatSeparator) ? ',' : $splatSeparator , [], $isVariable];
 
-                for ($count = count($remaining); $i < $count; $i++) {
+                for ($count = \count($remaining); $i < $count; $i++) {
                     $val[2][] = $remaining[$i];
                 }
 
@@ -5270,15 +5270,15 @@ class Compiler
      */
     protected function coerceValue($value)
     {
-        if (is_array($value) || $value instanceof \ArrayAccess) {
+        if (\is_array($value) || $value instanceof \ArrayAccess) {
             return $value;
         }
 
-        if (is_bool($value)) {
+        if (\is_bool($value)) {
             return $this->toBool($value);
         }
 
-        if (is_null($value)) {
+        if (\is_null($value)) {
             return static::$null;
         }
 
@@ -5346,7 +5346,7 @@ class Compiler
             $values = $item[2];
             $list = [];
 
-            for ($i = 0, $s = count($keys); $i < $s; $i++) {
+            for ($i = 0, $s = \count($keys); $i < $s; $i++) {
                 $key = $keys[$i];
                 $value = $values[$i];
 
@@ -5430,7 +5430,7 @@ class Compiler
 
             case Type::T_LIST:
                 if ($inRGBFunction) {
-                    if (count($value[2]) == 3 || count($value[2]) == 4) {
+                    if (\count($value[2]) == 3 || \count($value[2]) == 4) {
                         $color = $value[2];
                         array_unshift($color, Type::T_COLOR);
 
@@ -5441,16 +5441,16 @@ class Compiler
                 return null;
 
             case Type::T_KEYWORD:
-                if (! is_string($value[1])) {
+                if (! \is_string($value[1])) {
                     return null;
                 }
 
                 $name = strtolower($value[1]);
                 // hexa color?
                 if (preg_match('/^#([0-9a-f]+)$/i', $name, $m)) {
-                    $nofValues = strlen($m[1]);
+                    $nofValues = \strlen($m[1]);
 
-                    if (in_array($nofValues, [3, 4, 6, 8])) {
+                    if (\in_array($nofValues, [3, 4, 6, 8])) {
                         $nbChannels = 3;
                         $color      = [];
                         $num        = hexdec($m[1]);
@@ -5534,18 +5534,18 @@ class Compiler
     protected function compileColorPartValue($value, $min, $max, $isInt = true, $clamp = true, $modulo = false)
     {
         if (! is_numeric($value)) {
-            if (is_array($value)) {
+            if (\is_array($value)) {
                 $reduced = $this->reduce($value);
 
-                if (is_object($reduced) && $value->type === Type::T_NUMBER) {
+                if (\is_object($reduced) && $value->type === Type::T_NUMBER) {
                     $value = $reduced;
                 }
             }
 
-            if (is_object($value) && $value->type === Type::T_NUMBER) {
+            if (\is_object($value) && $value->type === Type::T_NUMBER) {
                 $num = $value->dimension;
 
-                if (count($value->units)) {
+                if (\count($value->units)) {
                     $unit = array_keys($value->units);
                     $unit = reset($unit);
 
@@ -5559,7 +5559,7 @@ class Compiler
                 }
 
                 $value = $num;
-            } elseif (is_array($value)) {
+            } elseif (\is_array($value)) {
                 $value = $this->compileValue($value);
             }
         }
@@ -5907,7 +5907,7 @@ class Compiler
         ['red', 'green', 'blue', 'alpha'] ];
     protected function libRgb($args, $kwargs, $funcName = 'rgb')
     {
-        switch (count($args)) {
+        switch (\count($args)) {
             case 1:
                 if (! $color = $this->coerceColor($args[0], true)) {
                     $color = [Type::T_STRING, '', [$funcName . '(', $args[0], ')']];
@@ -5976,7 +5976,7 @@ class Compiler
                     $color[$irgba] = (($irgba < 4) ? 0 : 1);
                 }
 
-                $color[$irgba] = call_user_func($fn, $color[$irgba], $val, $iarg);
+                $color[$irgba] = \call_user_func($fn, $color[$irgba], $val, $iarg);
             }
         }
 
@@ -5986,7 +5986,7 @@ class Compiler
             foreach ([4 => 1, 5 => 2, 6 => 3] as $iarg => $ihsl) {
                 if (! empty($args[$iarg])) {
                     $val = $this->assertNumber($args[$iarg]);
-                    $hsl[$ihsl] = call_user_func($fn, $hsl[$ihsl], $val, $iarg);
+                    $hsl[$ihsl] = \call_user_func($fn, $hsl[$ihsl], $val, $iarg);
                 }
             }
 
@@ -6162,8 +6162,8 @@ class Compiler
         ['hue', 'saturation', 'lightness', 'alpha'] ];
     protected function libHsl($args, $kwargs, $funcName = 'hsl')
     {
-        if (count($args) == 1) {
-            if ($args[0][0] !== Type::T_LIST || count($args[0][2]) < 3 || count($args[0][2]) > 4) {
+        if (\count($args) == 1) {
+            if ($args[0][0] !== Type::T_LIST || \count($args[0][2]) < 3 || \count($args[0][2]) > 4) {
                 return [Type::T_STRING, '', [$funcName . '(', $args[0], ')']];
             }
 
@@ -6176,7 +6176,7 @@ class Compiler
 
         $alpha = null;
 
-        if (count($args) === 4) {
+        if (\count($args) === 4) {
             $alpha = $this->compileColorPartValue($args[3], 0, 100, false);
 
             if (! is_numeric($hue) || ! is_numeric($saturation) || ! is_numeric($lightness) || ! is_numeric($alpha)) {
@@ -6191,7 +6191,7 @@ class Compiler
 
         $color = $this->toRGB($hue, $saturation, $lightness);
 
-        if (! is_null($alpha)) {
+        if (! \is_null($alpha)) {
             $color[4] = $alpha;
         }
 
@@ -6451,8 +6451,8 @@ class Compiler
 
         foreach ($numbers as $key => $pair) {
             list($original, $normalized) = $pair;
-            if (is_null($normalized) or is_null($minNormalized)) {
-                if (is_null($minOriginal) || $original[1] <= $minOriginal[1]) {
+            if (\is_null($normalized) or \is_null($minNormalized)) {
+                if (\is_null($minOriginal) || $original[1] <= $minOriginal[1]) {
                     $minOriginal = $original;
                     $minNormalized = $normalized;
                 }
@@ -6473,8 +6473,8 @@ class Compiler
 
         foreach ($numbers as $key => $pair) {
             list($original, $normalized) = $pair;
-            if (is_null($normalized) or is_null($maxNormalized)) {
-                if (is_null($maxOriginal) || $original[1] >= $maxOriginal[1]) {
+            if (\is_null($normalized) or \is_null($maxNormalized)) {
+                if (\is_null($maxOriginal) || $original[1] >= $maxOriginal[1]) {
                     $maxOriginal = $original;
                     $maxNormalized = $normalized;
                 }
@@ -6527,19 +6527,19 @@ class Compiler
     {
         $list = $this->coerceList($args[0], ',', true);
 
-        return count($list[2]);
+        return \count($list[2]);
     }
 
     //protected static $libListSeparator = ['list...'];
     protected function libListSeparator($args)
     {
-        if (count($args) > 1) {
+        if (\count($args) > 1) {
             return 'comma';
         }
 
         $list = $this->coerceList($args[0]);
 
-        if (count($list[2]) <= 1) {
+        if (\count($list[2]) <= 1) {
             return 'space';
         }
 
@@ -6559,7 +6559,7 @@ class Compiler
         if ($n > 0) {
             $n--;
         } elseif ($n < 0) {
-            $n += count($list[2]);
+            $n += \count($list[2]);
         }
 
         return isset($list[2][$n]) ? $list[2][$n] : static::$defaultValue;
@@ -6574,7 +6574,7 @@ class Compiler
         if ($n > 0) {
             $n--;
         } elseif ($n < 0) {
-            $n += count($list[2]);
+            $n += \count($list[2]);
         }
 
         if (! isset($list[2][$n])) {
@@ -6594,10 +6594,10 @@ class Compiler
         $map = $this->assertMap($args[0]);
         $key = $args[1];
 
-        if (! is_null($key)) {
+        if (! \is_null($key)) {
             $key = $this->compileStringContent($this->coerceString($key));
 
-            for ($i = count($map[1]) - 1; $i >= 0; $i--) {
+            for ($i = \count($map[1]) - 1; $i >= 0; $i--) {
                 if ($key === $this->compileStringContent($this->coerceString($map[1][$i]))) {
                     return $map[2][$i];
                 }
@@ -6631,7 +6631,7 @@ class Compiler
         $map = $this->assertMap($args[0]);
         $key = $this->compileStringContent($this->coerceString($args[1]));
 
-        for ($i = count($map[1]) - 1; $i >= 0; $i--) {
+        for ($i = \count($map[1]) - 1; $i >= 0; $i--) {
             if ($key === $this->compileStringContent($this->coerceString($map[1][$i]))) {
                 array_splice($map[1], $i, 1);
                 array_splice($map[2], $i, 1);
@@ -6647,7 +6647,7 @@ class Compiler
         $map = $this->assertMap($args[0]);
         $key = $this->compileStringContent($this->coerceString($args[1]));
 
-        for ($i = count($map[1]) - 1; $i >= 0; $i--) {
+        for ($i = \count($map[1]) - 1; $i >= 0; $i--) {
             if ($key === $this->compileStringContent($this->coerceString($map[1][$i]))) {
                 return true;
             }
@@ -6913,7 +6913,7 @@ class Compiler
         $string = $this->coerceString($args[0]);
         $stringContent = $this->compileStringContent($string);
 
-        return new Node\Number(strlen($stringContent), '');
+        return new Node\Number(\strlen($stringContent), '');
     }
 
     protected static $libStrSlice = ['string', 'start-at', 'end-at:-1'];
@@ -6948,7 +6948,7 @@ class Compiler
         $string = $this->coerceString($args[0]);
         $stringContent = $this->compileStringContent($string);
 
-        $string[2] = [function_exists('mb_strtolower') ? mb_strtolower($stringContent) : strtolower($stringContent)];
+        $string[2] = [\function_exists('mb_strtolower') ? mb_strtolower($stringContent) : strtolower($stringContent)];
 
         return $string;
     }
@@ -6959,7 +6959,7 @@ class Compiler
         $string = $this->coerceString($args[0]);
         $stringContent = $this->compileStringContent($string);
 
-        $string[2] = [function_exists('mb_strtoupper') ? mb_strtoupper($stringContent) : strtoupper($stringContent)];
+        $string[2] = [\function_exists('mb_strtoupper') ? mb_strtoupper($stringContent) : strtoupper($stringContent)];
 
         return $string;
     }
@@ -6971,7 +6971,7 @@ class Compiler
         $name = $this->compileStringContent($string);
 
         return $this->toBool(
-            array_key_exists($name, $this->registeredFeatures) ? $this->registeredFeatures[$name] : false
+            \array_key_exists($name, $this->registeredFeatures) ? $this->registeredFeatures[$name] : false
         );
     }
 
@@ -6995,7 +6995,7 @@ class Compiler
         // built-in functions
         $f = $this->getBuiltinFunction($name);
 
-        return $this->toBool(is_callable($f));
+        return $this->toBool(\is_callable($f));
     }
 
     protected static $libGlobalVariableExists = ['name'];
@@ -7050,13 +7050,13 @@ class Compiler
 
                 return null;
             }
-            if ($n - intval($n) > 0) {
+            if ($n - \intval($n) > 0) {
                 $this->throwError("Expected \$limit to be an integer but got $n for `random`");
 
                 return null;
             }
 
-            return new Node\Number(mt_rand(1, intval($n)), '');
+            return new Node\Number(mt_rand(1, \intval($n)), '');
         }
 
         return new Node\Number(mt_rand(1, mt_getrandmax()), '');
@@ -7090,7 +7090,7 @@ class Compiler
             if (! empty($value['enclosing'])) {
                 if ($force_enclosing_display
                     || ($value['enclosing'] === 'bracket' )
-                    || !count($value[2])) {
+                    || !\count($value[2])) {
                     $value['enclosing'] = 'forced_'.$value['enclosing'];
                     $force_enclosing_display = true;
                 }
@@ -7122,7 +7122,7 @@ class Compiler
     {
         static $parser = null;
 
-        if (is_null($parser)) {
+        if (\is_null($parser)) {
             $parser = $this->parserFactory(__METHOD__);
         }
 
@@ -7177,11 +7177,11 @@ class Compiler
     protected function isSuperSelector($super, $sub)
     {
         // one and only one selector for each arg
-        if (! $super || count($super) !== 1) {
+        if (! $super || \count($super) !== 1) {
             $this->throwError("Invalid super selector for isSuperSelector()");
         }
 
-        if (! $sub || count($sub) !== 1) {
+        if (! $sub || \count($sub) !== 1) {
             $this->throwError("Invalid sub selector for isSuperSelector()");
         }
 
@@ -7209,7 +7209,7 @@ class Compiler
                 $nextMustMatch = true;
                 $i++;
             } else {
-                while ($i < count($sub) && ! $this->isSuperPart($node, $sub[$i])) {
+                while ($i < \count($sub) && ! $this->isSuperPart($node, $sub[$i])) {
                     if ($nextMustMatch) {
                         return false;
                     }
@@ -7217,7 +7217,7 @@ class Compiler
                     $i++;
                 }
 
-                if ($i >= count($sub)) {
+                if ($i >= \count($sub)) {
                     return false;
                 }
 
@@ -7242,11 +7242,11 @@ class Compiler
         $i = 0;
 
         foreach ($superParts as $superPart) {
-            while ($i < count($subParts) && $subParts[$i] !== $superPart) {
+            while ($i < \count($subParts) && $subParts[$i] !== $superPart) {
                 $i++;
             }
 
-            if ($i >= count($subParts)) {
+            if ($i >= \count($subParts)) {
                 return false;
             }
 
@@ -7263,7 +7263,7 @@ class Compiler
         $args = reset($args);
         $args = $args[2];
 
-        if (count($args) < 1) {
+        if (\count($args) < 1) {
             $this->throwError("selector-append() needs at least 1 argument");
         }
 
@@ -7289,7 +7289,7 @@ class Compiler
             $this->throwError("Invalid selector list in selector-append()");
         }
 
-        while (count($selectors)) {
+        while (\count($selectors)) {
             $previousSelectors = array_pop($selectors);
 
             if (! $previousSelectors) {
@@ -7390,12 +7390,12 @@ class Compiler
                 $extended[] = $selector;
             }
 
-            $n = count($extended);
+            $n = \count($extended);
 
             $this->matchExtends($selector, $extended);
 
             // if didnt match, keep the original selector if we are in a replace operation
-            if ($replace and count($extended) === $n) {
+            if ($replace and \count($extended) === $n) {
                 $extended[] = $selector;
             }
         }
@@ -7413,7 +7413,7 @@ class Compiler
         $args = reset($args);
         $args = $args[2];
 
-        if (count($args) < 1) {
+        if (\count($args) < 1) {
             $this->throwError("selector-nest() needs at least 1 argument");
         }
 
@@ -7476,11 +7476,11 @@ class Compiler
      */
     protected function unifyCompoundSelectors($compound1, $compound2)
     {
-        if (! count($compound1)) {
+        if (! \count($compound1)) {
             return $compound2;
         }
 
-        if (! count($compound2)) {
+        if (! \count($compound2)) {
             return $compound1;
         }
 
@@ -7497,7 +7497,7 @@ class Compiler
         $unifiedSelectors = [$unifiedCompound];
 
         // do the rest
-        while (count($compound1) || count($compound2)) {
+        while (\count($compound1) || \count($compound2)) {
             $part1 = end($compound1);
             $part2 = end($compound2);
 
@@ -7597,7 +7597,7 @@ class Compiler
         $after   = [];
 
         // try to find a match by tag name first
-        while (count($before)) {
+        while (\count($before)) {
             $p = array_pop($before);
 
             if ($partTag && $partTag !== '*' && $partTag == $this->findTagName($p)) {
@@ -7611,11 +7611,11 @@ class Compiler
         $before = $compound;
         $after = [];
 
-        while (count($before)) {
+        while (\count($before)) {
             $p = array_pop($before);
 
             if ($this->checkCompatibleTags($partTag, $this->findTagName($p))) {
-                if (count(array_intersect($part, $p))) {
+                if (\count(array_intersect($part, $p))) {
                     return [$before, $p, $after];
                 }
             }
@@ -7691,12 +7691,12 @@ class Compiler
         $tags = array_unique($tags);
         $tags = array_filter($tags);
 
-        if (count($tags) > 1) {
+        if (\count($tags) > 1) {
             $tags = array_diff($tags, ['*']);
         }
 
         // not compatible nodes
-        if (count($tags) > 1) {
+        if (\count($tags) > 1) {
             return false;
         }
 

--- a/src/Formatter.php
+++ b/src/Formatter.php
@@ -319,12 +319,12 @@ abstract class Formatter
             );
 
             $lines = explode("\n", $str);
-            $lineCount = count($lines);
+            $lineCount = \count($lines);
             $this->currentLine += $lineCount-1;
 
             $lastLine = array_pop($lines);
 
-            $this->currentColumn = ($lineCount === 1 ? $this->currentColumn : 0) + strlen($lastLine);
+            $this->currentColumn = ($lineCount === 1 ? $this->currentColumn : 0) + \strlen($lastLine);
         }
 
         echo $str;

--- a/src/Formatter/Nested.php
+++ b/src/Formatter/Nested.php
@@ -90,7 +90,7 @@ class Nested extends Formatter
             $previousHasSelector = false;
         }
 
-        $isMediaOrDirective = in_array($block->type, [Type::T_DIRECTIVE, Type::T_MEDIA]);
+        $isMediaOrDirective = \in_array($block->type, [Type::T_DIRECTIVE, Type::T_MEDIA]);
         $isSupport = ($block->type === Type::T_DIRECTIVE
             && $block->selectors && strpos(implode('', $block->selectors), '@supports') !== false);
 

--- a/src/Node/Number.php
+++ b/src/Node/Number.php
@@ -89,7 +89,7 @@ class Number extends Node implements \ArrayAccess
     {
         $this->type      = Type::T_NUMBER;
         $this->dimension = $dimension;
-        $this->units     = is_array($initialUnit)
+        $this->units     = \is_array($initialUnit)
             ? $initialUnit
             : ($initialUnit ? [$initialUnit => 1]
                             : []);
@@ -110,7 +110,7 @@ class Number extends Node implements \ArrayAccess
 
         $dimension = $this->dimension;
 
-        if (count($units)) {
+        if (\count($units)) {
             $baseUnit = array_keys($units);
             $baseUnit = reset($baseUnit);
             $baseUnit = $this->findBaseUnit($baseUnit);
@@ -148,11 +148,11 @@ class Number extends Node implements \ArrayAccess
     public function offsetExists($offset)
     {
         if ($offset === -3) {
-            return ! is_null($this->sourceColumn);
+            return ! \is_null($this->sourceColumn);
         }
 
         if ($offset === -2) {
-            return ! is_null($this->sourceLine);
+            return ! \is_null($this->sourceLine);
         }
 
         if ($offset === -1 ||
@@ -252,10 +252,10 @@ class Number extends Node implements \ArrayAccess
         $baseUnit = null;
         foreach ($this->units as $unit => $exp) {
             $b = $this->findBaseUnit($unit);
-            if (is_null($baseUnit)) {
+            if (\is_null($baseUnit)) {
                 $baseUnit = $b;
             }
-            if (is_null($b) or $b !== $baseUnit) {
+            if (\is_null($b) or $b !== $baseUnit) {
                 return false;
             }
         }
@@ -274,17 +274,17 @@ class Number extends Node implements \ArrayAccess
 
         foreach ($this->units as $unit => $unitSize) {
             if ($unitSize > 0) {
-                $numerators = array_pad($numerators, count($numerators) + $unitSize, $unit);
+                $numerators = array_pad($numerators, \count($numerators) + $unitSize, $unit);
                 continue;
             }
 
             if ($unitSize < 0) {
-                $denominators = array_pad($denominators, count($denominators) - $unitSize, $unit);
+                $denominators = array_pad($denominators, \count($denominators) - $unitSize, $unit);
                 continue;
             }
         }
 
-        return implode('*', $numerators) . (count($denominators) ? '/' . implode('*', $denominators) : '');
+        return implode('*', $numerators) . (\count($denominators) ? '/' . implode('*', $denominators) : '');
     }
 
     /**
@@ -302,7 +302,7 @@ class Number extends Node implements \ArrayAccess
             return $unitSize;
         });
 
-        if (count($units) > 1 && array_sum($units) === 0) {
+        if (\count($units) > 1 && array_sum($units) === 0) {
             $dimension = $this->dimension;
             $units     = [];
 
@@ -316,7 +316,7 @@ class Number extends Node implements \ArrayAccess
 
         $unitSize = array_sum($units);
 
-        if ($compiler && ($unitSize > 1 || $unitSize < 0 || count($units) > 1)) {
+        if ($compiler && ($unitSize > 1 || $unitSize < 0 || \count($units) > 1)) {
             $this->units = $units;
             $unit = $this->unitStr();
         } else {

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -173,7 +173,7 @@ class Parser
             ];
             $v = $this->cache->getCache("parse", $cacheKey, $parseOptions);
 
-            if (! is_null($v)) {
+            if (! \is_null($v)) {
                 return $v;
             }
         }
@@ -201,7 +201,7 @@ class Parser
             ;
         }
 
-        if ($this->count !== strlen($this->buffer)) {
+        if ($this->count !== \strlen($this->buffer)) {
             $this->throwParseError();
         }
 
@@ -601,7 +601,7 @@ class Parser
                 while ($cond[0] === Type::T_LIST
                     && !empty($cond['enclosing'])
                     && $cond['enclosing'] === 'parent'
-                    && count($cond[2]) == 1) {
+                    && \count($cond[2]) == 1) {
                     $cond = reset($cond[2]);
                 }
                 $if->cond  = $cond;
@@ -1076,7 +1076,7 @@ class Parser
     {
         $token = null;
 
-        $end = strlen($this->buffer);
+        $end = \strlen($this->buffer);
 
         // look for either ending delim, escape, or string interpolation
         foreach (['#{', '\\', $delim] as $lookahead) {
@@ -1098,7 +1098,7 @@ class Parser
             $match,
             $token
         ];
-        $this->count = $end + strlen($token);
+        $this->count = $end + \strlen($token);
 
         return true;
     }
@@ -1120,7 +1120,7 @@ class Parser
             return false;
         }
 
-        $this->count += strlen($out[0]);
+        $this->count += \strlen($out[0]);
 
         if (! isset($eatWhitespace)) {
             $eatWhitespace = $this->eatWhiteDefault;
@@ -1202,7 +1202,7 @@ class Parser
                 // comment that are kept in the output CSS
                 $comment = [];
                 $startCommentCount = $this->count;
-                $endCommentCount = $this->count + strlen($m[1]);
+                $endCommentCount = $this->count + \strlen($m[1]);
 
                 // find interpolations in comment
                 $p = strpos($this->buffer, '#{', $this->count);
@@ -1249,7 +1249,7 @@ class Parser
                 $this->count = $endCommentCount;
             } else {
                 // comment that are ignored and not kept in the output css
-                $this->count += strlen($m[0]);
+                $this->count += \strlen($m[0]);
             }
 
             $gotWhite = true;
@@ -1267,12 +1267,12 @@ class Parser
     {
         if (! $this->discardComments) {
             if ($comment[0] === Type::T_COMMENT) {
-                if (is_string($comment[1])) {
+                if (\is_string($comment[1])) {
                     $comment[1] = substr(preg_replace(['/^\s+/m', '/^(.)/m'], ['', ' \1'], $comment[1]), 1);
                 }
-                if (isset($comment[2]) and is_array($comment[2]) and $comment[2][0] === Type::T_STRING) {
+                if (isset($comment[2]) and \is_array($comment[2]) and $comment[2][0] === Type::T_STRING) {
                     foreach ($comment[2][2] as $k => $v) {
-                        if (is_string($v)) {
+                        if (\is_string($v)) {
                             $p = strpos($v, "\n");
                             if ($p !== false) {
                                 $comment[2][2][$k] = substr($v, 0, $p + 1)
@@ -1295,8 +1295,8 @@ class Parser
      */
     protected function append($statement, $pos = null)
     {
-        if (! is_null($statement)) {
-            if (! is_null($pos)) {
+        if (! \is_null($statement)) {
+            if (! \is_null($pos)) {
                 list($line, $column) = $this->getSourcePosition($pos);
 
                 $statement[static::SOURCE_LINE]   = $line;
@@ -1322,7 +1322,7 @@ class Parser
      */
     protected function last()
     {
-        $i = count($this->env->children) - 1;
+        $i = \count($this->env->children) - 1;
 
         if (isset($this->env->children[$i])) {
             return $this->env->children[$i];
@@ -1369,7 +1369,7 @@ class Parser
             $media = [Type::T_LIST, '', []];
 
             foreach ((array) $mediaType as $type) {
-                if (is_array($type)) {
+                if (\is_array($type)) {
                     $media[2][] = $type;
                 } else {
                     $media[2][] = [Type::T_KEYWORD, $type];
@@ -1383,7 +1383,7 @@ class Parser
         if (empty($parts) || $this->literal('and', 3)) {
             $this->genericList($expressions, 'mediaExpression', 'and', false);
 
-            if (is_array($expressions)) {
+            if (\is_array($expressions)) {
                 $parts = array_merge($parts, $expressions[2]);
             }
         }
@@ -1459,7 +1459,7 @@ class Parser
                 $compound = [Type::T_STRING, '', []];
 
                 foreach ($sc as $scp) {
-                    if (is_array($scp)) {
+                    if (\is_array($scp)) {
                         $compound[2][] = $scp;
                     } else {
                         $compound[2][] = [Type::T_KEYWORD, $scp];
@@ -1503,7 +1503,7 @@ class Parser
             $this->seek($s);
         }
 
-        if (count($parts)) {
+        if (\count($parts)) {
             if ($this->eatWhiteDefault) {
                 $this->whitespace();
             }
@@ -1703,7 +1703,7 @@ class Parser
             $items[] = $value;
 
             if ($delim) {
-                if (! $this->literal($delim, strlen($delim))) {
+                if (! $this->literal($delim, \strlen($delim))) {
                     break;
                 }
                 $trailing_delim = true;
@@ -1719,7 +1719,7 @@ class Parser
         if ($trailing_delim) {
             $items[] = [Type::T_NULL];
         }
-        if ($flatten && count($items) === 1) {
+        if ($flatten && \count($items) === 1) {
             $out = $items[0];
         } else {
             $out = [Type::T_LIST, $delim, $items];
@@ -1760,7 +1760,7 @@ class Parser
             $this->seek($s);
         }
 
-        if (in_array(Type::T_LIST, $allowedTypes) && $this->matchChar('[')) {
+        if (\in_array(Type::T_LIST, $allowedTypes) && $this->matchChar('[')) {
             if ($this->enclosedExpression($lhs, $s, "]", [Type::T_LIST])) {
                 if ($lookForExp) {
                     $out = $this->expHelper($lhs, 0);
@@ -1803,7 +1803,7 @@ class Parser
      */
     protected function enclosedExpression(&$out, $s, $closingParen = ")", $allowedTypes = [Type::T_LIST, Type::T_MAP])
     {
-        if ($this->matchChar($closingParen) && in_array(Type::T_LIST, $allowedTypes)) {
+        if ($this->matchChar($closingParen) && \in_array(Type::T_LIST, $allowedTypes)) {
             $out = [Type::T_LIST, '', []];
             switch ($closingParen) {
                 case ")":
@@ -1817,8 +1817,8 @@ class Parser
         }
 
         if ($this->valueList($out) && $this->matchChar($closingParen)
-            && in_array($out[0], [Type::T_LIST, Type::T_KEYWORD])
-            && in_array(Type::T_LIST, $allowedTypes)) {
+            && \in_array($out[0], [Type::T_LIST, Type::T_KEYWORD])
+            && \in_array(Type::T_LIST, $allowedTypes)) {
             if ($out[0] !== Type::T_LIST || ! empty($out['enclosing'])) {
                 $out = [Type::T_LIST, '', [$out]];
             }
@@ -1835,7 +1835,7 @@ class Parser
 
         $this->seek($s);
 
-        if (in_array(Type::T_MAP, $allowedTypes) && $this->map($out)) {
+        if (\in_array(Type::T_MAP, $allowedTypes) && $this->map($out)) {
             return true;
         }
 
@@ -2347,7 +2347,7 @@ class Parser
         $s = $this->count;
 
         if ($this->match('(#([0-9a-f]+))', $m)) {
-            if (in_array(strlen($m[2]), [3,4,6,8])) {
+            if (\in_array(\strlen($m[2]), [3,4,6,8])) {
                 $out = [Type::T_KEYWORD, $m[0]];
                 return true;
             }
@@ -2371,7 +2371,7 @@ class Parser
         $s = $this->count;
 
         if ($this->match('([0-9]*(\.)?[0-9]+)([%a-zA-Z]+)?', $m, false)) {
-            if (strlen($this->buffer) === $this->count || ! ctype_digit($this->buffer[$this->count])) {
+            if (\strlen($this->buffer) === $this->count || ! ctype_digit($this->buffer[$this->count])) {
                 $this->whitespace();
 
                 $unit = new Node\Number($m[1], empty($m[3]) ? '' : $m[3]);
@@ -2415,13 +2415,13 @@ class Parser
             }
 
             if ($m[2] === '#{') {
-                $this->count -= strlen($m[2]);
+                $this->count -= \strlen($m[2]);
 
                 if ($this->interpolation($inter, false)) {
                     $content[] = $inter;
                     $hasInterpolation = true;
                 } else {
-                    $this->count += strlen($m[2]);
+                    $this->count += \strlen($m[2]);
                     $content[] = '#{'; // ignore it
                 }
             } elseif ($m[2] === '\\') {
@@ -2441,14 +2441,14 @@ class Parser
                     $content[] = $m[2];
                 }
             } else {
-                $this->count -= strlen($delim);
+                $this->count -= \strlen($delim);
                 break; // delim
             }
         }
 
         $this->eatWhiteDefault = $oldWhite;
 
-        if ($this->literal($delim, strlen($delim))) {
+        if ($this->literal($delim, \strlen($delim))) {
             if ($hasInterpolation) {
                 $delim = '"';
 
@@ -2557,7 +2557,7 @@ class Parser
 
             $tok = $m[2];
 
-            $this->count-= strlen($tok);
+            $this->count-= \strlen($tok);
 
             if ($tok === $end && ! $nestingLevel) {
                 break;
@@ -2578,7 +2578,7 @@ class Parser
             }
 
             $content[] = $tok;
-            $this->count+= strlen($tok);
+            $this->count+= \strlen($tok);
         }
 
         $this->eatWhiteDefault = $oldWhite;
@@ -2588,8 +2588,8 @@ class Parser
         }
 
         // trim the end
-        if ($trimEnd && is_string(end($content))) {
-            $content[count($content) - 1] = rtrim(end($content));
+        if ($trimEnd && \is_string(end($content))) {
+            $content[\count($content) - 1] = rtrim(end($content));
         }
 
         $out = [Type::T_STRING, '', $content];
@@ -2696,7 +2696,7 @@ class Parser
         )) {
             if (! empty($m[0])) {
                 $parts[] = $m[0];
-                $this->count += strlen($m[0]);
+                $this->count += \strlen($m[0]);
             }
         }
 
@@ -2748,7 +2748,7 @@ class Parser
 
         $this->eatWhiteDefault = $oldWhite;
 
-        if (count($parts) == 1) {
+        if (\count($parts) == 1) {
             $this->seek($s);
 
             return false;
@@ -2813,7 +2813,7 @@ class Parser
             $s = $this->count;
 
             if ($this->match('[>+~]+', $m, true)) {
-                if ($subSelector && is_string($subSelector) && strpos($subSelector, 'nth-') === 0 &&
+                if ($subSelector && \is_string($subSelector) && strpos($subSelector, 'nth-') === 0 &&
                     $m[0] === '+' && $this->match("(\d+|n\b)", $counter)
                 ) {
                     $this->seek($s);
@@ -2970,12 +2970,12 @@ class Parser
                                         $parts[] = $p;
                                     }
 
-                                    if (count($sub) && reset($sub)) {
+                                    if (\count($sub) && reset($sub)) {
                                         $parts[] = ' ';
                                     }
                                 }
 
-                                if (count($subs) && reset($subs)) {
+                                if (\count($subs) && reset($subs)) {
                                     $parts[] = ', ';
                                 }
                             }
@@ -3008,7 +3008,7 @@ class Parser
             $this->seek($s);
 
             // 2n+1
-            if ($subSelector && is_string($subSelector) && strpos($subSelector, 'nth-') === 0) {
+            if ($subSelector && \is_string($subSelector) && strpos($subSelector, 'nth-') === 0) {
                 if ($this->match("(\s*(\+\s*|\-\s*)?(\d+|n|\d+n))+", $counter)) {
                     $parts[] = $counter[0];
                     //$parts[] = str_replace(' ', '', $counter[0]);
@@ -3124,7 +3124,7 @@ class Parser
     {
         $s = $this->count;
 
-        if ($this->keyword($word, $eatWhitespace) && (ord($word[0]) > 57 || ord($word[0]) < 48)) {
+        if ($this->keyword($word, $eatWhitespace) && (\ord($word[0]) > 57 || \ord($word[0]) < 48)) {
             return true;
         }
 
@@ -3189,7 +3189,7 @@ class Parser
             return true;
         }
 
-        if ($this->count === strlen($this->buffer) || $this->buffer[$this->count] === '}') {
+        if ($this->count === \strlen($this->buffer) || $this->buffer[$this->count] === '}') {
             // if there is end of file or a closing block next then we don't need a ;
             return true;
         }
@@ -3208,10 +3208,10 @@ class Parser
     {
         $flags = [];
 
-        for ($token = &$value; $token[0] === Type::T_LIST && ($s = count($token[2])); $token = &$lastNode) {
+        for ($token = &$value; $token[0] === Type::T_LIST && ($s = \count($token[2])); $token = &$lastNode) {
             $lastNode = &$token[2][$s - 1];
 
-            while ($lastNode[0] === Type::T_KEYWORD && in_array($lastNode[1], ['!default', '!global'])) {
+            while ($lastNode[0] === Type::T_KEYWORD && \in_array($lastNode[1], ['!default', '!global'])) {
                 array_pop($token[2]);
 
                 $node     = end($token[2]);
@@ -3238,7 +3238,7 @@ class Parser
         $part     = end($selector);
 
         if ($part === ['!optional']) {
-            array_pop($selectors[count($selectors) - 1]);
+            array_pop($selectors[\count($selectors) - 1]);
 
             $optional = true;
         }
@@ -3255,7 +3255,7 @@ class Parser
      */
     protected function flattenList($value)
     {
-        if ($value[0] === Type::T_LIST && count($value[2]) === 1) {
+        if ($value[0] === Type::T_LIST && \count($value[2]) === 1) {
             return $this->flattenList($value[2][0]);
         }
 
@@ -3273,7 +3273,7 @@ class Parser
      */
     protected function to($what, &$out, $until = false, $allowNewline = false)
     {
-        if (is_string($allowNewline)) {
+        if (\is_string($allowNewline)) {
             $validChars = $allowNewline;
         } else {
             $validChars = $allowNewline ? '.' : "[^\n]";
@@ -3286,7 +3286,7 @@ class Parser
         }
 
         if ($until) {
-            $this->count -= strlen($what); // give back $what
+            $this->count -= \strlen($what); // give back $what
         }
 
         $out = $m[1];
@@ -3333,10 +3333,10 @@ class Parser
             $prev = $pos + 1;
         }
 
-        $this->sourcePositions[] = strlen($buffer);
+        $this->sourcePositions[] = \strlen($buffer);
 
         if (substr($buffer, -1) !== "\n") {
-            $this->sourcePositions[] = strlen($buffer) + 1;
+            $this->sourcePositions[] = \strlen($buffer) + 1;
         }
     }
 
@@ -3350,7 +3350,7 @@ class Parser
     private function getSourcePosition($pos)
     {
         $low = 0;
-        $high = count($this->sourcePositions);
+        $high = \count($this->sourcePositions);
 
         while ($low < $high) {
             $mid = (int) (($high + $low) / 2);
@@ -3376,7 +3376,7 @@ class Parser
      */
     private function saveEncoding()
     {
-        if (extension_loaded('mbstring')) {
+        if (\extension_loaded('mbstring')) {
             $this->encoding = mb_internal_encoding();
 
             mb_internal_encoding('iso-8859-1');
@@ -3388,7 +3388,7 @@ class Parser
      */
     private function restoreEncoding()
     {
-        if (extension_loaded('mbstring') && $this->encoding) {
+        if (\extension_loaded('mbstring') && $this->encoding) {
             mb_internal_encoding($this->encoding);
         }
     }

--- a/src/SourceMap/SourceMapGenerator.php
+++ b/src/SourceMap/SourceMapGenerator.php
@@ -132,7 +132,7 @@ class SourceMapGenerator
     public function saveMap($content)
     {
         $file = $this->options['sourceMapWriteTo'];
-        $dir  = dirname($file);
+        $dir  = \dirname($file);
 
         // directory does not exist
         if (! is_dir($dir)) {
@@ -201,7 +201,7 @@ class SourceMapGenerator
         }
 
         // less.js compat fixes
-        if (count($sourceMap['sources']) && empty($sourceMap['sourceRoot'])) {
+        if (\count($sourceMap['sources']) && empty($sourceMap['sourceRoot'])) {
             unset($sourceMap['sourceRoot']);
         }
 
@@ -235,7 +235,7 @@ class SourceMapGenerator
      */
     public function generateMappings()
     {
-        if (! count($this->mappings)) {
+        if (! \count($this->mappings)) {
             return '';
         }
 
@@ -313,8 +313,8 @@ class SourceMapGenerator
         $basePath = $this->options['sourceMapBasepath'];
 
         // "Trim" the 'sourceMapBasepath' from the output filename.
-        if (strlen($basePath) && strpos($filename, $basePath) === 0) {
-            $filename = substr($filename, strlen($basePath));
+        if (\strlen($basePath) && strpos($filename, $basePath) === 0) {
+            $filename = substr($filename, \strlen($basePath));
         }
 
         // Remove extra leading path separators.


### PR DESCRIPTION
Some built-in functions can be turned into specific opcodes at compile time when the compiler is sure that they will be used (i.e. no namespace fallback is needed). This can have a major performance impact when they appear in hot paths.
In the profiling, is_null was one of the most expansive function due to the huge number of times it was used. And it is one of the functions which is optimized. Closes #96.

This change has been done using the php-cs-fixer tool, which maintains a list of functions which benefit from such optimization.