### PR TITLE
Refactor Number to be immutable and spec-compliant

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -104,7 +104,9 @@ class Compiler
 
     public static $true         = [Type::T_KEYWORD, 'true'];
     public static $false        = [Type::T_KEYWORD, 'false'];
+    /** @deprecated */
     public static $NaN          = [Type::T_KEYWORD, 'NaN'];
+    /** @deprecated */
     public static $Infinity     = [Type::T_KEYWORD, 'Infinity'];
     public static $null         = [Type::T_NULL];
     public static $nullString   = [Type::T_STRING, '', []];
@@ -3633,15 +3635,10 @@ class Compiler
      * @param Number $left
      * @param Number $right
      *
-     * @return array|Number
+     * @return Number
      */
     protected function opDivNumberNumber(Number $left, Number $right)
     {
-        // TODO handle NaN and Infinity inside Number for proper math everywhere
-        if ($right->getDimension() == 0) {
-            return ($left->getDimension() == 0) ? static::$NaN : static::$Infinity;
-        }
-
         return $left->dividedBy($right);
     }
 
@@ -3655,10 +3652,6 @@ class Compiler
      */
     protected function opModNumberNumber(Number $left, Number $right)
     {
-        if ($right->getDimension() == 0) {
-            return static::$NaN;
-        }
-
         return $left->modulo($right);
     }
 

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -2659,7 +2659,7 @@ class Compiler
                                 $divider = $this->reduce($divider, true);
                             }
 
-                            if (\intval($divider->dimension) && ! \count($divider->units)) {
+                            if ($divider instanceof Node\Number && \intval($divider->getDimension()) && $divider->unitless()) {
                                 $revert = false;
                             }
                         }
@@ -2683,7 +2683,7 @@ class Compiler
                                                 $divider = $this->reduce($divider, true);
                                             }
 
-                                            if (\intval($divider->dimension) && ! \count($divider->units)) {
+                                            if ($divider instanceof Node\Number && \intval($divider->getDimension()) && $divider->unitless()) {
                                                 $revert = false;
                                             }
                                         }
@@ -6168,9 +6168,9 @@ class Compiler
 
             if ($value instanceof Node\Number) {
                 if ($value->unitless()) {
-                    $num = $value->dimension;
+                    $num = $value->getDimension();
                 } elseif ($value->hasUnit('%')) {
-                    $num = $max * $value->dimension / 100;
+                    $num = $max * $value->getDimension() / 100;
                 } else {
                     throw $this->error('Expected %s to have no units or "%%".', $value);
                 }
@@ -6935,13 +6935,13 @@ class Compiler
             }
         }
 
-        $hueValue = $hue->dimension % 360;
+        $hueValue = $hue->getDimension() % 360;
 
         while ($hueValue < 0) {
             $hueValue += 360;
         }
 
-        $color = $this->toRGB($hueValue, max(0, min($saturation->dimension, 100)), max(0, min($lightness->dimension, 100)));
+        $color = $this->toRGB($hueValue, max(0, min($saturation->getDimension(), 100)), max(0, min($lightness->getDimension(), 100)));
 
         if (! \is_null($alpha)) {
             $color[4] = $alpha;

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -6320,7 +6320,7 @@ class Compiler
      * @param mixed $value
      * @param string $varName
      *
-     * @return integer|float
+     * @return Number
      *
      * @throws \Exception
      */
@@ -6332,7 +6332,7 @@ class Compiler
             throw $this->error("Error:{$var_display} $value is not a number.");
         }
 
