### PR TITLE
Improve test names for sass-spec by using a named provider

### DIFF
--- a/tests/SassSpecTest.php
+++ b/tests/SassSpecTest.php
@@ -453,12 +453,15 @@ class SassSpecTest extends TestCase
         ksort($tests);
         $tests = array_values($tests);
 
+        $testCases = array();
+
         foreach ($tests as $k => $test) {
-            $rang = $k . "/" . $nb_tests . '. ';
-            $tests[$k][0] = $rang . $tests[$k][0];
+            $testName = ($k+1) . '/' . $nb_tests . '. ' . $test[0];
+            $test[0] = $testName;
+            $testCases[$testName] = $test;
         }
 
         //var_dump($skippedTests);
-        return $tests;
+        return $testCases;
     }
 }


### PR DESCRIPTION
This makes it a lot easier to use phpunit --filter as using the file name (without the hrx) exception now works rather than having to
discover the index.
The number of tests is back to 1-based in the names to make it less confusion (tests now go again from 1/1980 to 1980 rather than from 0/1980 to 1979/1980), which is not an issue as phpunit --filter does not require the usage of a 0-based index anymore.