### PR TITLE
Simplify the handling of comments to be more spec-compliant

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -2381,14 +2381,6 @@ class Compiler
     {
         $outWrite = &$out;
 
-        if ($type === Type::T_COMMENT) {
-            $parent = $out->parent;
-
-            if (end($parent->children) !== $out) {
-                $outWrite = &$parent->children[\count($parent->children) - 1];
-            }
-        }
-
         // check if it's a flat output or not
         if (\count($out->children)) {
             $lastChild = &$out->children[\count($out->children) - 1];

--- a/src/Formatter/Expanded.php
+++ b/src/Formatter/Expanded.php
@@ -55,7 +55,7 @@ class Expanded extends Formatter
 
         foreach ($block->lines as $index => $line) {
             if (substr($line, 0, 2) === '/*') {
-                $block->lines[$index] = preg_replace('/[\r\n]+/', $glue, $line);
+                $block->lines[$index] = preg_replace('/\r\n?|\n|\f/', $this->break, $line);
             }
         }
 

--- a/src/Formatter/Nested.php
+++ b/src/Formatter/Nested.php
@@ -62,7 +62,7 @@ class Nested extends Formatter
 
         foreach ($block->lines as $index => $line) {
             if (substr($line, 0, 2) === '/*') {
-                $block->lines[$index] = preg_replace('/[\r\n]+/', $glue, $line);
+                $block->lines[$index] = preg_replace('/\r\n?|\n|\f/', $this->break, $line);
             }
         }
 

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -1308,25 +1308,6 @@ class Parser
     protected function appendComment($comment)
     {
         if (! $this->discardComments) {
-            if ($comment[0] === Type::T_COMMENT) {
-                if (\is_string($comment[1])) {
-                    $comment[1] = substr(preg_replace(['/^\s+/m', '/^(.)/m'], ['', ' \1'], $comment[1]), 1);
-                }
-
-                if (isset($comment[2]) and \is_array($comment[2]) and $comment[2][0] === Type::T_STRING) {
-                    foreach ($comment[2][2] as $k => $v) {
-                        if (\is_string($v)) {
-                            $p = strpos($v, "\n");
-
-                            if ($p !== false) {
-                                $comment[2][2][$k] = substr($v, 0, $p + 1)
-                                    . preg_replace(['/^\s+/m', '/^(.)/m'], ['', ' \1'], substr($v, $p+1));
-                            }
-                        }
-                    }
-                }
-            }
-
             $this->env->comments[] = $comment;
         }
     }

--- a/tests/outputs/comments.css
+++ b/tests/outputs/comments.css
@@ -1,7 +1,9 @@
 /** what the heck **/
 /**
- Here is a block comment
- **/
+
+Here is a block comment
+
+**/
 /*hello*/
 div {
   /*yeah*/
@@ -31,10 +33,10 @@ a {
 /* comment 7 */
 /* коммент */
 /* This is a comment with vars references:
- color:red
- and a fake #{ doing nothing
- radius:2px
- and also a #{$fake} interpolation that should not throw an error
+color:red
+and a fake #{ doing nothing
+radius:2px
+   and also a #{$fake} interpolation that should not throw an error
  */
 .textimage-background-fullheight .background {
   /* @noflip */
@@ -44,8 +46,8 @@ a {
 
 .class {
   /* This is a comment with vars references not on root level
-   color:red
-   and a fake #{ doing nothing
-   radius:2px
-   and also a #{$fake} interpolation that should not throw an error
-   */ }
+  color:red
+  and a fake #{ doing nothing
+  radius:2px
+     and also a #{$fake} interpolation that should not throw an error
+  */ }

--- a/tests/outputs/parsing_comments.css
+++ b/tests/outputs/parsing_comments.css
@@ -19,15 +19,15 @@ b {
  */
 c {
   /*
-   * multi-line comment 2
-   */
+     * multi-line comment 2
+     */
   color: red;
   /*
-   * multi-line comment 3
-   */
+                 * multi-line comment 3
+                 */
   /*
-   * multi-line comment 4
-   */ }
+     * multi-line comment 4
+     */ }
 
 /*
  * multi-line comment 5
@@ -37,15 +37,15 @@ c {
  */
 d {
   /*!
-   * multi-line comment 2
-   */
+     * multi-line comment 2
+     */
   color: red;
   /*!
-   * multi-line comment 3
-   */
+                 * multi-line comment 3
+                 */
   /*!
-   * multi-line comment 4
-   */ }
+     * multi-line comment 4
+     */ }
 
 /*!
  * multi-line comment 5

--- a/tests/outputs/scss_css.css
+++ b/tests/outputs/scss_css.css
@@ -44,14 +44,14 @@ sel {
 
 .foo {
   /* Foo
-   Bar
-   Baz */
+Bar
+  Baz */
   a: b; }
 
 .foo {
   /* Foo
-   Bar
-   Baz */
+Bar
+  Baz */
   a: b; }
 
 .foo {
@@ -62,7 +62,7 @@ sel {
 .foo {
   /* Foo
    Bar
-   Baz */
+  Baz */
   a: b; }
 
 @foo {
@@ -111,13 +111,13 @@ E > F, G > H {
 
 /* Another comment */
 /* The following should not be used:
- .two {color: red;} */
+.two {color: red;} */
 .three {
   color: green;
   /* color: red; */ }
 
 /**
- .four {color: red;} */
+.four {color: red;} */
 .five {
   color: green; }
 
@@ -603,8 +603,8 @@ E, F G, H {
 
 body {
   /*
-   //comment here
-   */ }
+  //comment here
+  */ }
 
 E > F {
   a: b; }

--- a/tests/outputs_numbered/comments.css
+++ b/tests/outputs_numbered/comments.css
@@ -1,7 +1,9 @@
 /** what the heck **/
 /**
- Here is a block comment
- **/
+
+Here is a block comment
+
+**/
 /*hello*/
 /* line 16, inputs/comments.scss */
 div {
@@ -34,10 +36,10 @@ a {
 /* comment 7 */
 /* коммент */
 /* This is a comment with vars references:
- color:red
- and a fake #{ doing nothing
- radius:2px
- and also a #{$fake} interpolation that should not throw an error
+color:red
+and a fake #{ doing nothing
+radius:2px
+   and also a #{$fake} interpolation that should not throw an error
  */
 /* line 61, inputs/comments.scss */
 /* line 62, inputs/comments.scss */
@@ -50,8 +52,8 @@ a {
 /* line 70, inputs/comments.scss */
 .class {
   /* This is a comment with vars references not on root level
-   color:red
-   and a fake #{ doing nothing
-   radius:2px
-   and also a #{$fake} interpolation that should not throw an error
-   */ }
+  color:red
+  and a fake #{ doing nothing
+  radius:2px
+     and also a #{$fake} interpolation that should not throw an error
+  */ }

--- a/tests/outputs_numbered/parsing_comments.css
+++ b/tests/outputs_numbered/parsing_comments.css
@@ -22,15 +22,15 @@ b {
 /* line 20, inputs/parsing_comments.scss */
 c {
   /*
-   * multi-line comment 2
-   */
+     * multi-line comment 2
+     */
   color: red;
   /*
-   * multi-line comment 3
-   */
+                 * multi-line comment 3
+                 */
   /*
-   * multi-line comment 4
-   */ }
+     * multi-line comment 4
+     */ }
 
 /*
  * multi-line comment 5
@@ -41,15 +41,15 @@ c {
 /* line 38, inputs/parsing_comments.scss */
 d {
   /*!
-   * multi-line comment 2
-   */
+     * multi-line comment 2
+     */
   color: red;
   /*!
-   * multi-line comment 3
-   */
+                 * multi-line comment 3
+                 */
   /*!
-   * multi-line comment 4
-   */ }
+     * multi-line comment 4
+     */ }
 
 /*!
  * multi-line comment 5

--- a/tests/outputs_numbered/scss_css.css
+++ b/tests/outputs_numbered/scss_css.css
@@ -53,15 +53,15 @@ sel {
 /* line 39, inputs/scss_css.scss */
 .foo {
   /* Foo
-   Bar
-   Baz */
+Bar
+  Baz */
   a: b; }
 
 /* line 46, inputs/scss_css.scss */
 .foo {
   /* Foo
-   Bar
-   Baz */
+Bar
+  Baz */
   a: b; }
 
 /* line 53, inputs/scss_css.scss */
@@ -74,7 +74,7 @@ sel {
 .foo {
   /* Foo
    Bar
-   Baz */
+  Baz */
   a: b; }
 
 @foo {
@@ -131,14 +131,14 @@ E > F, G > H {
 
 /* Another comment */
 /* The following should not be used:
- .two {color: red;} */
+.two {color: red;} */
 /* line 113, inputs/scss_css.scss */
 .three {
   color: green;
   /* color: red; */ }
 
 /**
- .four {color: red;} */
+.four {color: red;} */
 /* line 116, inputs/scss_css.scss */
 .five {
   color: green; }
@@ -751,8 +751,8 @@ E, F G, H {
 /* line 771, inputs/scss_css.scss */
 body {
   /*
-   //comment here
-   */ }
+  //comment here
+  */ }
 
 /* line 778, inputs/scss_css.scss */
 E > F {

--- a/tests/specs/sass-spec-exclude.txt
+++ b/tests/specs/sass-spec-exclude.txt
@@ -1,8 +1,5 @@
-basic/06_nesting_and_comments
 basic/11_attribute_selectors
 basic/15_arithmetic_and_lists
-basic/17_basic_mixins
-basic/19_full_mixin_craziness
 basic/25_basic_string_interpolation
 basic/41_slashy_urls
 basic/42_css_imports
@@ -128,9 +125,7 @@ core_functions/string/quote/quoted_single
 core_functions/variable_exists/error/argument/too_few
 core_functions/variable_exists/error/argument/too_many
 core_functions/variable_exists/error/argument/type
-css/comment/converts_newlines/scss/ff
 css/comment/multiple_stars
-css/comment/weird_indentation
 css/custom_properties/error/brackets/curly
 css/custom_properties/error/brackets/curly_in_square
 css/custom_properties/error/brackets/paren
@@ -403,7 +398,6 @@ libsass-closed-issues/issue_1266/max
 libsass-closed-issues/issue_1266/min
 libsass-closed-issues/issue_1271
 libsass-closed-issues/issue_1279
-libsass-closed-issues/issue_1294
 libsass-closed-issues/issue_1328
 libsass-closed-issues/issue_1355
 libsass-closed-issues/issue_1398
@@ -553,7 +547,6 @@ libsass-closed-issues/issue_558
 libsass-closed-issues/issue_575
 libsass-closed-issues/issue_590
 libsass-closed-issues/issue_628
-libsass-closed-issues/issue_646
 libsass-closed-issues/issue_657/default
 libsass-closed-issues/issue_659/static
 libsass-closed-issues/issue_660
@@ -818,7 +811,6 @@ scss-tests/130_test_random_directive_interpolation
 scss-tests/174_test_import_comments_in_imports
 scss-tests/186_test_newlines_removed_from_selectors_when_compressed
 scss/concat
-scss/css_crazy_comments
 scss/directives-in-propsets
 scss/feature-queries/without-query
 scss/ie-functions


### PR DESCRIPTION
The special logic dealing with comments was actually making them less spec-compliant than without it, as sass-spec differs from the old ruby-sass logic.

The output is a bit less nice for multi-line comments as it does not fix their indentation, but that matches the libsass behavior.
dart-sass has a slightly different output, where the re-indent the comment by replacing the original indentation with the output indentation. Something like this could be achieved in the nested and expanded formatters too. I haven't done it yet, as it would make the sass-spec compliance harder to maintain (the testsuite currently uses the libsass output when the hrx file contains implementation-specific outputs).