-        return $value->getDimension();
+        return $value;
     }
 
     /**
@@ -6350,7 +6350,7 @@ class Compiler
     public function assertInteger($value, $varName = null)
     {
 
-        $value = $this->assertNumber($value, $varName);
+        $value = $this->assertNumber($value, $varName)->getDimension();
         if (round($value - \intval($value), Number::PRECISION) > 0) {
             $var_display = ($varName ? " \${$varName}:" : '');
             throw $this->error("Error:{$var_display} $value is not an integer.");
@@ -6677,7 +6677,7 @@ class Compiler
 
         foreach ([1 => 1, 2 => 2, 3 => 3, 7 => 4] as $iarg => $irgba) {
             if (isset($args[$iarg])) {
-                $val = $this->assertNumber($args[$iarg]);
+                $val = $this->assertNumber($args[$iarg])->getDimension();
 
                 if (! isset($color[$irgba])) {
                     $color[$irgba] = (($irgba < 4) ? 0 : 1);
@@ -6692,7 +6692,7 @@ class Compiler
 
             foreach ([4 => 1, 5 => 2, 6 => 3] as $iarg => $ihsl) {
                 if (! empty($args[$iarg])) {
-                    $val = $this->assertNumber($args[$iarg]);
+                    $val = $this->assertNumber($args[$iarg])->getDimension();
                     $hsl[$ihsl] = \call_user_func($fn, $hsl[$ihsl], $val, $iarg);
                 }
             }
@@ -7010,7 +7010,7 @@ class Compiler
     protected function libAdjustHue($args)
     {
         $color = $this->assertColor($args[0]);
-        $degrees = $this->assertNumber($args[1]);
+        $degrees = $this->assertNumber($args[1])->getDimension();
 
         return $this->adjustHsl($color, 1, $degrees);
     }
@@ -7174,11 +7174,7 @@ class Compiler
     protected static $libPercentage = ['number'];
     protected function libPercentage($args)
     {
-        $this->assertNumber($args[0], 'number');
-        /**
-         * @var Number $num
-         */
-        $num = $args[0];
+        $num = $this->assertNumber($args[0], 'number');
         $num->assertNoUnits('number');
 
         return new Number($num->getDimension() * 100, '%');
@@ -7187,11 +7183,7 @@ class Compiler
     protected static $libRound = ['number'];
     protected function libRound($args)
     {
-        $this->assertNumber($args[0], 'number');
-        /**
-         * @var Number $num
-         */
-        $num = $args[0];
+        $num = $this->assertNumber($args[0], 'number');
 
         return new Number(round($num->getDimension()), $num->getNumeratorUnits(), $num->getDenominatorUnits());
     }
@@ -7199,11 +7191,7 @@ class Compiler
     protected static $libFloor = ['number'];
     protected function libFloor($args)
     {
-        $this->assertNumber($args[0], 'number');
-        /**
-         * @var Number $num
-         */
-        $num = $args[0];
+        $num = $this->assertNumber($args[0], 'number');
 
         return new Number(floor($num->getDimension()), $num->getNumeratorUnits(), $num->getDenominatorUnits());
     }
@@ -7211,11 +7199,7 @@ class Compiler
     protected static $libCeil = ['number'];
     protected function libCeil($args)
     {
-        $this->assertNumber($args[0], 'number');
-        /**
-         * @var Number $num
-         */
-        $num = $args[0];
+        $num = $this->assertNumber($args[0], 'number');
 
         return new Number(ceil($num->getDimension()), $num->getNumeratorUnits(), $num->getDenominatorUnits());
     }
@@ -7223,11 +7207,7 @@ class Compiler
     protected static $libAbs = ['number'];
     protected function libAbs($args)
     {
-        $this->assertNumber($args[0], 'number');
-        /**
-         * @var Number $num
-         */
-        $num = $args[0];
+        $num = $this->assertNumber($args[0], 'number');
 
         return new Number(abs($num->getDimension()), $num->getNumeratorUnits(), $num->getDenominatorUnits());
     }
