### PR TITLE
Fix the parsing of id tokens in values

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -2413,7 +2413,7 @@ class Parser
     {
         $s = $this->count;
 
-        if ($this->match('(#([0-9a-f]+))', $m)) {
+        if ($this->match('(#([0-9a-f]+)\b)', $m)) {
             if (\in_array(\strlen($m[2]), [3,4,6,8])) {
                 $out = [Type::T_KEYWORD, $m[0]];
 

--- a/tests/specs/sass-spec-exclude.txt
+++ b/tests/specs/sass-spec-exclude.txt
@@ -873,7 +873,6 @@
 1955/1980. selector-functions/unify/universal_simple
 1957/1980. values/colors/alpha_hex/initial_digit
 1958/1980. values/colors/alpha_hex/initial_letter
-1959/1980. values/ids
 1963/1980. values/maps/duplicate-keys
 1964/1980. values/maps/errors
 1966/1980. values/maps/invalid-key


### PR DESCRIPTION
If the token was starting with valid hex chars, the parser was previously splitting it into 2 keywords, with a color for the beginning.