### PR TITLE
Fix the initialization of the parser for secondary entrypoints

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -248,6 +248,7 @@ class Parser
         $this->buffer          = (string) $buffer;
 
         $this->saveEncoding();
+        $this->extractLineNumbers($this->buffer);
 
         $list = $this->valueList($out);
 
@@ -276,6 +277,7 @@ class Parser
         $this->buffer          = (string) $buffer;
 
         $this->saveEncoding();
+        $this->extractLineNumbers($this->buffer);
 
         $selector = $this->selectors($out);
 
@@ -307,6 +309,7 @@ class Parser
         $this->buffer          = (string) $buffer;
 
         $this->saveEncoding();
+        $this->extractLineNumbers($this->buffer);
 
         $isMediaQuery = $this->mediaQueryList($out);
 


### PR DESCRIPTION
The parse() method extract line numbers when setting the buffer, but other parse methods don't do it, while they might still trigger errors relying on that data.

This fixes tests broken by 8a30458de984e1fa79181c72378b5743907867e7 when it added parser errors in those other entrypoints.

Note that line numbers will be off for such errors. What dart-sass does is that it catches exceptions and re-throw them with an updated location when it uses the selector parser during the scss compilation. But we cannot do that easily in the current codebase. So at least, this ensures that the proper error message gets reported (even with a broken line number) instead of reporting a bug in the parser.