### PR TITLE
Properly skip error tests for sass-spec in compat run

### DIFF
--- a/tests/SassSpecTest.php
+++ b/tests/SassSpecTest.php
@@ -172,6 +172,8 @@ class SassSpecTest extends TestCase
             if (getenv('BUILD')) {
                 $this->appendToExclusionList($name);
                 $this->assertNull(null);
+            } else {
+                $this->markTestSkipped('Specs expecting an error are not supported for now.');
             }
         }
     }


### PR DESCRIPTION
Instead of doing a test without any assertion (which gets reported as risky), this reports the test as skipped, which matches the actual behavior.
Without `TEST_SASS_SPEC=1`, these tests are always skipped by the exclusion list anyway.