### PR TITLE
Fix the order of selectors when nesting them

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -4021,8 +4021,8 @@ class Compiler
                 $prevSelectors = $selectors;
                 $selectors     = [];
 
-                foreach ($prevSelectors as $selector) {
-                    foreach ($parentSelectors as $parent) {
+                foreach ($parentSelectors as $parent) {
+                    foreach ($prevSelectors as $selector) {
                         if ($selfParentSelectors) {
                             foreach ($selfParentSelectors as $selfParent) {
                                 // if no '&' in the selector, each call will give same result, only add once

--- a/tests/outputs/selectors.css
+++ b/tests/outputs/selectors.css
@@ -368,7 +368,7 @@ span a, p a, div a {
 .parent + .parent {
   content: "should match .parent + .parent"; }
 
-ul ul, ul ol, ol ul, ol ol {
+ul ul, ol ul, ul ol, ol ol {
   display: block; }
 
 .👤 {

--- a/tests/outputs_numbered/selectors.css
+++ b/tests/outputs_numbered/selectors.css
@@ -519,7 +519,7 @@ span a, p a, div a {
 
 /* line 285, inputs/selectors.scss */
 /* line 286, inputs/selectors.scss */
-ul ul, ul ol, ol ul, ol ol {
+ul ul, ol ul, ul ol, ol ol {
   display: block; }
 
 /* line 292, inputs/selectors.scss */

--- a/tests/specs/sass-spec-exclude.txt
+++ b/tests/specs/sass-spec-exclude.txt
@@ -1,14 +1,9 @@
 7/1980. basic/06_nesting_and_comments
-8/1980. basic/07_nested_simple_selector_groups
-10/1980. basic/09_selector_groups_and_combinators
-11/1980. basic/10_classes_and_ids
 12/1980. basic/11_attribute_selectors
-14/1980. basic/13_back_references
 16/1980. basic/15_arithmetic_and_lists
 17/1980. basic/17_basic_mixins
 19/1980. basic/19_full_mixin_craziness
 24/1980. basic/25_basic_string_interpolation
-25/1980. basic/26_selector_interpolation
 39/1980. basic/41_slashy_urls
 40/1980. basic/42_css_imports
 47/1980. basic/54_adjacent_identifiers_with_hyphens
@@ -477,7 +472,6 @@
 864/1980. libsass-closed-issues/issue_1669
 866/1980. libsass-closed-issues/issue_1670
 876/1980. libsass-closed-issues/issue_1706
-877/1980. libsass-closed-issues/issue_1710
 878/1980. libsass-closed-issues/issue_1715
 883/1980. libsass-closed-issues/issue_1732/invalid/mixin-def
 891/1980. libsass-closed-issues/issue_1739/basic
@@ -835,7 +829,6 @@
 1680/1980. scss-tests/019_test_css_import_directive
 1681/1980. scss-tests/020_test_css_import_directive
 1700/1980. scss-tests/040_test_newlines_in_selectors
-1701/1980. scss-tests/041_test_newlines_in_selectors
 1702/1980. scss-tests/042_test_newlines_in_selectors
 1703/1980. scss-tests/043_test_newlines_in_selectors
 1763/1980. scss-tests/130_test_random_directive_interpolation


### PR DESCRIPTION
Changing the order of nested loops makes the output compliant with sass-spec (7 new passing specs).

Here was one of the failure before for the newly passing tests (that's `basic/07_nested_simple_selector_groups`):

```diff
--- Expected
+++ Actual
@@ @@
 c, d {\n
   color: gray;\n
 }\n
-c e, c f, d e, d f {\n
+c e, d e, c f, d f {\n
   background: blue;\n
   padding: 10px 5px;\n
 }\n
-c g, c h, d g, d h {\n
+c g, d g, c h, d h {\n
   blah: blah;\n
   bloo: bloo;\n
 }\n
-c i, c j, d i, d j {\n
+c i, d i, c j, d j {\n
   foo: goo;\n
 }\n
-c i k, c i l, c j k, c j l, d i k, d i l, d j k, d j l {\n
+c i k, d i k, c j k, d j k, c i l, d i l, c j l, d j l {\n
   hoo: boo;\n
 }\n
-c i k m, c i k n, c i k o, c i l m, c i l n, c i l o, c j k m, c j k n, c j k o, c j l m, c j l n, c j l o, d i k m, d i k n, d i k o, d i l m, d i l n, d i l o, d j k m, d j k n, d j k o, d j l m, d j l n, d j l o {\n
+c i k m, d i k m, c j k m, d j k m, c i l m, d i l m, c j l m, d j l m, c i k n, d i k n, c j k n, d j k n, c i l n, d i l n, c j l n, d j l n, c i k o, d i k o, c j k o, d j k o, c i l o, d i l o, c j l o, d j l o {\n
   wow: we are far inside;\n
   but: it still works;\n
 }
```