### PR TITLE
Fix the build mode for error tests

### DIFF
--- a/tests/SassSpecTest.php
+++ b/tests/SassSpecTest.php
@@ -271,7 +271,6 @@ class SassSpecTest extends TestCase
             if (getenv('BUILD')) {
                 try {
                     static::$scss->compile($scss, 'input.scss');
-                    fclose($fp_err_stream);
                     throw new \Exception('Expecting a SassException for error tests');
                 } catch (SassException $e) {
                     // TODO assert the error message ?


### PR DESCRIPTION
Trying to close the error stream twice does not work. It is closed after the `try/catch`