### PR TITLE
Drop support for configuring the precision

### DIFF
--- a/bin/pscss
+++ b/bin/pscss
@@ -24,7 +24,6 @@ use ScssPhp\ScssPhp\Version;
 
 $style = null;
 $loadPaths = null;
-$precision = null;
 $dumpTree = false;
 $inputFile = null;
 $changeDir = false;
@@ -77,7 +76,7 @@ Options include:
     --iso8859-1         Use iso8859-1 encoding instead of default utf-8
     --line-numbers      Annotate selectors with comments referring to the source file and line number [--line-comments]
     --load-path=PATH    Set import path [-I]
-    --precision=N       Set decimal number precision (default 10) [-p]
+    --precision=N       [deprecated] Set decimal number precision. Ignored. (default 10) [-p]
     --sourcemap         Create source map file
     --style=FORMAT      Set the output format (compact, compressed, crunched, expanded, or nested) [-s, -t]
     --version           Print the version [-v]
@@ -134,10 +133,11 @@ EOT;
         continue;
     }
 
+    // Keep parsing --precision to avoid BC breaks for scripts using it
     $value = parseArgument($i, array('-p', '--precision'));
 
     if (isset($value)) {
-        $precision = $value;
+        // TODO report it as a warning ?
         continue;
     }
 
@@ -190,10 +190,6 @@ if ($ignoreErrors) {
 
 if ($loadPaths) {
     $scss->setImportPaths(explode(PATH_SEPARATOR, $loadPaths));
-}
-
-if ($precision) {
-    $scss->setNumberPrecision($precision);
 }
 
 if ($style) {

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -4565,10 +4565,12 @@ class Compiler
      * @api
      *
      * @param integer $numberPrecision
+     *
+     * @deprecated The number precision is not configurable anymore. The default is enough for all browsers.
      */
     public function setNumberPrecision($numberPrecision)
     {
-        Node\Number::$precision = $numberPrecision;
+        @trigger_error('The number precision is not configurable anymore. The default is enough for all browsers.', E_USER_DEPRECATED);
     }
 
     /**
@@ -5574,7 +5576,7 @@ class Compiler
                             if ($color[3] === 255) {
                                 $color[3] = 1; // fully opaque
                             } else {
-                                $color[3] = round($color[3] / 255, Node\Number::$precision);
+                                $color[3] = round($color[3] / 255, Node\Number::PRECISION);
                             }
                         }
 

--- a/src/Node/Number.php
+++ b/src/Node/Number.php
@@ -28,10 +28,13 @@ use ScssPhp\ScssPhp\Type;
  */
 class Number extends Node implements \ArrayAccess
 {
+    const PRECISION = 10;
+
     /**
      * @var integer
+     * @deprecated use {Number::PRECISION} instead to read the precision. Configuring it is not supported anymore.
      */
-    public static $precision = 10;
+    public static $precision = self::PRECISION;
 
     /**
      * @see http://www.w3.org/TR/2012/WD-css3-values-20120308/
@@ -301,7 +304,7 @@ class Number extends Node implements \ArrayAccess
      */
     public function output(Compiler $compiler = null)
     {
-        $dimension = round($this->dimension, static::$precision);
+        $dimension = round($this->dimension, self::PRECISION);
 
         $units = array_filter($this->units, function ($unitSize) {
             return $unitSize;
@@ -313,7 +316,7 @@ class Number extends Node implements \ArrayAccess
 
             $this->normalizeUnits($dimension, $units);
 
-            $dimension = round($dimension, static::$precision);
+            $dimension = round($dimension, self::PRECISION);
             $units     = array_filter($units, function ($unitSize) {
                 return $unitSize;
             });
@@ -329,9 +332,9 @@ class Number extends Node implements \ArrayAccess
             $unit = key($units);
         }
 
-        $dimension = number_format($dimension, static::$precision, '.', '');
+        $dimension = number_format($dimension, self::PRECISION, '.', '');
 
-        return (static::$precision ? rtrim(rtrim($dimension, '0'), '.') : $dimension) . $unit;
+        return (self::PRECISION ? rtrim(rtrim($dimension, '0'), '.') : $dimension) . $unit;
     }
 
     /**

--- a/tests/SassSpecTest.php
+++ b/tests/SassSpecTest.php
@@ -29,20 +29,6 @@ class SassSpecTest extends TestCase
     protected static $fileExclusionList = __DIR__ . '/specs/sass-spec-exclude.txt';
     protected static $fileWarningExclusionList = __DIR__ . '/specs/sass-spec-exclude-warning.txt';
 
-    private $precisionBackup;
-
-    /** @before */
-    protected function saveState()
-    {
-        $this->precisionBackup = Number::$precision;
-    }
-
-    /** @after */
-    protected function restoreState()
-    {
-        Number::$precision = $this->precisionBackup;
-    }
-
     /**
      * List of excluded tests if not in TEST_SCSS_COMPAT mode
      *


### PR DESCRIPTION
A precision of 10 is enough for all browsers to avoid rounding issues.
This matches the behavior of dart-sass in which it cannot be configured either.

I used the Symfony convention (also used by the Drupal for instance, and maybe others) to report the deprecation of the setter with `@trigger_error('...', E_USER_DEPRECATED);` to make it discoverable in projects using a compatible deprecation collector. I can remove it if your prefer.

Closes #141 