### PR TITLE
Fix the implementation of modulo

### DIFF
--- a/src/Node/Number.php
+++ b/src/Node/Number.php
@@ -370,7 +370,17 @@ class Number extends Node implements \ArrayAccess
                 return NAN;
             }
 
-            return $num1 % $num2;
+            $result = fmod($num1, $num2);
+
+            if ($result == 0) {
+                return 0;
+            }
+
+            if ($num2 < 0 xor $num1 < 0) {
+                $result += $num2;
+            }
+
+            return $result;
         });
     }
 

--- a/tests/specs/sass-spec-exclude.txt
+++ b/tests/specs/sass-spec-exclude.txt
@@ -845,8 +845,6 @@ libsass-closed-issues/issue_2175
 libsass-closed-issues/issue_2179
 libsass-closed-issues/issue_2185
 libsass-closed-issues/issue_2233
-libsass-closed-issues/issue_2236/floats
-libsass-closed-issues/issue_2236/ints
 libsass-closed-issues/issue_2260/no-parent-with-compound
 libsass-closed-issues/issue_2260/outer-parent-with-compound
 libsass-closed-issues/issue_2261


### PR DESCRIPTION
The Sass modulo works for floats and the returned value must have the same sign than the right operand (i.e. the Ruby behavior for modulo).

In PHP, `%` is the integer modulo. `fmod` must be used for float modulo.
And the PHP behavior is to is to use the sign of the left operand rather than of the right one.