@@ -7240,11 +7220,7 @@ class Compiler
         $min = null;
 
         foreach ($args as $arg) {
-            $this->assertNumber($arg);
-            /**
-             * @var Number $number
-             */
-            $number = $arg;
+            $number = $this->assertNumber($arg);
 
             if (\is_null($min) || $min->greaterThan($number)) {
                 $min = $number;
@@ -7266,11 +7242,7 @@ class Compiler
         $max = null;
 
         foreach ($args as $arg) {
-            $this->assertNumber($arg);
-            /**
-             * @var Number $number
-             */
-            $number = $arg;
+            $number = $this->assertNumber($arg);
 
             if (\is_null($max) || $max->lessThan($number)) {
                 $max = $number;
@@ -7320,7 +7292,7 @@ class Compiler
     protected function libNth($args)
     {
         $list = $this->coerceList($args[0], ',', false);
-        $n = $this->assertNumber($args[1]);
+        $n = $this->assertNumber($args[1])->getDimension();
 
         if ($n > 0) {
             $n--;
@@ -7335,7 +7307,7 @@ class Compiler
     protected function libSetNth($args)
     {
         $list = $this->coerceList($args[0]);
-        $n = $this->assertNumber($args[1]);
+        $n = $this->assertNumber($args[1])->getDimension();
 
         if ($n > 0) {
             $n--;
@@ -7846,7 +7818,7 @@ class Compiler
     protected function libRandom($args)
     {
         if (isset($args[0]) & $args[0] !== static::$null) {
-            $n = $this->assertNumber($args[0]);
+            $n = $this->assertNumber($args[0])->getDimension();
 
             if ($n < 1) {
                 throw $this->error("\$limit must be greater than or equal to 1");

--- a/src/Exception/SassScriptException.php
+++ b/src/Exception/SassScriptException.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace ScssPhp\ScssPhp\Exception;
+
+/**
+ * Internal exception thrown in places not having access to reporting the location.
+ *
+ * This class does not implement SassException on purpose, as it should never be returned to the outside code.
+ *
+ * @internal
+ */
+class SassScriptException extends \Exception
+{
+}

--- a/src/Node/Number.php
+++ b/src/Node/Number.php
@@ -76,27 +76,34 @@ class Number extends Node implements \ArrayAccess
     /**
      * @var integer|float
      */
-    public $dimension;
+    private $dimension;
 
     /**
      * @var array
      */
-    public $units;
+    private $units;
 
     /**
      * Initialize number
      *
-     * @param mixed $dimension
-     * @param mixed $initialUnit
+     * @param integer|float $dimension
+     * @param array|string $initialUnit
      */
     public function __construct($dimension, $initialUnit)
     {
-        $this->type      = Type::T_NUMBER;
         $this->dimension = $dimension;
         $this->units     = \is_array($initialUnit)
             ? $initialUnit
             : ($initialUnit ? [$initialUnit => 1]
                             : []);
+    }
+
+    /**
+     * @return float|int
+     */
+    public function getDimension()
+    {
+        return $this->dimension;
     }
 
     /**
@@ -187,7 +194,7 @@ class Number extends Node implements \ArrayAccess
                 return $this->sourceIndex;
 
             case 0:
-                return $this->type;
+                return Type::T_NUMBER;
 
             case 1:
                 return $this->dimension;
@@ -202,17 +209,7 @@ class Number extends Node implements \ArrayAccess
      */
     public function offsetSet($offset, $value)
     {
-        if ($offset === 1) {
-            $this->dimension = $value;
-        } elseif ($offset === 2) {
-            $this->units = $value;
-        } elseif ($offset == -1) {
-            $this->sourceIndex = $value;
-        } elseif ($offset == -2) {
-            $this->sourceLine = $value;
-        } elseif ($offset == -3) {
-            $this->sourceColumn = $value;
-        }
+        throw new \BadMethodCallException('Number is immutable');
     }
 
     /**
@@ -220,17 +217,7 @@ class Number extends Node implements \ArrayAccess
      */
     public function offsetUnset($offset)
     {
-        if ($offset === 1) {
-            $this->dimension = null;
-        } elseif ($offset === 2) {
-            $this->units = null;
-        } elseif ($offset === -1) {
-            $this->sourceIndex = null;
-        } elseif ($offset === -2) {
-            $this->sourceLine = null;
-        } elseif ($offset === -3) {
-            $this->sourceColumn = null;
-        }
+        throw new \BadMethodCallException('Number is immutable');
     }
 
     /**

--- a/src/Node/Number.php
+++ b/src/Node/Number.php
@@ -366,6 +366,10 @@ class Number extends Node implements \ArrayAccess
     public function modulo(Number $other)
     {
         return $this->coerceNumber($other, function ($num1, $num2) {
+            if ($num2 == 0) {
+                return NAN;
+            }
+
             return $num1 % $num2;
         });
     }
@@ -387,7 +391,17 @@ class Number extends Node implements \ArrayAccess
      */
     public function dividedBy(Number $other)
     {
-        return $this->multiplyUnits($this->dimension / $other->dimension, $this->numeratorUnits, $this->denominatorUnits, $other->denominatorUnits, $other->numeratorUnits);
+        if ($other->dimension == 0) {
+            if ($this->dimension == 0) {
+                $value = NAN;
+            } else {
+                $value = INF;
+            }
+        } else {
+            $value = $this->dimension / $other->dimension;
+        }
+
+        return $this->multiplyUnits($value, $this->numeratorUnits, $this->denominatorUnits, $other->denominatorUnits, $other->numeratorUnits);
     }
 
     /**
@@ -425,6 +439,14 @@ class Number extends Node implements \ArrayAccess
     public function output(Compiler $compiler = null)
     {
         $dimension = round($this->dimension, self::PRECISION);
+
+        if (is_nan($dimension)) {
+            return 'NaN';
+        }
+
+        if ($dimension === INF) {
+            return 'Infinity';
+        }
 
         if ($compiler) {
             $unit = $this->unitStr();

--- a/src/Node/Number.php
+++ b/src/Node/Number.php
@@ -394,8 +394,10 @@ class Number extends Node implements \ArrayAccess
         if ($other->dimension == 0) {
             if ($this->dimension == 0) {
                 $value = NAN;
-            } else {
+            } elseif ($this->dimension > 0) {
                 $value = INF;
+            } else {
+                $value = -INF;
             }
         } else {
             $value = $this->dimension / $other->dimension;
@@ -413,6 +415,11 @@ class Number extends Node implements \ArrayAccess
     {
         // Unitless numbers are convertable to unit numbers, but not equal, so we special-case unitless here.
         if ($this->unitless() !== $other->unitless()) {
+            return false;
+        }
+
+        // In Sass, neither NaN nor Infinity are equal to themselves, while PHP defines INF==INF
+        if (is_nan($this->dimension) || is_nan($other->dimension) || !is_finite($this->dimension) || !is_finite($other->dimension)) {
             return false;
         }
 
@@ -446,6 +453,10 @@ class Number extends Node implements \ArrayAccess
 
         if ($dimension === INF) {
             return 'Infinity';
+        }
+
+        if ($dimension === -INF) {
+            return '-Infinity';
         }
 
         if ($compiler) {

--- a/src/Node/Number.php
+++ b/src/Node/Number.php
@@ -335,7 +335,7 @@ class Number extends Node implements \ArrayAccess
 
         $dimension = number_format($dimension, self::PRECISION, '.', '');
 
-        return (self::PRECISION ? rtrim(rtrim($dimension, '0'), '.') : $dimension) . $unit;
+        return rtrim(rtrim($dimension, '0'), '.') . $unit;
     }
 
     /**

--- a/src/Node/Number.php
+++ b/src/Node/Number.php
@@ -244,6 +244,18 @@ class Number extends Node implements \ArrayAccess
     }
 
     /**
+     * Checks whether the number has exactly this unit
+     *
+     * @param string $unit
+     *
+     * @return bool
+     */
+    public function hasUnit($unit)
+    {
+        return isset($this->units[$unit]) && $this->units[$unit] === 1 && array_sum($this->units) === 1;
+    }
+
+    /**
      * Test if a number can be normalized in a base unit
      * ie if its units are homogeneous
      *

--- a/src/Node/Number.php
+++ b/src/Node/Number.php
@@ -293,6 +293,18 @@ class Number extends Node implements \ArrayAccess
             }
         }
 
+        if (!\count($numerators)) {
+            if (\count($denominators) === 0) {
+                return '';
+            }
+
+            if (\count($denominators) === 1) {
+                return $denominators[0] . '^-1';
+            }
+
+            return '(' . implode('*', $denominators) . ')^-1';
+        }
+
         return implode('*', $numerators) . (\count($denominators) ? '/' . implode('*', $denominators) : '');
     }
 

--- a/tests/outputs/builtins.css
+++ b/tests/outputs/builtins.css
@@ -85,7 +85,7 @@
   top: 1ex;
   width: 200%;
   bottom: 10px;
-  padding: 3em 1in 96px 72pt; }
+  padding: 3em 1in 1in 1in; }
 
 #list {
   len: 3;
@@ -96,7 +96,6 @@
   hello: one, two, three, hello;
   index: 2;
   index: 3;
-  index: 1;
   index: 1;
   index: 2;
   index: 2;

--- a/tests/outputs_numbered/builtins.css
+++ b/tests/outputs_numbered/builtins.css
@@ -92,7 +92,7 @@
   top: 1ex;
   width: 200%;
   bottom: 10px;
-  padding: 3em 1in 96px 72pt; }
+  padding: 3em 1in 1in 1in; }
 
 /* line 120, inputs/builtins.scss */
 #list {
@@ -104,7 +104,6 @@
   hello: one, two, three, hello;
   index: 2;
   index: 3;
-  index: 1;
   index: 1;
   index: 2;
   index: 2;

--- a/tests/specs/sass-spec-exclude.txt
+++ b/tests/specs/sass-spec-exclude.txt
@@ -44,7 +44,6 @@ core_functions/color/fade_in/error/type/alpha
 core_functions/color/fade_out/error/bounds/too_high
 core_functions/color/fade_out/error/bounds/too_low
 core_functions/color/fade_out/error/type/alpha
-core_functions/color/hsl/error/four_args/alpha/unit
 core_functions/color/hsl/error/four_args/hue/type
 core_functions/color/hsl/error/four_args/lightness/type
 core_functions/color/hsl/error/four_args/saturation/type
@@ -67,7 +66,6 @@ core_functions/color/hsl/one_arg/special_functions/alpha/multi_argument_var/1_of
 core_functions/color/hsl/one_arg/special_functions/alpha/multi_argument_var/2_of_2
 core_functions/color/hsl/one_arg/special_functions/alpha/var/arg_3
 core_functions/color/hsl/one_arg/special_functions/alpha/var/arg_4
-core_functions/color/hsla/error/four_args/alpha/type
 core_functions/color/hsla/error/four_args/hue/type
 core_functions/color/hsla/error/four_args/lightness/type
 core_functions/color/hsla/error/four_args/saturation/type
@@ -110,7 +108,6 @@ core_functions/color/invert/error/type/weight
 core_functions/color/mix/error/bounds/too_high
 core_functions/color/mix/error/bounds/too_low
 core_functions/color/mix/error/type/weight
-core_functions/color/rgb/error/four_args/alpha/unit
 core_functions/color/rgb/error/four_args/blue/type
 core_functions/color/rgb/error/four_args/green/type
 core_functions/color/rgb/error/four_args/red/type
@@ -128,7 +125,6 @@ core_functions/color/rgb/error/three_args/blue/type
 core_functions/color/rgb/error/three_args/green/type
 core_functions/color/rgb/error/three_args/red/type
 core_functions/color/rgb/error/two_args/alpha/type
-core_functions/color/rgb/error/two_args/alpha/unit
 core_functions/color/rgb/error/two_args/color/type
 core_functions/color/rgb/four_args/special_functions/var/arg_2/args/both
 core_functions/color/rgb/four_args/special_functions/var/arg_2/args/color
@@ -172,7 +168,6 @@ core_functions/color/rgb/one_arg/special_functions/no_alpha/min/arg_3
 core_functions/color/rgb/one_arg/special_functions/no_alpha/var/arg_1
 core_functions/color/rgb/one_arg/special_functions/no_alpha/var/arg_2
 core_functions/color/rgb/one_arg/special_functions/no_alpha/var/arg_3
-core_functions/color/rgba/error/four_args/alpha/unit
 core_functions/color/rgba/error/four_args/blue/type
 core_functions/color/rgba/error/four_args/green/type
 core_functions/color/rgba/error/four_args/red/type
@@ -190,7 +185,6 @@ core_functions/color/rgba/error/three_args/blue/type
 core_functions/color/rgba/error/three_args/green/type
 core_functions/color/rgba/error/three_args/red/type
 core_functions/color/rgba/error/two_args/alpha/type
-core_functions/color/rgba/error/two_args/alpha/unit
 core_functions/color/rgba/error/two_args/color/type
 core_functions/color/rgba/four_args/special_functions/var/arg_2/args/both
 core_functions/color/rgba/four_args/special_functions/var/arg_2/args/color

--- a/tests/specs/sass-spec-exclude.txt
+++ b/tests/specs/sass-spec-exclude.txt
@@ -309,7 +309,6 @@ core_functions/math/percentage/error/unit
 core_functions/math/round/error/type
 core_functions/math/round/up/within_precision
 core_functions/math/unit/error/type
-core_functions/math/unit/multiple_denominators
 core_functions/math/unitless/error/type
 core_functions/math/unitless/numerator_and_denominator
 core_functions/meta/call/error/invalid_args

--- a/tests/specs/sass-spec-exclude.txt
+++ b/tests/specs/sass-spec-exclude.txt
@@ -299,18 +299,11 @@ core_functions/map/keys/empty
 core_functions/map/keys/single
 core_functions/map/values/empty
 core_functions/map/values/single
-core_functions/math/abs/error/type
-core_functions/math/ceil/error/type
-core_functions/math/floor/error/type
 core_functions/math/max/error/too_few_args
 core_functions/math/min/error/too_few_args
-core_functions/math/percentage/error/type
-core_functions/math/percentage/error/unit
-core_functions/math/round/error/type
 core_functions/math/round/up/within_precision
 core_functions/math/unit/error/type
 core_functions/math/unitless/error/type
-core_functions/math/unitless/numerator_and_denominator
 core_functions/meta/call/error/invalid_args
 core_functions/meta/content_exists/error/in_content
 core_functions/meta/content_exists/error/in_function_called_by_mixin
@@ -795,7 +788,6 @@ libsass-closed-issues/issue_1550/mixin_embedded
 libsass-closed-issues/issue_1550/while_embedded
 libsass-closed-issues/issue_1567
 libsass-closed-issues/issue_1569
-libsass-closed-issues/issue_1577
 libsass-closed-issues/issue_1583
 libsass-closed-issues/issue_1585
 libsass-closed-issues/issue_1590/ampersand-against-literal
@@ -953,7 +945,6 @@ libsass/basic/44_not_number_expression
 libsass/bourbon
 libsass/color-functions/other/change-color/h
 libsass/color-functions/saturate
-libsass/conversions
 libsass/debug-directive-nested/inline
 libsass/debug-directive-nested/mixin
 libsass/delayed
@@ -977,7 +968,6 @@ libsass/propsets
 libsass/selectors/simple
 libsass/test
 libsass/units/feature-test
-libsass/units/simple
 libsass/variable-scoping/blead-global/expanding/each
 libsass/variable-scoping/blead-global/expanding/else
 libsass/variable-scoping/blead-global/expanding/elseif
@@ -1021,7 +1011,6 @@ non_conformant/errors/import/file/simple
 non_conformant/errors/import/miss/simple
 non_conformant/errors/import/url/simple
 non_conformant/errors/invalid-operation/plus
-non_conformant/errors/invalid-operation/sub
 non_conformant/errors/invalid-operation/times
 non_conformant/errors/invalid-parent/function-in-each
 non_conformant/errors/invalid-parent/function-in-for
@@ -1268,4 +1257,3 @@ values/identifiers/escape/script
 values/maps/duplicate-keys
 values/maps/errors
 values/maps/invalid-key
-values/numbers/units/multiple


### PR DESCRIPTION
As part of this effort, I improved the handling of weird cases in color functions (now reporting a spec-compliant error when using units in there which are not `%`) as I had to rework usages of `$number->units()` outside the Number class, to allow making it private.

Then comes the big refactoring, where I rework all the handling of units for numbers (and so all the math) to be spec-compliant. The new code in `Number` is more or less a port of the dart-sass code of https://github.com/sass/dart-sass/blob/master/lib/src/value/number.dart (I don't implement all the "fuzzy" comparisons yet, but that might come if necessary)