### PR TITLE
Add access to scss exception line.

### DIFF
--- a/src/Exception/ParserException.php
+++ b/src/Exception/ParserException.php
@@ -11,6 +11,8 @@
 
 namespace ScssPhp\ScssPhp\Exception;
 
+use Exception;
+
 /**
  * Parser Exception
  *
@@ -18,4 +20,36 @@ namespace ScssPhp\ScssPhp\Exception;
  */
 class ParserException extends \Exception
 {
+    /**
+     * Style exception line.
+     *
+     * @var integer
+     */
+    protected $styleLine = 0;
+
+    /**
+     * Create new FieldException instance.
+     *
+     * @param string $message
+     * @param string $file
+     * @param int $line
+     * @param integer $code
+     * @param Exception $previous
+     */
+    public function __construct($message = null, int $styleLine = 0, $code = 0, Exception $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+
+        $this->styleLine = $styleLine;
+    }
+
+    /**
+     * Get style line.
+     *
+     * @return integer
+     */
+    public function getStyleLine()
+    {
+        return $this->styleLine;
+    }
 }

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -146,12 +146,12 @@ class Parser
         if ($this->peek("(.*?)(\n|$)", $m, $this->count)) {
             $this->restoreEncoding();
 
-            throw new ParserException("$msg: failed at `$m[1]` $loc");
+            throw new ParserException("$msg: failed at `$m[1]` $loc", $line);
         }
 
         $this->restoreEncoding();
 
-        throw new ParserException("$msg: $loc");
+        throw new ParserException("$msg: $loc", $line);
     }
 
     /**


### PR DESCRIPTION
I need the ability to use the `scss` exception line to display more readable errors directly in the template. For this I need the line where error happens. If the scss exception line is passed to the `ParserException` you can get it directly without reading it from the error message.

```php
try {
    return (new ScssPhp())->compile($style);
} catch (ParserException $e) {
    $e->getStyleLine();
}
```