### PR TITLE
Deprecate registering additional features

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -5041,9 +5041,13 @@ class Compiler
      * @api
      *
      * @param string $name
+     *
+     * @deprecated Registering additional features is deprecated.
      */
     public function addFeature($name)
     {
+        @trigger_error('Registering additional features is deprecated.', E_USER_DEPRECATED);
+
         $this->registeredFeatures[$name] = true;
     }
 


### PR DESCRIPTION
`feature-exists` is meant to provide metadata about features which are supported by the Sass implementation. It does not make sense to let users customize that as they cannot actually implement the features at the same time.
Such list is not customizable either in official Sass implementations