### PR TITLE
Ensure sass-spec tests are properly isolated for precision changes

### DIFF
--- a/tests/SassSpecTest.php
+++ b/tests/SassSpecTest.php
@@ -13,6 +13,7 @@ namespace ScssPhp\ScssPhp\Tests;
 
 use PHPUnit\Framework\TestCase;
 use ScssPhp\ScssPhp\Compiler;
+use ScssPhp\ScssPhp\Node\Number;
 
 /**
  * Sass Spec Test - extracts tests from https://github.com/sass/sass-spec
@@ -27,6 +28,20 @@ class SassSpecTest extends TestCase
 
     protected static $fileExclusionList = __DIR__ . '/specs/sass-spec-exclude.txt';
     protected static $fileWarningExclusionList = __DIR__ . '/specs/sass-spec-exclude-warning.txt';
+
+    private $precisionBackup;
+
+    /** @before */
+    protected function saveState()
+    {
+        $this->precisionBackup = Number::$precision;
+    }
+
+    /** @after */
+    protected function restoreState()
+    {
+        Number::$precision = $this->precisionBackup;
+    }
 
     /**
      * List of excluded tests if not in TEST_SCSS_COMPAT mode


### PR DESCRIPTION
`Compiler::setNumberPrecision` is actually changing some global state. For now, sass-spec tests are not changing this config yet (which is why some specs are skipped) so this is not an issue. But it breaks test isolation if we want to start testing with different precision.