### PR TITLE
Clean the composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,9 +31,9 @@
         "ext-ctype": "*"
     },
     "require-dev": {
+        "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5 || ^8.3 || ^9.4",
         "sass/sass-spec": "2020.08.10",
         "squizlabs/php_codesniffer": "~3.5",
-        "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5 || ^8.3 || ^9.4",
         "twbs/bootstrap": "~4.3",
         "zurb/foundation": "~6.5"
     },
@@ -58,6 +58,9 @@
         }
     ],
     "bin": ["bin/pscss"],
+    "config": {
+        "sort-packages": true
+    },
     "archive": {
         "exclude": [
             "/Makefile",

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,6 @@
             }
         }
     ],
-    "minimum-stability": "dev",
     "bin": ["bin/pscss"],
     "archive": {
         "exclude": [

--- a/composer.json
+++ b/composer.json
@@ -60,15 +60,5 @@
     "bin": ["bin/pscss"],
     "config": {
         "sort-packages": true
-    },
-    "archive": {
-        "exclude": [
-            "/Makefile",
-            "/.gitattributes",
-            "/.gitignore",
-            "/.travis.yml",
-            "/phpunit.xml.dist",
-            "/tests"
-        ]
     }
 }


### PR DESCRIPTION
- don't override the minimum stable but use Composer's default one (`stable`)
- sort packages in requirements (this helps when using `composer require` to add new ones)
- remove the outdated `composer archive` config in favor of `.gitattributes` (which Composer will use as fallback) to avoid maintaining the list twice (thus, this config is relevant only when adding the package in a Satis repo, as packagist.org does not build archives but relies on the GitHub ones)