### PR TITLE
Fix leaks in the call stack

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -1891,6 +1891,7 @@ class Compiler
             $ret = $this->compileChild($stm, $out);
 
             if (isset($ret)) {
+                $this->popCallStack();
                 return $ret;
             }
         }
@@ -1929,6 +1930,7 @@ class Compiler
 
             if (isset($ret)) {
                 $this->throwError('@return may only be used within a function');
+                $this->popCallStack();
 
                 return;
             }


### PR DESCRIPTION
When using a return directive, a frame was leaked in the call stack.
This has 2 effects:

- the call stack displayed in error message becomes very confusing, as it includes unrelated locations
- the call stack grows much more than necessary. This has a cost when computing the call stack message, and makes it more likely to reach the threshold used to prevent infinite loops (without actually doing infinite loops).

Another frame leak happened when using a return directive in a forbidden location (so now leaking 2 frames due to the previous leak), in case exceptions are ignored (to allow the code to continue to execute and so to care about it).

This will probably solve #89 but I haven't checked.