### PR TITLE
Fix the logic setting the memory_limit in SassSpecTest

### DIFF
--- a/tests/SassSpecTest.php
+++ b/tests/SassSpecTest.php
@@ -160,7 +160,28 @@ class SassSpecTest extends TestCase
     public function testTests($name, $input, $output)
     {
         if (is_null(static::$scss)) {
-            @ini_set('memory_limit', "256M");
+            // Increase the memory_limit to at least 256M to run these tests.
+            // This code takes care of not lowering it.
+            $memoryLimit = trim(ini_get('memory_limit'));
+            if ($memoryLimit != -1) {
+                $unit = strtolower(substr($memoryLimit, -1, 1));
+                $memoryInBytes = (int) $memoryLimit;
+
+                switch ($unit) {
+                    case 'g':
+                        $memoryInBytes *= 1024;
+                        // no break (cumulative multiplier)
+                    case 'm':
+                        $memoryInBytes *= 1024;
+                        // no break (cumulative multiplier)
+                    case 'k':
+                        $memoryInBytes *= 1024;
+                }
+
+                if ($memoryInBytes < 256*1024*1024) {
+                    @ini_set('memory_limit', "256M");
+                }
+            }
 
             static::$scss = new Compiler();
             static::$scss->setFormatter('ScssPhp\ScssPhp\Formatter\Expanded');


### PR DESCRIPTION
The new version of the code makes sure that 256M is the minimum limit, but will preserve any higher limit.
This makes it possible to use PCOV to collect code coverage while running tests, as it requires lots of memory.