### PR TITLE
Deprecate all formatters except Expanded and Compressed

### DIFF
--- a/bin/pscss
+++ b/bin/pscss
@@ -20,6 +20,7 @@ if (version_compare(PHP_VERSION, '5.6') < 0) {
 include __DIR__ . '/../scss.inc.php';
 
 use ScssPhp\ScssPhp\Compiler;
+use ScssPhp\ScssPhp\OutputStyle;
 use ScssPhp\ScssPhp\Parser;
 use ScssPhp\ScssPhp\Version;
 
@@ -76,7 +77,7 @@ Options include:
     --load-path=PATH    Set import path [-I]
     --precision=N       [deprecated] Ignored. (default 10) [-p]
     --sourcemap         Create source map file
-    --style=FORMAT      Set the output format (compact, compressed, crunched, expanded, or nested) [-s, -t]
+    --style=FORMAT      Set the output style (compressed or expanded) [-s, -t]
     --version           Print the version [-v]
 
 EOT;
@@ -182,7 +183,12 @@ if ($loadPaths) {
 }
 
 if ($style) {
-    $scss->setFormatter('ScssPhp\\ScssPhp\\Formatter\\' . ucfirst($style));
+    if ($style === OutputStyle::COMPRESSED || $style === OutputStyle::EXPANDED) {
+        $scss->setOutputStyle($style);
+    } else {
+        fwrite(STDERR, "WARNING: the $style style is deprecated.\n");
+        $scss->setFormatter('ScssPhp\\ScssPhp\\Formatter\\' . ucfirst($style));
+    }
 }
 
 if ($sourceMap) {

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -120,8 +120,8 @@ default formatter.
 
 Five formatters are included:
 
-* `ScssPhp\ScssPhp\Formatter\Expanded`
-* `ScssPhp\ScssPhp\Formatter\Nested` *(default)*
+* `ScssPhp\ScssPhp\Formatter\Expanded` *(default)*
+* `ScssPhp\ScssPhp\Formatter\Nested`
 * `ScssPhp\ScssPhp\Formatter\Compressed`
 * `ScssPhp\ScssPhp\Formatter\Compact`
 * `ScssPhp\ScssPhp\Formatter\Crunched`

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -115,22 +115,9 @@ method, and unset a variable using the `unsetVariable($name)` method.
 
 ### Output Formatting
 
-It's possible to customize the formatting of the output CSS by changing the
-default formatter.
-
-Five formatters are included:
-
-* `ScssPhp\ScssPhp\Formatter\Expanded` *(default)*
-* `ScssPhp\ScssPhp\Formatter\Nested`
-* `ScssPhp\ScssPhp\Formatter\Compressed`
-* `ScssPhp\ScssPhp\Formatter\Compact`
-* `ScssPhp\ScssPhp\Formatter\Crunched`
-
-We can change the formatting using the `setFormatter` method.
-
-* `setFormatter($formatterName)` sets the current formatter to `$formatterName`,
-  the name of a class as a string that implements the formatting interface. See
-  the source for `ScssPhp\ScssPhp\Formatter\Expanded` for an example.
+The output formatting can be configured using the `setOutputStyle` method.
+2 styles are provided: `\ScssPhp\ScssPhp\OutputStyle::EXPANDED` and
+`\ScssPhp\ScssPhp\OutputStyle::COMPRESSED`.
 
 Given the following SCSS:
 
@@ -153,9 +140,9 @@ Given the following SCSS:
 }
 {% endhighlight %}
 
-The formatters output the following:
+The output will look like that:
 
-`ScssPhp\ScssPhp\Formatter\Expanded`:
+`OutputStyle::EXPANDED`:
 
 {% highlight css %}
 /*! Comment */
@@ -171,41 +158,10 @@ The formatters output the following:
 }
 {% endhighlight %}
 
-`ScssPhp\ScssPhp\Formatter\Nested`:
-
-{% highlight css %}
-/*! Comment */
-.navigation ul {
-  line-height: 20px;
-  color: blue; }
-    .navigation ul a {
-      color: red; }
-
-.footer .copyright {
-  color: silver; }
-{% endhighlight %}
-
-`ScssPhp\ScssPhp\Formatter\Compact`:
-
-{% highlight css %}
-/*! Comment */
-.navigation ul { line-height:20px; color:blue; }
-
-.navigation ul a { color:red; }
-
-.footer .copyright { color:silver; }
-{% endhighlight %}
-
-`ScssPhp\ScssPhp\Formatter\Compressed`:
+`OutputStyle::COMPRESSED`:
 
 {% highlight css %}
 /* Comment*/.navigation ul{line-height:20px;color:blue;}.navigation ul a{color:red;}.footer .copyright{color:silver;}
-{% endhighlight %}
-
-`ScssPhp\ScssPhp\Formatter\Crunched`:
-
-{% highlight css %}
-.navigation ul{line-height:20px;color:blue;}.navigation ul a{color:red;}.footer .copyright{color:silver;}
 {% endhighlight %}
 
 ### Source Maps

--- a/docs/docs/server.md
+++ b/docs/docs/server.md
@@ -64,10 +64,11 @@ Here's an example of creating a SCSS server that outputs compressed CSS:
 
 {% highlight php startinline=true %}
 use ScssPhp\ScssPhp\Compiler;
+use ScssPhp\ScssPhp\OutputStyle;
 use ScssPhp\Server\Server;
 
 $scss = new Compiler();
-$scss->setFormatter('ScssPhp\ScssPhp\Formatter\Compressed');
+$scss->setOutputStyle(OutputStyle::COMPRESSED);
 
 $server = new Server('stylesheets', null, $scss);
 $server->serve();

--- a/scss.inc.php
+++ b/scss.inc.php
@@ -6,6 +6,7 @@ if (version_compare(PHP_VERSION, '5.6') < 0) {
 
 if (! class_exists('ScssPhp\ScssPhp\Version', false)) {
     include_once __DIR__ . '/src/Base/Range.php';
+    include_once __DIR__ . '/src/OutputStyle.php';
     include_once __DIR__ . '/src/Block.php';
     include_once __DIR__ . '/src/Cache.php';
     include_once __DIR__ . '/src/Colors.php';

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -5087,6 +5087,31 @@ class Compiler
     }
 
     /**
+     * Sets the output style.
+     *
+     * @api
+     *
+     * @param string $style One of the OutputStyle constants
+     *
+     * @phpstan-param OutputStyle::* $style
+     */
+    public function setOutputStyle($style)
+    {
+        switch ($style) {
+            case OutputStyle::EXPANDED:
+                $this->formatter = Expanded::class;
+                break;
+
+            case OutputStyle::COMPRESSED:
+                $this->formatter = Compressed::class;
+                break;
+
+            default:
+                throw new \InvalidArgumentException(sprintf('Invalid output style "%s".', $style));
+        }
+    }
+
+    /**
      * Set formatter
      *
      * @api
@@ -5094,12 +5119,15 @@ class Compiler
      * @param string $formatterName
      *
      * @return void
+     *
+     * @deprecated Use {@see setOutputStyle} instead.
      */
     public function setFormatter($formatterName)
     {
         if (!\in_array($formatterName, [Expanded::class, Compressed::class], true)) {
             @trigger_error('Formatters other than Expanded and Compressed are deprecated.', E_USER_DEPRECATED);
         }
+        @trigger_error('The method "setFormatter" is deprecated. Use "setOutputStyle" instead.', E_USER_DEPRECATED);
 
         $this->formatter = $formatterName;
     }

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -16,6 +16,7 @@ use ScssPhp\ScssPhp\Base\Range;
 use ScssPhp\ScssPhp\Compiler\Environment;
 use ScssPhp\ScssPhp\Exception\CompilerException;
 use ScssPhp\ScssPhp\Exception\SassScriptException;
+use ScssPhp\ScssPhp\Formatter\Compressed;
 use ScssPhp\ScssPhp\Formatter\Expanded;
 use ScssPhp\ScssPhp\Formatter\OutputBlock;
 use ScssPhp\ScssPhp\Node\Number;
@@ -5096,6 +5097,10 @@ class Compiler
      */
     public function setFormatter($formatterName)
     {
+        if (!\in_array($formatterName, [Expanded::class, Compressed::class], true)) {
+            @trigger_error('Formatters other than Expanded and Compressed are deprecated.', E_USER_DEPRECATED);
+        }
+
         $this->formatter = $formatterName;
     }
 

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -16,6 +16,7 @@ use ScssPhp\ScssPhp\Base\Range;
 use ScssPhp\ScssPhp\Compiler\Environment;
 use ScssPhp\ScssPhp\Exception\CompilerException;
 use ScssPhp\ScssPhp\Exception\SassScriptException;
+use ScssPhp\ScssPhp\Formatter\Expanded;
 use ScssPhp\ScssPhp\Formatter\OutputBlock;
 use ScssPhp\ScssPhp\Node\Number;
 use ScssPhp\ScssPhp\SourceMap\SourceMapGenerator;
@@ -171,7 +172,7 @@ class Compiler
     /**
      * @var string|\ScssPhp\ScssPhp\Formatter
      */
-    protected $formatter = 'ScssPhp\ScssPhp\Formatter\Nested';
+    protected $formatter = Expanded::class;
 
     /**
      * @var Environment

--- a/src/Formatter/Compact.php
+++ b/src/Formatter/Compact.php
@@ -18,6 +18,8 @@ use ScssPhp\ScssPhp\Formatter;
  * Compact formatter
  *
  * @author Leaf Corcoran <leafot@gmail.com>
+ *
+ * @deprecated since 1.4.0. Use the Compressed formatter instead.
  */
 class Compact extends Formatter
 {
@@ -26,6 +28,8 @@ class Compact extends Formatter
      */
     public function __construct()
     {
+        @trigger_error('The Compact formatter is deprecated since 1.4.0. Use the Compressed formatter instead.', E_USER_DEPRECATED);
+
         $this->indentLevel = 0;
         $this->indentChar = '';
         $this->break = '';

--- a/src/Formatter/Crunched.php
+++ b/src/Formatter/Crunched.php
@@ -18,6 +18,8 @@ use ScssPhp\ScssPhp\Formatter;
  * Crunched formatter
  *
  * @author Anthon Pang <anthon.pang@gmail.com>
+ *
+ * @deprecated since 1.4.0. Use the Compressed formatter instead.
  */
 class Crunched extends Formatter
 {
@@ -26,6 +28,8 @@ class Crunched extends Formatter
      */
     public function __construct()
     {
+        @trigger_error('The Crunched formatter is deprecated since 1.4.0. Use the Compressed formatter instead.', E_USER_DEPRECATED);
+
         $this->indentLevel = 0;
         $this->indentChar = '  ';
         $this->break = '';

--- a/src/Formatter/Debug.php
+++ b/src/Formatter/Debug.php
@@ -18,6 +18,8 @@ use ScssPhp\ScssPhp\Formatter;
  * Debug formatter
  *
  * @author Anthon Pang <anthon.pang@gmail.com>
+ *
+ * @deprecated since 1.4.0.
  */
 class Debug extends Formatter
 {
@@ -26,6 +28,8 @@ class Debug extends Formatter
      */
     public function __construct()
     {
+        @trigger_error('The Debug formatter is deprecated since 1.4.0.', E_USER_DEPRECATED);
+
         $this->indentLevel = 0;
         $this->indentChar = '';
         $this->break = "\n";

--- a/src/Formatter/Nested.php
+++ b/src/Formatter/Nested.php
@@ -19,6 +19,8 @@ use ScssPhp\ScssPhp\Type;
  * Nested formatter
  *
  * @author Leaf Corcoran <leafot@gmail.com>
+ *
+ * @deprecated since 1.4.0. Use the Expanded formatter instead.
  */
 class Nested extends Formatter
 {
@@ -32,6 +34,8 @@ class Nested extends Formatter
      */
     public function __construct()
     {
+        @trigger_error('The Nested formatter is deprecated since 1.4.0. Use the Expanded formatter instead.', E_USER_DEPRECATED);
+
         $this->indentLevel = 0;
         $this->indentChar = '  ';
         $this->break = "\n";

--- a/src/OutputStyle.php
+++ b/src/OutputStyle.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace ScssPhp\ScssPhp;
+
+final class OutputStyle
+{
+    const EXPANDED = 'expanded';
+    const COMPRESSED = 'compressed';
+}

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -101,7 +101,7 @@ class ApiTest extends TestCase
     {
         return [
             [
-                ".magic {\n  color: red;\n  width: 760px; }",
+                ".magic {\n  color: red;\n  width: 760px;\n}",
                 '.magic { color: $color; width: $base - 200; }',
                 [
                     'color' => 'red',
@@ -109,7 +109,7 @@ class ApiTest extends TestCase
                 ],
             ],
             [
-                ".logo {\n  color: gray; }",
+                ".logo {\n  color: gray;\n}",
                 '.logo { color: desaturate($primary, 100%); }',
                 [
                     'primary' => '#ff0000',
@@ -117,14 +117,14 @@ class ApiTest extends TestCase
             ],
             // !default
             [
-                ".default {\n  color: red; }",
+                ".default {\n  color: red;\n}",
                 '$color: red !default;' . "\n" . '.default { color: $color; }',
                 [
                 ],
             ],
             // no !default
             [
-                ".default {\n  color: red; }",
+                ".default {\n  color: red;\n}",
                 '$color: red;' . "\n" . '.default { color: $color; }',
                 [
                 ],
@@ -132,7 +132,7 @@ class ApiTest extends TestCase
             ],
             // override !default
             [
-                ".default {\n  color: blue; }",
+                ".default {\n  color: blue;\n}",
                 '$color: red !default;' . "\n" . '.default { color: $color; }',
                 [
                     'color' => 'blue',

--- a/tests/InputTest.php
+++ b/tests/InputTest.php
@@ -14,6 +14,7 @@ namespace ScssPhp\ScssPhp\Tests;
 
 use PHPUnit\Framework\TestCase;
 use ScssPhp\ScssPhp\Compiler;
+use ScssPhp\ScssPhp\Formatter\Expanded;
 
 function _dump($value)
 {
@@ -46,6 +47,7 @@ class InputTest extends TestCase
         chdir(__DIR__);
 
         $this->scss = new Compiler();
+        $this->scss->setFormatter(Expanded::class);
         $this->scss->addImportPath(self::$inputDir);
 
         $fp_err_stream = fopen("php://memory", 'r+');

--- a/tests/InputTest.php
+++ b/tests/InputTest.php
@@ -47,7 +47,6 @@ class InputTest extends TestCase
         chdir(__DIR__);
 
         $this->scss = new Compiler();
-        $this->scss->setFormatter(Expanded::class);
         $this->scss->addImportPath(self::$inputDir);
 
         $fp_err_stream = fopen("php://memory", 'r+');

--- a/tests/outputs/at_root.css
+++ b/tests/outputs/at_root.css
@@ -1,114 +1,145 @@
 .parent-inline-selector {
-  color: white; }
-  .child {
-    color: black; }
-
+  color: white;
+}
+.child {
+  color: black;
+}
 .parent-block {
-  color: white; }
-  .child1 {
-    color: green; }
-  .child2 {
-    color: blue; }
-  .parent-block .step-child {
-    color: black; }
-
+  color: white;
+}
+.child1 {
+  color: green;
+}
+.child2 {
+  color: blue;
+}
+.parent-block .step-child {
+  color: black;
+}
 .first {
-  color: red; }
-
+  color: red;
+}
 body .second {
   color: white;
-  color: black; }
-  .nested1 {
-    color: blue;
-    color: orange; }
-    .nested2 {
-      color: yellow; }
-
+  color: black;
+}
+.nested1 {
+  color: blue;
+  color: orange;
+}
+.nested2 {
+  color: yellow;
+}
 .third {
-  color: green; }
-
+  color: green;
+}
 @media print {
   .page {
-    width: 8in; } }
+    width: 8in;
+  }
+}
 .page {
-  color: red; }
-
+  color: red;
+}
 @media (min-width: 300px) {
   .my-widget .inside-mq {
-    inside-style: mq; } }
+    inside-style: mq;
+  }
+}
 .my-widget .outside-mq {
-  outside-style: mq; }
-    .outside-class {
-      color: blue; }
+  outside-style: mq;
+}
+.outside-class {
+  color: blue;
+}
 @media (min-width: 300px) {
   .with-only {
-    color: pink; } }
-
+    color: pink;
+  }
+}
 @media screen and (max-width: 320px) {
   .foo {
-    margin: 0; } }
-
+    margin: 0;
+  }
+}
 @media screen and (max-width: 320px) {
   .bar {
-    padding: 0; } }
+    padding: 0;
+  }
+}
 .baar {
-  padding: 0; }
+  padding: 0;
+}
 .foo .barr {
-  padding: 0; }
-
+  padding: 0;
+}
 .foo .bar {
-  width: 0; }
+  width: 0;
+}
 @supports (display: flex) {
   .baz {
-    height: 0; } }
+    height: 0;
+  }
+}
 @media screen and (max-width: 640px) {
   .qux {
-    margin: 0; } }
-
+    margin: 0;
+  }
+}
 @media screen and (max-width: 640px) {
   .foo .quux {
-    padding: 0; } }
+    padding: 0;
+  }
+}
 .foo .quix {
-  padding: 0; }
-
+  padding: 0;
+}
 .test .test2 {
-  padding: 0px; }
-  tbody {
-    padding: 10px; }
-
+  padding: 0px;
+}
+tbody {
+  padding: 10px;
+}
 a.badge {
-  text-decoration: none; }
-
+  text-decoration: none;
+}
 .badge-primary {
-  background-color: blue; }
-  a.badge-primary:focus, a.badge-primary.focus {
-    outline: 0; }
-
+  background-color: blue;
+}
+a.badge-primary:focus, a.badge-primary.focus {
+  outline: 0;
+}
 .badge-secondary {
-  background-color: yellow; }
-  a.badge-secondary:focus, a.badge-secondary.focus {
-    outline: 0; }
-
+  background-color: yellow;
+}
+a.badge-secondary:focus, a.badge-secondary.focus {
+  outline: 0;
+}
 .table-hover tbody tr:hover, .table2#id tbody tr:hover {
   color: #ddd;
-  background-color: #eee; }
-  .table-hover tbody tr.foo, .table2#id tbody tr.foo {
-    color: red; }
-
+  background-color: #eee;
+}
+.table-hover tbody tr.foo, .table2#id tbody tr.foo {
+  color: red;
+}
 .badge {
-  display: inline-block; }
+  display: inline-block;
+}
 @media (prefers-reduced-motion: reduce) {
   .badge {
-    transition: none; } }
-  a.badge:hover, a.badge:focus {
-    text-decoration: none; }
-
+    transition: none;
+  }
+}
+a.badge:hover, a.badge:focus {
+  text-decoration: none;
+}
 .btn:hover, .btn:focus {
-  text-decoration: none; }
-
+  text-decoration: none;
+}
 .other {
   content: "bar";
-  content: "foo"; }
-
+  content: "foo";
+}
 .class .test {
-  color: red; }
+  color: red;
+}

--- a/tests/outputs/builtins.css
+++ b/tests/outputs/builtins.css
@@ -9,15 +9,15 @@
   mix: #020304;
   rgba: rgba(170, 119, 204, 0.4);
   rgba: rgba(170, 119, 204, 0.4);
-  green: 139; }
-
+  green: 139;
+}
 #hsl {
   color: #79c653;
   color: rgba(121, 198, 83, 0.5);
   hue: 100deg;
   sat: 50%;
-  lig: 55%; }
-
+  lig: 55%;
+}
 #more-color {
   light: #7e3d9e;
   dark: #432154;
@@ -25,16 +25,16 @@
   desat: #5e3871;
   gray: #545454;
   comp: #48792f;
-  inv: #9fd086; }
-
+  inv: #9fd086;
+}
 #more-more-color {
   op: 0.5;
   opacify: rgba(1, 2, 3, 0.6);
   opacify: rgba(1, 2, 3, 0.6);
   transparentize: rgba(1, 2, 3, 0.4);
   transparentize: rgba(1, 2, 3, 0.4);
-  transparentize: rgba(52, 130, 3, 0.9); }
-
+  transparentize: rgba(52, 130, 3, 0.9);
+}
 #more-more-more-color {
   color: rgba(65, 110, 79, 0.4);
   color: rgba(20, 255, 216, 0);
@@ -45,8 +45,8 @@
   color: rgba(145, 145, 145, 0);
   color: rgba(5, 5, 5, 0);
   color: #000A0A0A;
-  color: #FFAABBCC; }
-
+  color: #FFAABBCC;
+}
 #string {
   color: hello what is going on;
   color: "yeah";
@@ -73,8 +73,8 @@
   color: s;
   color: st;
   color: string;
-  color: strin; }
-
+  color: strin;
+}
 #number {
   color: 250%;
   color: 50%;
@@ -85,8 +85,8 @@
   top: 1ex;
   width: 200%;
   bottom: 10px;
-  padding: 3em 1in 1in 1in; }
-
+  padding: 3em 1in 1in 1in;
+}
 #list {
   len: 3;
   len: 1;
@@ -106,8 +106,8 @@
   cool: one two three great job;
   cool: great job one two three;
   zip: 1px solid, 2px dashed;
-  zip: 1px solid red, 2px dashed green; }
-
+  zip: 1px solid red, 2px dashed green;
+}
 #introspection {
   t: number;
   t: string;
@@ -126,60 +126,61 @@
   c: true;
   c: true;
   c: false;
-  c: true; }
-
+  c: true;
+}
 #if {
   color: yes;
   color: no;
   color: yes;
-  color: yes; }
-
+  color: yes;
+}
 .transparent {
   r: 0;
   g: 0;
   b: 0;
-  a: 0; }
-
+  a: 0;
+}
 .alpha {
   a: 1;
   a: 1;
   a: 1;
   a: 0.5;
-  a: alpha(currentColor); }
-
+  a: alpha(currentColor);
+}
 #exists {
   a: true;
   b: true;
-  c: false; }
-
+  c: false;
+}
 div.call-tests {
   a: #0a64ff;
   b: #0058ef;
-  c: b; }
-
+  c: b;
+}
 div.unquote-test {
-  a: [type='text']; }
-
+  a: [type='text'];
+}
 .does-compile-1 {
-  color: #666; }
-
+  color: #666;
+}
 .does-compile-2 {
-  color: #666; }
-
+  color: #666;
+}
 .does-compile-3 {
-  color: #666; }
-
+  color: #666;
+}
 .does-compile-4 {
-  color: #666; }
-
+  color: #666;
+}
 .join-list-with-or-without-interpolation {
   transition: value1 value2, value3 value4;
   transition: value1 value2, value3 value4;
   transition: value1, value2, value3 value4;
   transition: value1 value2, value3, value4;
   transition: value1, value2, value3, value4;
-  transition: value1, value2, value3, value4; }
-
+  transition: value1, value2, value3, value4;
+}
 .list-zip-types {
   zip: 2px solid;
-  zip: 3px "bold" blue; }
+  zip: 3px "bold" blue;
+}

--- a/tests/outputs/comments.css
+++ b/tests/outputs/comments.css
@@ -15,11 +15,11 @@ div {
   string: 'hello /* this is not a comment */';
   world: '// neither is this';
   what-ever: 100px;
-  background: url(); }
-
+  background: url();
+}
 .dummy {
-  color: blue; }
-
+  color: blue;
+}
 /* comment 1 */
 a {
   /* comment 2 */
@@ -28,8 +28,8 @@ a {
   /* comment 4 */
   background-color: red;
   /* comment 5 */
-  /* comment 6 */ }
-
+  /* comment 6 */
+}
 /* comment 7 */
 /* коммент */
 /* This is a comment with vars references:
@@ -42,12 +42,13 @@ radius:2px
   /* @noflip */
   display: block;
   /* hop */
-  width: 100%; }
-
+  width: 100%;
+}
 .class {
   /* This is a comment with vars references not on root level
   color:red
   and a fake #{ doing nothing
   radius:2px
      and also a #{$fake} interpolation that should not throw an error
-  */ }
+  */
+}

--- a/tests/outputs/compass_extract.css
+++ b/tests/outputs/compass_extract.css
@@ -6,23 +6,24 @@
   size: 1;
   size: 1;
   size: 2;
-  size: 2; }
-
+  size: 2;
+}
 #test-1 {
   margin-top: 7.5em;
   padding-top: 9em;
   padding-bottom: 10.5em;
-  margin-bottom: 0em; }
-
+  margin-bottom: 0em;
+}
 #test-2 {
   border-style: solid;
   border-width: 0.0625em;
-  padding: 1.4375em; }
-
+  padding: 1.4375em;
+}
 #test-3 {
   border-top-style: solid;
   border-top-width: 0.0625em;
   padding-top: 1.4375em;
   border-bottom-style: solid;
   border-bottom-width: 0.0625em;
-  padding-bottom: 1.4375em; }
+  padding-bottom: 1.4375em;
+}

--- a/tests/outputs/content.css
+++ b/tests/outputs/content.css
@@ -1,55 +1,68 @@
 * html #logo {
-  background-image: url(/logo.gif); }
-
+  background-image: url(/logo.gif);
+}
 .colors {
   background-color: blue;
   color: white;
-  border-color: blue; }
-
+  border-color: blue;
+}
 @media only screen and (max-width: 480px) {
   body {
-    color: red; } }
-
+    color: red;
+  }
+}
 #sidebar {
-  width: 300px; }
+  width: 300px;
+}
 @media only screen and (max-width: 480px) {
   #sidebar {
-    width: 100px; } }
-
+    width: 100px;
+  }
+}
 @media only screen and (min-width: 40em) {
   .grid-1 {
-    width: 100%; }
+    width: 100%;
+  }
   .grid-2 {
-    width: 100%; } }
-
+    width: 100%;
+  }
+}
 @media only screen and (min-width: 40em) {
   .grid-1 {
-    width: 100%; }
+    width: 100%;
+  }
   .grid-2 {
-    width: 100%; } }
-
+    width: 100%;
+  }
+}
 * html * body #logo {
-  background-image: url(/logo.gif); }
-
+  background-image: url(/logo.gif);
+}
 A {
-  top: 10px; }
-
+  top: 10px;
+}
 .test {
-  display: none; }
-
+  display: none;
+}
 .test_empty_content {
   display: inline;
-  font-weight: bold; }
-
+  font-weight: bold;
+}
 .grid > .small-1 {
-  width: 33.3333333333%; }
+  width: 33.3333333333%;
+}
 .grid > .small-2 {
-  width: 66.6666666667%; }
+  width: 66.6666666667%;
+}
 .grid > .small-3 {
-  width: 100%; }
+  width: 100%;
+}
 .grid > .medium-1 {
-  width: 33.3333333333%; }
+  width: 33.3333333333%;
+}
 .grid > .medium-2 {
-  width: 66.6666666667%; }
+  width: 66.6666666667%;
+}
 .grid > .medium-3 {
-  width: 100%; }
+  width: 100%;
+}

--- a/tests/outputs/content_with_function.css
+++ b/tests/outputs/content_with_function.css
@@ -1,2 +1,3 @@
 body {
-  padding: 1 px; }
+  padding: 1 px;
+}

--- a/tests/outputs/custom_properties.css
+++ b/tests/outputs/custom_properties.css
@@ -1,2 +1,3 @@
 a {
-  font: var(--theme-font, sans-serif); }
+  font: var(--theme-font, sans-serif);
+}

--- a/tests/outputs/default_args.css
+++ b/tests/outputs/default_args.css
@@ -1,3 +1,4 @@
 div {
   height: red;
-  margin: 100px; }
+  margin: 100px;
+}

--- a/tests/outputs/directives.css
+++ b/tests/outputs/directives.css
@@ -1,103 +1,144 @@
 @charset "hello-world";
 @page :left {
   div {
-    color: red; } }
+    color: red;
+  }
+}
 @page test {
   @media yes {
     div {
-      color: red; } } }
+      color: red;
+    }
+  }
+}
 @media something {
   @page {
     @media else {
       div {
-        height: 200px; } } } }
-
+        height: 200px;
+      }
+    }
+  }
+}
 div {
-  color: red; }
+  color: red;
+}
 @page yeah {
   div pre {
-    height: 20px; } }
+    height: 20px;
+  }
+}
 @font-face {
   color: red;
-  height: 20px; }
+  height: 20px;
+}
 @keyframes 'bounce' {
   from {
     top: 100px;
-    animation-timing-function: ease-out; }
+    animation-timing-function: ease-out;
+  }
   25% {
     top: 50px;
-    animation-timing-function: ease-in; }
+    animation-timing-function: ease-in;
+  }
   50% {
     top: 100px;
-    animation-timing-function: ease-out; }
+    animation-timing-function: ease-out;
+  }
   75% {
     top: 75px;
-    animation-timing-function: ease-in; }
+    animation-timing-function: ease-in;
+  }
   to {
-    top: 100px; } }
+    top: 100px;
+  }
+}
 @-webkit-keyframes flowouttoleft {
   0% {
-    -webkit-transform: translateX(0) scale(1); }
+    -webkit-transform: translateX(0) scale(1);
+  }
   60%, 70% {
-    -webkit-transform: translateX(0) scale(0.7); }
+    -webkit-transform: translateX(0) scale(0.7);
+  }
   100% {
-    -webkit-transform: translateX(-100%) scale(0.7); } }
-
+    -webkit-transform: translateX(-100%) scale(0.7);
+  }
+}
 div {
   animation-name: 'diagonal-slide';
   animation-duration: 5s;
-  animation-iteration-count: 10; }
-
+  animation-iteration-count: 10;
+}
 @keyframes 'diagonal-slide' {
   from {
     left: 0;
-    top: 0; }
+    top: 0;
+  }
   to {
     left: 100px;
-    top: 100px; } }
+    top: 100px;
+  }
+}
 @document url(http://www.w3.org/),
           url-prefix(http://www.w3.org/Style/),
           domain(mozilla.org),
           regexp("https:.*") {
   body {
     color: purple;
-    background: yellow; } }
+    background: yellow;
+  }
+}
 @keyframes anim-rotate {
   0% {
-    transform: rotate(0); }
+    transform: rotate(0);
+  }
   100% {
-    transform: rotate(360deg); } }
-
+    transform: rotate(360deg);
+  }
+}
 .bold, .icon-ajax {
-  font-weight: 700; }
-
+  font-weight: 700;
+}
 .custom-selector {
-  color: blue; }
-
+  color: blue;
+}
 @-webkit-keyframes zoomer {
   from {
-    transform: scale(0.5); }
+    transform: scale(0.5);
+  }
   to {
-    transform: scale(1); } }
+    transform: scale(1);
+  }
+}
 @keyframes zoomer {
   from {
-    transform: scale(0.5); }
+    transform: scale(0.5);
+  }
   to {
-    transform: scale(1); } }
-
+    transform: scale(1);
+  }
+}
 @supports (position: sticky) {
   .sticky-top .top2 {
-    position: sticky; } }
-
+    position: sticky;
+  }
+}
 @supports (position: sticky) {
   .sticky-top {
     position: sticky;
-    top: 0; } }
+    top: 0;
+  }
+}
 @supports (position: sticky) {
   .sticky-top2 {
-    position: sticky; } }
+    position: sticky;
+  }
+}
 @media print {
   .table-bordered th, .table-bordered td {
-    border: 1px solid #ddd !important; } }
+    border: 1px solid #ddd !important;
+  }
+}
 @font-face {
-  font-family: "Glyphicons Halflings"; }
+  font-family: "Glyphicons Halflings";
+}

--- a/tests/outputs/extending_compound_selector.css
+++ b/tests/outputs/extending_compound_selector.css
@@ -1,10 +1,12 @@
 .foo:after, .bar:after, .bar:before, .baz.bar:before {
-  color: red; }
+  color: red;
+}
 .foo:hover:after, .bar:hover:after, .bar:before:hover, .baz.bar:before:hover {
-  color: blue; }
-
+  color: blue;
+}
 a, a:link, a:visited, a:active, a:hover {
-  color: #fff; }
-
+  color: #fff;
+}
 .nest a.some-class, .nest a.some-class:link, .nest a.some-class:visited, .nest a.some-class:active, .nest a.some-class:hover {
-  color: #ccc; }
+  color: #ccc;
+}

--- a/tests/outputs/extends.css
+++ b/tests/outputs/extends.css
@@ -1,189 +1,201 @@
 error, pre seriousError, span seriousError, other, hello {
   border: 1px #f00;
-  background-color: #fdd; }
-
+  background-color: #fdd;
+}
 pre seriousError, span seriousError {
-  font-size: 20px; }
-
+  font-size: 20px;
+}
 hello {
-  color: green; }
-  hello div {
-    margin: 10px; }
-
+  color: green;
+}
+hello div {
+  margin: 10px;
+}
 .cool, .me {
-  color: red; }
-
+  color: red;
+}
 .blue, .me {
-  color: purple; }
-
+  color: purple;
+}
 a:hover, .hoverlink, #demo .overview .fakelink:hover {
-  text-decoration: underline; }
-
+  text-decoration: underline;
+}
 div.hello.world.hmm, pre div.world.hmm.okay.span, pre #butt .umm div.world.hmm.span.sure, #butt .umm pre div.world.hmm.span.sure, code div.world.hmm.okay.span, code #butt .umm div.world.hmm.span.sure, #butt .umm code div.world.hmm.span.sure {
-  color: blue; }
-
+  color: blue;
+}
 .xxxxx .xxxxx .xxxxx, code .xxxxx .xxxxx, .xxxxx code .xxxxx, .xxxxx .xxxxx code, code code .xxxxx, code .xxxxx code, code code code, .xxxxx code code {
-  color: green; }
-
+  color: green;
+}
 code {
-  color: red; }
-
+  color: red;
+}
 .alpha, .beta, .gama {
-  color: red; }
-
+  color: red;
+}
 .beta, .gama {
-  color: white; }
-
+  color: white;
+}
 .gama {
-  color: blue; }
-
+  color: blue;
+}
 #admin .tabbar a, #admin .tabbar #demo .overview .fakelink, #demo .overview #admin .tabbar .fakelink {
-  font-weight: bold; }
-
+  font-weight: bold;
+}
 a1 b1 c1 d1, x1 y1 z1 w1 b1 c1 d1 {
-  color: red; }
-
+  color: red;
+}
 a2 b2 c2 d2, a2 x2 y2 z2 w2 c2 d2, x2 y2 z2 a2 w2 c2 d2 {
-  color: red; }
-
+  color: red;
+}
 a3 b3 c3 d3, a3 b3 x3 y3 z3 w3 d3, x3 y3 z3 a3 b3 w3 d3 {
-  color: red; }
-
+  color: red;
+}
 a4 b4 c4 d4, a4 b4 c4 x4 y4 z4 w4, x4 y4 z4 a4 b4 c4 w4 {
-  color: red; }
-
+  color: red;
+}
 #butt .yeah .okay, #butt .yeah .umm .sure, #butt .umm .yeah .sure {
-  font-weight: bold; }
-
+  font-weight: bold;
+}
 a9 b9 s9 t9 v9, a9 b9 s9 t9 x9 y9 z9, a9 b9 x9 y9 s9 t9 z9 {
-  color: red; }
-
+  color: red;
+}
 @media print {
   horse, man {
-    color: blue; } }
-
+    color: blue;
+  }
+}
 man {
-  color: red; }
-
+  color: red;
+}
 wassup {
-  color: blue; }
-
+  color: blue;
+}
 .foo .wassup {
-  color: blue; }
-
+  color: blue;
+}
 #something, .x, .y {
-  color: red; }
-
+  color: red;
+}
 .nav-justified, .nav-tabs.nav-justified {
-  text-align: justify; }
-
+  text-align: justify;
+}
 .btn:hover, .edit .actions button:hover, .edit .new .actions button:hover, .btn:active, .edit .actions button:active, .edit .new .actions button:active, .btn.active, .edit .actions button.active, .edit .new .actions button.active, .btn.disabled, .edit .actions button.disabled, .edit .new .actions button.disabled, .btn[disabled], .edit .actions button[disabled], .edit .new .actions button[disabled] {
-  color: red; }
-
+  color: red;
+}
 .edit .actions button {
-  float: right; }
-
+  float: right;
+}
 .edit .new .actions {
-  padding: 0; }
-
+  padding: 0;
+}
 .z, .parent .self.z {
-  color: red; }
-
+  color: red;
+}
 #content .social-login {
   display: block;
   float: right;
   margin-right: 15px;
-  width: 250px; }
-  #content .social-login .facebook, #content .social-login .twitter {
-    display: block;
-    width: 255px;
-    height: 42px;
-    background: transparent url('images/login-btns.png') no-repeat;
-    background-position: 0 0; }
-    #content .social-login .facebook:hover, #content .social-login .twitter:hover {
-      background-position: 0 -43px; }
-    #content .social-login .facebook:focus, #content .social-login .twitter:focus, #content .social-login .facebook:active, #content .social-login .twitter:active {
-      background-position: 0 -86px; }
-  #content .social-login .twitter {
-    background-position: 0 -129px; }
-    #content .social-login .twitter:hover {
-      background-position: 0 -172px; }
-    #content .social-login .twitter:active, #content .social-login .twitter:focus {
-      background-position: 0 -215px; }
-
+  width: 250px;
+}
+#content .social-login .facebook, #content .social-login .twitter {
+  display: block;
+  width: 255px;
+  height: 42px;
+  background: transparent url('images/login-btns.png') no-repeat;
+  background-position: 0 0;
+}
+#content .social-login .facebook:hover, #content .social-login .twitter:hover {
+  background-position: 0 -43px;
+}
+#content .social-login .facebook:focus, #content .social-login .twitter:focus, #content .social-login .facebook:active, #content .social-login .twitter:active {
+  background-position: 0 -86px;
+}
+#content .social-login .twitter {
+  background-position: 0 -129px;
+}
+#content .social-login .twitter:hover {
+  background-position: 0 -172px;
+}
+#content .social-login .twitter:active, #content .social-login .twitter:focus {
+  background-position: 0 -215px;
+}
 body .to-extend, body .test {
-  color: red; }
-
+  color: red;
+}
 .navbar .navbar-brand, .navbar .navbar-brand:hover {
   font-weight: bold;
   text-shadow: none;
-  color: #fff; }
-
+  color: #fff;
+}
 .foo__bar#test, input {
-  background: red; }
-
+  background: red;
+}
 .selector1, .master-class {
-  color: blue; }
-
+  color: blue;
+}
 .selector2, .master-class {
-  background: #ccc; }
-
+  background: #ccc;
+}
 .main .block__element, .main .block__element--modifier {
-  font-size: 14px; }
-  .main .block__element--modifier {
-    font-weight: bold; }
-
+  font-size: 14px;
+}
+.main .block__element--modifier {
+  font-weight: bold;
+}
 .pagination-bullet {
   width: 6px;
   height: 6px;
-  margin-left: 5px; }
-  .pagination-bullet:first-child {
-    margin-left: 0; }
-  .is-active.pagination-bullet {
-    background-color: white; }
-
+  margin-left: 5px;
+}
+.pagination-bullet:first-child {
+  margin-left: 0;
+}
+.is-active.pagination-bullet {
+  background-color: white;
+}
 .parent-nested-foo-include .in-nested-foo .child-nested-foo-include, .parent-nested-foo-include .in-nested-foo .beard + .mustache {
-  color: green; }
-
+  color: green;
+}
 .btn-group > .btn-lg, .btn-group-lg.btn-group > .btn, .edit .actions .btn-group-lg.btn-group > button, .edit .new .actions .btn-group-lg.btn-group > button {
   padding-right: 12px;
-  padding-left: 12px; }
-
+  padding-left: 12px;
+}
 .fp-content-center form + div {
-  padding-left: 0; }
-
+  padding-left: 0;
+}
 .form-inline + .a .form-group > b, .form-inline + .a .fp-content-center form + div > b, .fp-content-center .form-inline + .a form + div > b {
-  margin-bottom: 0; }
-
+  margin-bottom: 0;
+}
 canvas, object, embed.bar {
-  color: yellow; }
-
+  color: yellow;
+}
 .popup, input, img.bar, .prepend input.foo, .prepend div.foo {
-  color: red; }
-
+  color: red;
+}
 div.popup, .prepend div.foo {
-  color: blue; }
-
+  color: blue;
+}
 .before span.popup .after {
-  color: green; }
-
+  color: green;
+}
 .class1:not(:last-child), .class2:not(.foo):not(:last-child), .class3:not(:last-child) {
-  color: red; }
-
+  color: red;
+}
 .inline-menu:hover > .sub-menu, .header-menu:hover > .sub-menu {
-  border-radius: 5px; }
-
+  border-radius: 5px;
+}
 .myclass {
-  color: red; }
-
+  color: red;
+}
 .foo3, .baz3, .bar3 {
-  a: b; }
-
+  a: b;
+}
 .bar3, .foo3, .baz3 {
-  c: d; }
-
+  c: d;
+}
 .baz3, .bar3, .foo3 {
-  e: f; }
-
+  e: f;
+}
 .parentsub:hover:before, .parent-sub:hover:before {
-  display: inline-block; }
+  display: inline-block;
+}

--- a/tests/outputs/extends_nesting.css
+++ b/tests/outputs/extends_nesting.css
@@ -1,36 +1,42 @@
 .btn, .extend .the-button {
-  padding: 1px; }
-
+  padding: 1px;
+}
 .btn-lg, .btn-group-lg > .btn, .extend .btn-group-lg > .the-button {
-  font-size: 10px; }
-
+  font-size: 10px;
+}
 .dropup .btn-lg .caret, .dropup .btn-group-lg > .btn .caret, .dropup .extend .btn-group-lg > .the-button .caret, .extend .dropup .btn-group-lg > .the-button .caret {
-  border-width: 100px; }
-
+  border-width: 100px;
+}
 .dropup .btn, .dropup .extend .the-button, .extend .dropup .the-button {
-  content: "dropup btn"; }
-  .dropup .btn .caret, .dropup .extend .the-button .caret, .extend .dropup .the-button .caret {
-    content: "dropup btn caret"; }
-
+  content: "dropup btn";
+}
+.dropup .btn .caret, .dropup .extend .the-button .caret, .extend .dropup .the-button .caret {
+  content: "dropup btn caret";
+}
 .dropup > .btn, .extend .dropup > .the-button {
-  content: "dropup > btn"; }
-  .dropup > .btn > .caret, .extend .dropup > .the-button > .caret {
-    content: "dropup > btn > caret"; }
-
+  content: "dropup > btn";
+}
+.dropup > .btn > .caret, .extend .dropup > .the-button > .caret {
+  content: "dropup > btn > caret";
+}
 .dropup + .btn, .extend .dropup + .the-button {
-  content: "dropup + btn"; }
-  .dropup + .btn + .caret, .extend .dropup + .the-button + .caret {
-    content: "dropup + btn + caret"; }
-
+  content: "dropup + btn";
+}
+.dropup + .btn + .caret, .extend .dropup + .the-button + .caret {
+  content: "dropup + btn + caret";
+}
 .dropup.btn, .extend .dropup.the-button {
-  content: "dropupbtn"; }
-  .dropup.btn.caret, .extend .dropup.caret.the-button {
-    content: "dropupbtncaret"; }
-
+  content: "dropupbtn";
+}
+.dropup.btn.caret, .extend .dropup.caret.the-button {
+  content: "dropupbtncaret";
+}
 .nav-bar, header ul {
-  background: #eee; }
-  .nav-bar > .item, header ul > .item, header ul.nav-bar > li, header ul > li {
-    margin: 0 10px; }
-
+  background: #eee;
+}
+.nav-bar > .item, header ul > .item, header ul.nav-bar > li, header ul > li {
+  margin: 0 10px;
+}
 .a .b + .btn-block, .a .b + .b {
-  margin-top: 1.5rem; }
+  margin-top: 1.5rem;
+}

--- a/tests/outputs/filter_effects.css
+++ b/tests/outputs/filter_effects.css
@@ -1,20 +1,21 @@
 #number {
-  -webkit-filter: grayscale(1) sepia(0.5) saturate(0.1) invert(1) opacity(0.5) brightness(0.5) contrast(0.5); }
-
+  -webkit-filter: grayscale(1) sepia(0.5) saturate(0.1) invert(1) opacity(0.5) brightness(0.5) contrast(0.5);
+}
 #percentage {
-  -webkit-filter: grayscale(100%) sepia(50%) saturate(10%) invert(100%) opacity(50%) brightness(50%) contrast(50%); }
-
+  -webkit-filter: grayscale(100%) sepia(50%) saturate(10%) invert(100%) opacity(50%) brightness(50%) contrast(50%);
+}
 #misc {
-  -webkit-filter: hue-rotate(90deg) blur(10px) drop-shadow(10px -16px 30px purple); }
-
+  -webkit-filter: hue-rotate(90deg) blur(10px) drop-shadow(10px -16px 30px purple);
+}
 #decimal {
   opacity: 0.5;
-  filter: alpha(opacity=50, style=1); }
-
+  filter: alpha(opacity=50, style=1);
+}
 #percent {
   opacity: 0.5;
-  filter: alpha(opacity=50); }
-
+  filter: alpha(opacity=50);
+}
 .row {
   background-color: #071c23;
-  color: #2284a1; }
+  color: #2284a1;
+}

--- a/tests/outputs/functions.css
+++ b/tests/outputs/functions.css
@@ -1,38 +1,38 @@
 div {
   color: 14px;
-  sum: 23; }
-
+  sum: 23;
+}
 div {
   hello: 10 55;
   hello: 1010 55;
-  hello: "hello 10 and 55"; }
-
+  hello: "hello 10 and 55";
+}
 del {
-  color: 1000; }
-
+  color: 1000;
+}
 div {
   hello: "hello foo and bar";
   hello: "hello bar and default";
-  hello: "hello Alice, Bob, Tom"; }
-
+  hello: "hello Alice, Bob, Tom";
+}
 .foo {
-  test2: -moz-art; }
-
+  test2: -moz-art;
+}
 div span {
-  height: 3px; }
-
+  height: 3px;
+}
 div {
-  width: 2; }
-
+  width: 2;
+}
 p {
-  color: arglist; }
-
+  color: arglist;
+}
 .test {
   display: 'global';
   display: 'test-mixin';
   display: 'test-mixin';
-  display: 'global'; }
-
+  display: 'global';
+}
 .test-inspect {
   n: null;
   b1: true;
@@ -44,14 +44,15 @@ p {
   l2: 3 4;
   l3: 5, 6;
   l4: (a: 1, b: 2);
-  l5: (a: 1, b: 2); }
-
+  l5: (a: 1, b: 2);
+}
 div {
   margin: 1px 1px 2px 2px;
-  padding: 1px 1px 2px 2px; }
-
+  padding: 1px 1px 2px 2px;
+}
 .test {
-  color: rgba(159, 159, 159, 0.625); }
-
+  color: rgba(159, 159, 159, 0.625);
+}
 .skin .var-in-class {
-  background-color: #ddd; }
+  background-color: #ddd;
+}

--- a/tests/outputs/ie7.css
+++ b/tests/outputs/ie7.css
@@ -1,8 +1,9 @@
 #foo:before {
-  content: counter(item,".") ": "; }
-
+  content: counter(item,".") ": ";
+}
 #bar:before {
-  content: counter(item,"."); }
-
+  content: counter(item,".");
+}
 #fu:before {
-  content: counter(item); }
+  content: counter(item);
+}

--- a/tests/outputs/if.css
+++ b/tests/outputs/if.css
@@ -1,24 +1,25 @@
 div {
-  color: blue; }
-
+  color: blue;
+}
 pre {
   val-1: "red";
   val-2: "blue";
   val-3: "blue";
   val-4: "red";
-  val-5: "red"; }
-
+  val-5: "red";
+}
 span {
   color: blue;
   height: 10px;
-  width: 20px; }
-
+  width: 20px;
+}
 div {
   color: blue;
-  border-color: green; }
-
+  border-color: green;
+}
 del {
-  thing: no; }
-
+  thing: no;
+}
 .debug {
-  color: red; }
+  color: red;
+}

--- a/tests/outputs/if_on_null.css
+++ b/tests/outputs/if_on_null.css
@@ -1,2 +1,3 @@
 body {
-  background-color: "red"; }
+  background-color: "red";
+}

--- a/tests/outputs/import.css
+++ b/tests/outputs/import.css
@@ -5,46 +5,52 @@
 @import url("https://fontapi.example.com/css?family=Source+Sans+Pro:wght@300;400;700&display=swap");
 div {
   height: 200px;
-  color: red; }
-
+  color: red;
+}
 pre {
-  color: red; }
-  pre div {
-    height: 200px;
-    color: red; }
-
+  color: red;
+}
+pre div {
+  height: 200px;
+  color: red;
+}
 code div {
   height: 200px;
-  color: red; }
+  color: red;
+}
 code div {
   height: 200px;
-  color: red; }
-
+  color: red;
+}
 #partial {
-  color: blue; }
-
+  color: blue;
+}
 body {
   color: #7C2;
-  background: gray; }
-
+  background: gray;
+}
 a:before {
-  content: ''; }
-
+  content: '';
+}
 div::before {
-  content: ':)'; }
-
+  content: ':)';
+}
 @keyframes spin {
   0% {
-    transform: rotate(0deg); }
+    transform: rotate(0deg);
+  }
   100% {
-    transform: rotate(359deg); } }
-
+    transform: rotate(359deg);
+  }
+}
 .fancybox-is-hidden {
-  position: absolute !important; }
-
+  position: absolute !important;
+}
 .fancybox-navigation .fancybox-button {
-  transition: opacity 0.25s ease, visibility 0s ease 0.25s; }
-
+  transition: opacity 0.25s ease, visibility 0s ease 0.25s;
+}
 @media (max-width: 576px) {
   .fancybox-thumbs {
-    width: 110px; } }
+    width: 110px;
+  }
+}

--- a/tests/outputs/interpolation.css
+++ b/tests/outputs/interpolation.css
@@ -11,38 +11,44 @@ div {
   test: "whatworldwrong";
   test: "whatworldwrong";
   test: "what"world"wrong";
-  hi: "what is 16 end"; }
-
+  hi: "what is 16 end";
+}
 pre var {
-  color: red; }
+  color: red;
+}
 pre var dad {
-  color: red; }
+  color: red;
+}
 pre bedvardad {
-  color: red; }
-
+  color: red;
+}
 cool .thing-1 {
-  color: red; }
+  color: red;
+}
 cool .thing-2 {
-  color: red; }
+  color: red;
+}
 cool .thing-3 {
-  color: red; }
+  color: red;
+}
 cool .thing-4 {
-  color: red; }
+  color: red;
+}
 cool .thing-5 {
-  color: red; }
-
+  color: red;
+}
 abcde {
-  color: red; }
-
+  color: red;
+}
 #hello, .world {
-  color: red; }
-
+  color: red;
+}
 #abchelloyeah, .coolworldyes {
-  color: red; }
-
+  color: red;
+}
 div.element:nth-child(2n) {
-  display: none; }
-
+  display: none;
+}
 div {
   hello: world;
   coolhello: world;
@@ -51,32 +57,35 @@ div {
   oneabtwo: cool;
   hello-world: red;
   hello-mold: white;
-  hello-hello: blue; }
-
+  hello-hello: blue;
+}
 body {
-  color: 3; }
-
+  color: 3;
+}
 foo, x, y {
-  color: #abc; }
-
+  color: #abc;
+}
 div {
-  prop: a, b; }
-
+  prop: a, b;
+}
 a.badge {
-  text-decoration: none; }
-
+  text-decoration: none;
+}
 .btn-primary {
-  background: yellow; }
-  .btn-primary:not(.disabled) {
-    border-color: red; }
-    .btn-primary:not(.disabled):focus {
-      border-width: 3px; }
-
+  background: yellow;
+}
+.btn-primary:not(.disabled) {
+  border-color: red;
+}
+.btn-primary:not(.disabled):focus {
+  border-width: 3px;
+}
 .pagination .page-item:first-child .page-link {
-  border-radius: 5px; }
-
+  border-radius: 5px;
+}
 .element {
-  border: 2px solid #000; }
-
+  border: 2px solid #000;
+}
 div > p > strong, div > h1 > strong {
-  color: red; }
+  color: red;
+}

--- a/tests/outputs/keyword_args.css
+++ b/tests/outputs/keyword_args.css
@@ -1,6 +1,7 @@
 pre {
-  out: alpha fort three palace; }
-
+  out: alpha fort three palace;
+}
 div {
   hello: 5;
-  world: -5; }
+  world: -5;
+}

--- a/tests/outputs/list.css
+++ b/tests/outputs/list.css
@@ -1,25 +1,26 @@
 div {
   padding: 10px 20px 30px 40px;
   margin: 0 10px 10px 10px;
-  background: linear-gradient(black, white); }
-
+  background: linear-gradient(black, white);
+}
 p {
-  background: linear-gradient(red, blue); }
-
+  background: linear-gradient(red, blue);
+}
 .bracket-list {
-  background: linear-gradient(red, blue); }
-
+  background: linear-gradient(red, blue);
+}
 div {
   x: 2;
-  z: 2; }
-
+  z: 2;
+}
 div {
   a: 10px;
   b: -20px;
   c: 30px;
-  d: 30px; }
-
+  d: 30px;
+}
 div {
   x: space;
   y: comma;
-  z: space; }
+  z: space;
+}

--- a/tests/outputs/looping.css
+++ b/tests/outputs/looping.css
@@ -17,14 +17,17 @@ div {
   background: what what;
   background: is is;
   background: this this;
-  color: red; }
-  div h1 {
-    font-size: 2em; }
-  div h2 {
-    font-size: 1.5em; }
-  div h3 {
-    font-size: 1.2em; }
-
+  color: red;
+}
+div h1 {
+  font-size: 2em;
+}
+div h2 {
+  font-size: 1.5em;
+}
+div h3 {
+  font-size: 1.2em;
+}
 span {
   color: 0;
   color: 1;
@@ -36,8 +39,8 @@ span {
   color: 7;
   color: 8;
   color: 9;
-  color: 10; }
-
+  color: 10;
+}
 pre {
   color: 1;
   color: 2;
@@ -55,26 +58,35 @@ pre {
   cool: 6;
   cool: 5;
   cool: 4;
-  cool: 3; }
-
+  cool: 3;
+}
 div {
   a: false;
   b: true;
   c: true;
-  c: true; }
-  .bg-gray-0 {
-    background-color: #f8f9fa; }
-  .bg-gray-1 {
-    background-color: #f1f3f5; }
-  .bg-red-0 {
-    background-color: #fff5f5; }
-  .bg-red-1 {
-    background-color: #ffe3e3; }
-  a.a-blue {
-    color: #44e; }
-  a.a-black {
-    color: #333; }
-  div.div-green {
-    color: #8d8; }
-  div.div-black {
-    color: #333; }
+  c: true;
+}
+.bg-gray-0 {
+  background-color: #f8f9fa;
+}
+.bg-gray-1 {
+  background-color: #f1f3f5;
+}
+.bg-red-0 {
+  background-color: #fff5f5;
+}
+.bg-red-1 {
+  background-color: #ffe3e3;
+}
+a.a-blue {
+  color: #44e;
+}
+a.a-black {
+  color: #333;
+}
+div.div-green {
+  color: #8d8;
+}
+div.div-black {
+  color: #333;
+}

--- a/tests/outputs/map.css
+++ b/tests/outputs/map.css
@@ -5,23 +5,27 @@ div {
   bar: color, length;
   baz: (color: white, color2: red, 'color3': #00FF00, length: 40em);
   foo: (length: 40em);
-  bar: true; }
-
+  bar: true;
+}
 div {
   foo: color black;
-  bar: color; }
-  .black {
-    background-color: #000000 !important; }
-  .grey {
-    background-color: #888888 !important; }
-  .white {
-    background-color: #ffffff !important; }
-
+  bar: color;
+}
+.black {
+  background-color: #000000 !important;
+}
+.grey {
+  background-color: #888888 !important;
+}
+.white {
+  background-color: #ffffff !important;
+}
 div {
   a: 1;
   b: 2;
   color: 1;
-  background-color: 2; }
-
+  background-color: 2;
+}
 div {
-  x: 2; }
+  x: 2;
+}

--- a/tests/outputs/media.css
+++ b/tests/outputs/media.css
@@ -1,126 +1,169 @@
 @media {
   div {
-    color: blue; } }
-
+    color: blue;
+  }
+}
 @media what {
   div {
-    color: blue; } }
-
+    color: blue;
+  }
+}
 @media (cool) {
   div {
-    color: blue; } }
-
+    color: blue;
+  }
+}
 @media (cool: blue) {
   div {
-    color: blue; } }
-
+    color: blue;
+  }
+}
 @media hello and (world) and (butt: man) {
   div {
-    color: blue; } }
-
+    color: blue;
+  }
+}
 @media (max-width: 940px) {
-  color: red; }
+  color: red;
+}
 @media not hello and (world) {
   color: blue;
-    pre {
-      color: blue; } }
-  @media not hello and (world) {
+  pre {
+    color: blue;
+  }
+}
+@media not hello and (world) {
   @media butt {
     color: red;
-      div {
-        color: red; } } }
-
+    div {
+      color: red;
+    }
+  }
+}
 @media c {
-  color: blue; }
-
+  color: blue;
+}
 div {
-  color: blue; }
+  color: blue;
+}
 @media screen and (-webkit-min-device-pixel-ratio: 1.5) {
   div .sidebar {
-    width: 500px; } }
-
+    width: 500px;
+  }
+}
 div {
-  position: absolute; }
+  position: absolute;
+}
 @media screen {
   div {
     top: 0;
     bottom: 8em;
-    color: red; }
-    div p {
-      margin: 5px; }
-    div .success {
-      color: green; } }
-
+    color: red;
+  }
+  div p {
+    margin: 5px;
+  }
+  div .success {
+    color: green;
+  }
+}
 .button {
   width: 300px;
   height: 100px;
-  background: #eee; }
-  .button :hover {
-    background: #aaa; }
-  @media only screen and (max-width: 300px) {
-    .button {
-      width: 100px;
-      height: 100px; } }
-
+  background: #eee;
+}
+.button :hover {
+  background: #aaa;
+}
+@media only screen and (max-width: 300px) {
+  .button {
+    width: 100px;
+    height: 100px;
+  }
+}
 code {
-  position: absolute; }
+  position: absolute;
+}
 @media screen {
   code {
-    height: 10px; }
-    code pre {
-      height: 20px; } }
-
+    height: 10px;
+  }
+  code pre {
+    height: 20px;
+  }
+}
 @media screen and (color: blue) {
   dt {
-    height: 10px; } }
-
+    height: 10px;
+  }
+}
 @media screen {
   .screen {
-    width: 12px; } }
+    width: 12px;
+  }
+}
 @media only screen {
   .only-screen {
-    height: 11px; } }
-
+    height: 11px;
+  }
+}
 @media only screen {
   .only-screen {
-    width: 14px; } }
+    width: 14px;
+  }
+}
 @media only screen {
   .only-screen {
-    height: 16px; } }
-
+    height: 16px;
+  }
+}
 @media print {
   .only-print {
-    height: 12px; } }
-
+    height: 12px;
+  }
+}
 @media screen {
   .only-print {
-    height: 12px; } }
-
+    height: 12px;
+  }
+}
 @media not screen {
   .not-screen {
-    height: 15px; } }
-
+    height: 15px;
+  }
+}
 @media only screen and (color: blue) and (width: 13) {
   .only-screen {
-    height: 15px; } }
-
+    height: 15px;
+  }
+}
 @media screen and (max-width: 749px) and (max-width: 600px) and (min-width: 361px) {
   .item {
-    color: red; } }
-
+    color: red;
+  }
+}
 @media not all and (max-width: 450px) {
   @media not all and (max-width: 690px) and (orientation: portrait) {
     @media (max-width: 1000px) {
       a {
-        color: red; } } } }
-
+        color: red;
+      }
+    }
+  }
+}
 @media not all and (max-width: 450px) {
   @media (max-width: 690px) and (orientation: portrait) and (max-width: 1000px) {
     a {
-      color: red; } } }
-
+      color: red;
+    }
+  }
+}
 @media (max-width: 450px) {
   @media not all and (max-width: 690px) and (orientation: portrait) {
     @media not all and (max-width: 1000px) {
       a {
-        color: red; } } } }
+        color: red;
+      }
+    }
+  }
+}

--- a/tests/outputs/mixins.css
+++ b/tests/outputs/mixins.css
@@ -1,137 +1,152 @@
 div {
   color: blue;
-  color: red; }
-  div pre {
-    height: 200px; }
-
+  color: red;
+}
+div pre {
+  height: 200px;
+}
 span {
-  color: blue; }
-  span div {
-    height: 20px; }
-
+  color: blue;
+}
+span div {
+  height: 20px;
+}
 html {
-  height: 43px; }
-
+  height: 43px;
+}
 del {
-  height: 20px; }
-
+  height: 20px;
+}
 div {
   color: white;
   color: blue;
-  color: white; }
-
+  color: white;
+}
 div {
-  background-image: linear-gradient(left top, red, green); }
-
+  background-image: linear-gradient(left top, red, green);
+}
 div {
   -moz-box-shadow: 10px 10px 5px #888;
   -webkit-box-shadow: 10px 10px 5px #888;
   box-shadow: 10px 10px 5px #888;
   -moz-box-shadow: inset 10px 10px #888, -10px -10px #f4f4f4;
   -webkit-box-shadow: inset 10px 10px #888, -10px -10px #f4f4f4;
-  box-shadow: inset 10px 10px #888, -10px -10px #f4f4f4; }
-
+  box-shadow: inset 10px 10px #888, -10px -10px #f4f4f4;
+}
 div p {
   color: red;
-  color: blue; }
-  div p .class {
-    color: red; }
-    div p .class div {
-      height: 20px; }
-  div p div {
-    height: 20px; }
-  div p .top {
-    top: 0; }
-    div p .top div {
-      color: red; }
-
+  color: blue;
+}
+div p .class {
+  color: red;
+}
+div p .class div {
+  height: 20px;
+}
+div p div {
+  height: 20px;
+}
+div p .top {
+  top: 0;
+}
+div p .top div {
+  color: red;
+}
 div.mixin-content-simple {
-  color: red; }
-
+  color: red;
+}
 div.mixin-content-with-arg {
   background: blue;
-  color: red; }
-
+  color: red;
+}
 div.mixin-content-with-arg {
   background: purple;
-  height: 20px; }
-
+  height: 20px;
+}
 div.mixin-content-simple {
-  height: 43px; }
-
+  height: 43px;
+}
 div.mixin-content-simple {
-  color: orange; }
-  div.mixin-content-simple div {
-    height: 20px; }
-
+  color: orange;
+}
+div.mixin-content-simple div {
+  height: 20px;
+}
 div.mixin-content-with-arg {
   background: purple;
-  height: 43px; }
-
+  height: 43px;
+}
 div.mixin-content-with-arg {
   background: purple;
-  color: orange; }
-  div.mixin-content-with-arg div {
-    height: 20px; }
-
+  color: orange;
+}
+div.mixin-content-with-arg div {
+  height: 20px;
+}
 #please-wait {
   background: url(/images/logo.png);
   position: absolute;
   top: 1em;
   right: 0;
   bottom: 3em;
-  left: 4em; }
-
+  left: 4em;
+}
 div.parameter-name-scope {
-  -webkit-transform: translateX(50px); }
-
+  -webkit-transform: translateX(50px);
+}
 @-webkit-keyframes change-color {
   0% {
-    color: green; }
+    color: green;
+  }
   100% {
-    color: red; } }
-
+    color: red;
+  }
+}
 @media screen and (min-width:0\0) {
   .test {
-    color: #000; } }
-
+    color: #000;
+  }
+}
 div {
   content: "div";
-  content: "div"; }
-  div p {
-    content: "p";
-    content: "p"; }
-
+  content: "div";
+}
+div p {
+  content: "p";
+  content: "p";
+}
 .content-with-using-scope-test-before {
   border-color: black;
   color: white;
-  text-align: left; }
-
+  text-align: left;
+}
 .content-with-using {
   color: black;
-  text-align: left; }
-
+  text-align: left;
+}
 .content-with-using-scope-test-after {
   background-color: black;
   color: white;
-  text-align: left; }
-
+  text-align: left;
+}
 .content-with-using-scope-test-outside {
-  color: white; }
-
+  color: white;
+}
 .content-with-using-and-args {
   background-color: white;
   color: black;
-  text-align: left; }
-
+  text-align: left;
+}
 .content-with-using-nested-outside {
   background-color: white;
   color: black;
-  text-align: left; }
-  .content-with-using-nested-outside .content-with-using-nested-inside {
-    background-color: white;
-    color: red;
-    text-align: right; }
-
+  text-align: left;
+}
+.content-with-using-nested-outside .content-with-using-nested-inside {
+  background-color: white;
+  color: red;
+  text-align: right;
+}
 .skin .var-in-class {
-  border: 1px solid #ccc; }
+  border: 1px solid #ccc;
+}

--- a/tests/outputs/nested_mixins.css
+++ b/tests/outputs/nested_mixins.css
@@ -1,23 +1,30 @@
 div .container {
-  width: 10px; }
-  div .container .container {
-    width: 10px;
-    max-width: 12px; }
-  div .container .foo {
-    width: 10px; }
-  div .container .bar {
-    width: 12px; }
-
+  width: 10px;
+}
+div .container .container {
+  width: 10px;
+  max-width: 12px;
+}
+div .container .foo {
+  width: 10px;
+}
+div .container .bar {
+  width: 12px;
+}
 @media print, screen and (min-width:640px) {
   .position-left {
     color: red;
-    background: yellow; } }
-
+    background: yellow;
+  }
+}
 @media print, screen and (min-width:640px) {
   .element {
-    float: left; } }
-
+    float: left;
+  }
+}
 .a {
-  x: y; }
-  .a .inner {
-    x: y; }
+  x: y;
+}
+.a .inner {
+  x: y;
+}

--- a/tests/outputs/nesting.css
+++ b/tests/outputs/nesting.css
@@ -1,22 +1,24 @@
 body {
-  color: red; }
-
+  color: red;
+}
 div {
   color: red;
-  height: yes; }
-  div pre {
-    color: blue; }
-
+  height: yes;
+}
+div pre {
+  color: blue;
+}
 div: blue;
 div {
   font: 10px hello world;
-    font-size: 10px;
-    font-color: blue;
+  font-size: 10px;
+  font-color: blue;
   border-left: 1px solid blue;
-  border-right: 2px dashed green; }
-
+  border-right: 2px dashed green;
+}
 #nested-nesting {
   bar: baz;
   bang-bop: bar;
   bang-bip: 1px;
-  bang-blat-baf: bort; }
+  bang-blat-baf: bort;
+}

--- a/tests/outputs/null.css
+++ b/tests/outputs/null.css
@@ -3,19 +3,20 @@
   one: world;
   one: NULL world;
   one: a, b;
-  two: a, b; }
-
+  two: a, b;
+}
 p:before {
-  content: "I ate  pies!"; }
-
+  content: "I ate  pies!";
+}
 .foo {
   -webkit-border-radius: 10;
-  border-radius: 10; }
-
+  border-radius: 10;
+}
 .fu {
   -webkit-border-radius: 20;
-  border-radius: 20; }
-
+  border-radius: 20;
+}
 .bar {
   -webkit-border-top-left-radius: 30;
-  border-top-left-radius: 30; }
+  border-top-left-radius: 30;
+}

--- a/tests/outputs/operators.css
+++ b/tests/outputs/operators.css
@@ -6,26 +6,26 @@ body {
   color: 5px;
   top: 1.5em;
   left: -1cm;
-  top: 6.2992125984; }
-
+  top: 6.2992125984;
+}
 div {
   color: false;
   color: true;
   color: true;
   color: false;
-  color: what > 3; }
-
+  color: what > 3;
+}
 #units {
   test: 2.5748031496in;
   test: 13mm;
   test: 4em;
   test: 11mm;
-  test: 1.1cm; }
-
+  test: 1.1cm;
+}
 #modulo {
   test: 1;
-  test: 1cm; }
-
+  test: 1cm;
+}
 #colors {
   color: #ff0203;
   color: #fe0000;
@@ -43,12 +43,12 @@ div {
   color: false;
   color: true;
   color: true;
-  color: false; }
-
+  color: false;
+}
 #preserve {
   hello: what -going;
-  hello: what - going; }
-
+  hello: what - going;
+}
 #strings {
   hello: what -going;
   hello: whatgoing;
@@ -57,21 +57,21 @@ div {
   hello: whatgoing;
   hello: "whatgoing";
   hello: goingwhat;
-  hello: "whatwhat"; }
-
+  hello: "whatwhat";
+}
 #negation {
   a: -60;
   b: -90;
-  b: -90; }
-
+  b: -90;
+}
 #bools-fail {
   and: false and two;
   and: one and two;
   and: one and false;
   or: false or two;
   or: one or two;
-  or: one or false; }
-
+  or: one or false;
+}
 #bools {
   and: false;
   and: two;
@@ -79,16 +79,16 @@ div {
   or: two;
   or: one;
   or: one;
-  or: two; }
-
+  or: two;
+}
 #nots-fail {
   not: false2;
   not: not false;
   not: not 0;
   not: not 1;
   not: not "";
-  not: not hello; }
-
+  not: not hello;
+}
 #nots {
   not: false2;
   not: true;
@@ -96,85 +96,85 @@ div {
   not: false;
   not: false;
   not: false;
-  not: true; }
-
+  not: true;
+}
 #string-test {
   str: true;
   str: false;
   str: true;
   str: true;
   str: xhellohellofalse;
-  str: true; }
-
+  str: true;
+}
 #special {
-  cancel-unit: 1; }
-
+  cancel-unit: 1;
+}
 .row .a {
-  margin: -0.5em; }
-
+  margin: -0.5em;
+}
 .row .b {
-  margin: -0.5em; }
-
+  margin: -0.5em;
+}
 .row .c {
-  margin: -0.5em; }
-
+  margin: -0.5em;
+}
 .row .d {
-  margin: -0.5em; }
-
+  margin: -0.5em;
+}
 .row .e {
-  margin: 0 -0.5em; }
-
+  margin: 0 -0.5em;
+}
 .alt .a {
-  margin: -0.5em; }
-
+  margin: -0.5em;
+}
 .alt .b {
-  margin: -0.5em; }
-
+  margin: -0.5em;
+}
 .alt .c {
-  margin: -0.5em; }
-
+  margin: -0.5em;
+}
 .alt .d {
-  margin: 0 -0.5em; }
-
+  margin: 0 -0.5em;
+}
 .alt .e {
-  margin: 0 -0.5em; }
-
+  margin: 0 -0.5em;
+}
 .row .f {
-  margin: -2em; }
-
+  margin: -2em;
+}
 .row .g {
-  margin: -2em; }
-
+  margin: -2em;
+}
 .row .h {
-  margin: -2em; }
-
+  margin: -2em;
+}
 .row .i {
-  margin: -2em; }
-
+  margin: -2em;
+}
 .row .j {
-  margin: 0 -2em; }
-
+  margin: 0 -2em;
+}
 .alt .f {
-  margin: -2em; }
-
+  margin: -2em;
+}
 .alt .g {
-  margin: -2em; }
-
+  margin: -2em;
+}
 .alt .h {
-  margin: -2em; }
-
+  margin: -2em;
+}
 .alt .i {
-  margin: 0 -2em; }
-
+  margin: 0 -2em;
+}
 .alt .j {
-  margin: 0 -2em; }
-
+  margin: 0 -2em;
+}
 div {
-  *margin-left: 2.0744680851%; }
-
+  *margin-left: 2.0744680851%;
+}
 .foo {
-  width: 12.5%; }
-
+  width: 12.5%;
+}
 #bools-test {
   a: false;
   b: true;
@@ -183,8 +183,9 @@ div {
   o: true;
   p: false;
   r: one;
-  s: one; }
-
+  s: one;
+}
 a {
   width: 0.9722222222vw;
-  height: 0.9722222222vw; }
+  height: 0.9722222222vw;
+}

--- a/tests/outputs/parsing_comments.css
+++ b/tests/outputs/parsing_comments.css
@@ -3,16 +3,16 @@ a {
   /* comment 2 */
   color: red;
   /* comment 3 */
-  /* comment 4 */ }
-
+  /* comment 4 */
+}
 /* comment 5 */
 /*! comment 1 */
 b {
   /*! comment 2 */
   color: red;
   /*! comment 3 */
-  /*! comment 4 */ }
-
+  /*! comment 4 */
+}
 /*! comment 5 */
 /*
  * multi-line comment 1
@@ -27,8 +27,8 @@ c {
                  */
   /*
      * multi-line comment 4
-     */ }
-
+     */
+}
 /*
  * multi-line comment 5
  */
@@ -45,10 +45,11 @@ d {
                  */
   /*!
      * multi-line comment 4
-     */ }
-
+     */
+}
 /*!
  * multi-line comment 5
  */
 e {
-  color: red; }
+  color: red;
+}

--- a/tests/outputs/placeholder_selector.css
+++ b/tests/outputs/placeholder_selector.css
@@ -1,10 +1,11 @@
 #context a.notice span, #context a.error span, p a.notice span, p a.error span {
   color: blue;
   font-weight: bold;
-  font-size: 2em; }
-
+  font-size: 2em;
+}
 p {
-  padding: 2em; }
-
+  padding: 2em;
+}
 .layout {
-  color: red; }
+  color: red;
+}

--- a/tests/outputs/rgb_rgba.css
+++ b/tests/outputs/rgb_rgba.css
@@ -1,47 +1,48 @@
 a {
-  b: rgb(var(--foo), 3, 0.4); }
-
+  b: rgb(var(--foo), 3, 0.4);
+}
 a {
-  b: rgba(17, 34, 51, 0.5); }
-
+  b: rgba(17, 34, 51, 0.5);
+}
 a {
-  b: rgb(0, 0, 255, calc(0.4)); }
-
+  b: rgb(0, 0, 255, calc(0.4));
+}
 a {
-  b: rgb(0, 0, 255, var(--foo)); }
-
+  b: rgb(0, 0, 255, var(--foo));
+}
 a {
-  b: rgba(0, 255, 127, 0); }
-
+  b: rgba(0, 255, 127, 0);
+}
 a {
-  b: springgreen; }
-
+  b: springgreen;
+}
 a {
-  b: rgb(calc(1) 2 3); }
-
+  b: rgb(calc(1) 2 3);
+}
 a {
-  b: rgba(var(--foo) / 0.4); }
-
+  b: rgba(var(--foo) / 0.4);
+}
 a {
-  b: rgb(calc(1), 2, 3, 0.4); }
-
-basic {
-  transparent: rgba(51, 204, 204, 0);
-  opaque: #3cc;
-  partial: rgba(51, 204, 204, 0.5);
-  named: rgba(51, 204, 204, 0.4); }
-
+  b: rgb(calc(1), 2, 3, 0.4);
+}
 basic {
   transparent: rgba(51, 204, 204, 0);
   opaque: #3cc;
   partial: rgba(51, 204, 204, 0.5);
   named: rgba(51, 204, 204, 0.4);
-  parenthesized: rgba(51, 204, 204, 0.4); }
-
+}
+basic {
+  transparent: rgba(51, 204, 204, 0);
+  opaque: #3cc;
+  partial: rgba(51, 204, 204, 0.5);
+  named: rgba(51, 204, 204, 0.4);
+  parenthesized: rgba(51, 204, 204, 0.4);
+}
 basic {
   transparent: rgba(0, 255, 127, 0);
   opaque: #beaded;
   partial: rgba(18, 52, 86, 0.5);
   percent: rgba(18, 52, 86, 0.5);
   named: rgba(0, 255, 127, 0.3);
-  parenthesized: rgba(0, 255, 127, 0.3); }
+  parenthesized: rgba(0, 255, 127, 0.3);
+}

--- a/tests/outputs/scss_css.css
+++ b/tests/outputs/scss_css.css
@@ -25,20 +25,20 @@
 @namespace html url("http://www.w3.org/Profiles/xhtml1-strict");
 
 [foo~=bar] {
-  a: b; }
-
+  a: b;
+}
 [foo^=bar] {
-  a: b; }
-
+  a: b;
+}
 [foo$=bar] {
-  a: b; }
-
+  a: b;
+}
 [foo*=bar] {
-  a: b; }
-
+  a: b;
+}
 [foo|=en] {
-  a: b; }
-
+  a: b;
+}
 foo {
   a: 2;
   b: 2.3em;
@@ -46,120 +46,124 @@ foo {
   d: "fraz bran";
   e: flanny-blanny-blan;
   f: url(http://sass-lang.com);
-  h: #aabbcc; }
-
+  h: #aabbcc;
+}
 selector {
   property: value;
-  property2: value; }
-
+  property2: value;
+}
 sel {
-  p: v; }
-
+  p: v;
+}
 .foo {
   /* Foo
 Bar
   Baz */
-  a: b; }
-
+  a: b;
+}
 .foo {
   /* Foo
 Bar
   Baz */
-  a: b; }
-
+  a: b;
+}
 .foo {
   /* Foo
    Bar */
-  a: b; }
-
+  a: b;
+}
 .foo {
   /* Foo
    Bar
   Baz */
-  a: b; }
-
+  a: b;
+}
 @foo {
   a: b;
-    rule {
-      a: b; } }
+  rule {
+    a: b;
+  }
+}
 @foo {
-  a: b; }
+  a: b;
+}
 @bar {
-  a: b; }
+  a: b;
+}
 @foo "bar"
 
 foo {
   a: 12px calc(100%/3 - 2*1em - 2*1px);
   b: 12px -moz-calc(100%/3 - 2*1em - 2*1px);
   b: 12px -webkit-calc(100%/3 - 2*1em - 2*1px);
-  b: 12px -foobar-calc(100%/3 - 2*1em - 2*1px); }
-
+  b: 12px -foobar-calc(100%/3 - 2*1em - 2*1px);
+}
 foo {
-  bar: baz; }
-
+  bar: baz;
+}
 bar {
-  bar: baz; }
-
+  bar: baz;
+}
 baz {
-  bar: baz; }
-
+  bar: baz;
+}
 /*
  * foo
  */
 bar {
-  baz: bang; }
-
+  baz: bang;
+}
 E, F {
-  a: b; }
-
+  a: b;
+}
 E F, G H {
-  a: b; }
-
+  a: b;
+}
 E > F, G > H {
-  a: b; }
-
+  a: b;
+}
 /* This is a CSS comment. */
 .one {
-  color: green; }
-
+  color: green;
+}
 /* Another comment */
 /* The following should not be used:
 .two {color: red;} */
 .three {
   color: green;
-  /* color: red; */ }
-
+  /* color: red; */
+}
 /**
 .four {color: red;} */
 .five {
-  color: green; }
-
+  color: green;
+}
 /**/
 .six {
-  color: green; }
-
+  color: green;
+}
 /*********/
 .seven {
-  color: green; }
-
+  color: green;
+}
 /* a comment **/
 .eight {
-  color: green; }
-
+  color: green;
+}
 foo {
   a: \f oo bar;
   b: foo\ bar;
   c: • ;
   d: foo\\bar;
-  e: foo\"\'bar; }
-
+  e: foo\"\'bar;
+}
 foo {
   a: "\foo bar";
   b: "foo bar";
   c: "• ";
   d: "foo\\bar";
-  e: "foo\"'bar"; }
-
+  e: "foo\"'bar";
+}
 foo {
   _name: val;
   *name: val;
@@ -168,235 +172,243 @@ foo {
   #name: val;
   name/**/: val;
   name/*\**/: val;
-  name: val; }
-
+  name: val;
+}
 foo {
   a: -moz-element(#foo);
   b: -webkit-element(#foo);
-  b: -foobar-element(#foo); }
-
+  b: -foobar-element(#foo);
+}
 foo {
-  bar: baz; }
-
+  bar: baz;
+}
 0% {
-  a: b; }
-
+  a: b;
+}
 60% {
-  a: b; }
-
+  a: b;
+}
 100% {
-  a: b; }
-
+  a: b;
+}
 12px {
-  a: b; }
-
+  a: b;
+}
 foo {
-  a: b; }
-
+  a: b;
+}
 foo {
-  a: 12px expression(1 + (3 / Foo.bar("baz" + "bang") + function() {return 12;}) % 12); }
-
+  a: 12px expression(1 + (3 / Foo.bar("baz" + "bang") + function() {return 12;}) % 12);
+}
 :foo("bar") {
-  a: b; }
-
+  a: b;
+}
 :foo(bar) {
-  a: b; }
-
+  a: b;
+}
 :foo(12px) {
-  a: b; }
-
+  a: b;
+}
 :foo(+) {
-  a: b; }
-
+  a: b;
+}
 :foo(-) {
-  a: b; }
-
+  a: b;
+}
 :foo(+"bar") {
-  a: b; }
-
+  a: b;
+}
 :foo(-++--baz-"bar"12px) {
-  a: b; }
-
+  a: b;
+}
 foo {
   a: foo-bar(12);
-  b: -foo-bar-baz(13, 14 15); }
-
+  b: -foo-bar-baz(13, 14 15);
+}
 foo {
   a: foo !important;
   b: foo bar !important;
-  b: foo, bar !important; }
-
+  b: foo, bar !important;
+}
 foo {
   a: -moz-bar-baz;
-  b: foo -o-bar-baz; }
-
+  b: foo -o-bar-baz;
+}
 foo {
   a: d;
-  /* b; c: */ }
-
+  /* b; c: */
+}
 foo {
-  a: d; }
-
+  a: d;
+}
 /* Foo
  * Bar */
 .foo {
   /* Foo
-   * Bar */ }
-
+   * Bar */
+}
 [foo] {
-  a: b; }
-
+  a: b;
+}
 [foo="bar"] {
-  a: b; }
-
+  a: b;
+}
 [foo~="bar"] {
-  a: b; }
-
+  a: b;
+}
 [foo^="bar"] {
-  a: b; }
-
+  a: b;
+}
 [foo$="bar"] {
-  a: b; }
-
+  a: b;
+}
 [foo*="bar"] {
-  a: b; }
-
+  a: b;
+}
 [foo|="en"] {
-  a: b; }
-
+  a: b;
+}
 :root {
-  a: b; }
-
+  a: b;
+}
 :nth-child(n) {
-  a: b; }
-
+  a: b;
+}
 :nth-last-child(n) {
-  a: b; }
-
+  a: b;
+}
 :nth-of-type(n) {
-  a: b; }
-
+  a: b;
+}
 :nth-last-of-type(n) {
-  a: b; }
-
+  a: b;
+}
 :first-child {
-  a: b; }
-
+  a: b;
+}
 :last-child {
-  a: b; }
-
+  a: b;
+}
 :first-of-type {
-  a: b; }
-
+  a: b;
+}
 :last-of-type {
-  a: b; }
-
+  a: b;
+}
 :only-child {
-  a: b; }
-
+  a: b;
+}
 :only-of-type {
-  a: b; }
-
+  a: b;
+}
 :empty {
-  a: b; }
-
+  a: b;
+}
 :link {
-  a: b; }
-
+  a: b;
+}
 :visited {
-  a: b; }
-
+  a: b;
+}
 :active {
-  a: b; }
-
+  a: b;
+}
 :hover {
-  a: b; }
-
+  a: b;
+}
 :focus {
-  a: b; }
-
+  a: b;
+}
 :target {
-  a: b; }
-
+  a: b;
+}
 :lang(fr) {
-  a: b; }
-
+  a: b;
+}
 :enabled {
-  a: b; }
-
+  a: b;
+}
 :disabled {
-  a: b; }
-
+  a: b;
+}
 :checked {
-  a: b; }
-
+  a: b;
+}
 ::first-line {
-  a: b; }
-
+  a: b;
+}
 ::first-letter {
-  a: b; }
-
+  a: b;
+}
 ::before {
-  a: b; }
-
+  a: b;
+}
 ::after {
-  a: b; }
-
+  a: b;
+}
 .warning {
-  a: b; }
-
+  a: b;
+}
 #myid {
-  a: b; }
-
+  a: b;
+}
 :not(s) {
-  a: b; }
-
+  a: b;
+}
 @media all {
   rule1 {
-    prop: val; }
+    prop: val;
+  }
   rule2 {
-    prop: val; } }
-
+    prop: val;
+  }
+}
 @media screen, print {
   rule1 {
-    prop: val; }
+    prop: val;
+  }
   rule2 {
-    prop: val; } }
-
+    prop: val;
+  }
+}
 @media screen and (-webkit-min-device-pixel-ratio: 0) {
-  a: b; }
+  a: b;
+}
 @media only screen, print and (foo: 0px) and (bar: flam(12px solid)) {
-  a: b; }
-
+  a: b;
+}
 :-moz-any(h1, h2, h3) {
-  a: b; }
-
+  a: b;
+}
 :-moz-any(.foo) {
-  a: b; }
-
+  a: b;
+}
 :-moz-any(foo bar, .baz > .bang) {
-  a: b; }
-
+  a: b;
+}
 @-moz-document url(http://www.w3.org/),
                url-prefix(http://www.w3.org/Style/),
                domain(mozilla.org),
                regexp("^https:.*") {
   .foo {
-    a: b; } }
-
+    a: b;
+  }
+}
 foo {
   filter: progid:DXImageTransform.Microsoft.gradient(GradientType=1, startColorstr=#c0ff3300, endColorstr=#ff000000);
-  filter: progid:DXImageTransform.Microsoft.gradient(GradientType=1, startColorstr=#c0ff3300, endColorstr=#ff000000); }
-
+  filter: progid:DXImageTransform.Microsoft.gradient(GradientType=1, startColorstr=#c0ff3300, endColorstr=#ff000000);
+}
 foo {
   filter: alpha(opacity=20);
   filter: alpha(opacity=20, enabled=true);
-  filter: blaznicate(foo=bar, baz=bang bip, bart=#fa4600); }
-
+  filter: blaznicate(foo=bar, baz=bang bip, bart=#fa4600);
+}
 @foo bar {
-  a: b; }
+  a: b;
+}
 @bar baz {
-  c: d; }
+  c: d;
+}
 /* Foo
  * Bar */
 /* Baz
@@ -405,374 +417,381 @@ foo {
   /* Foo
    * Bar */
   /* Baz
-   * Bang */ }
-
+   * Bang */
+}
 .foo {
   /* Foo Bar */
-  /* Baz Bang */ }
-
+  /* Baz Bang */
+}
 [foo|bar=baz] {
-  a: b; }
-
+  a: b;
+}
 [*|bar=baz] {
-  a: b; }
-
+  a: b;
+}
 [foo|bar|=baz] {
-  a: b; }
-
+  a: b;
+}
 foo|E {
-  a: b; }
-
+  a: b;
+}
 *|E {
-  a: b; }
-
+  a: b;
+}
 foo|* {
-  a: b; }
-
+  a: b;
+}
 *|* {
-  a: b; }
-
+  a: b;
+}
 :not(foo|bar) {
-  a: b; }
-
+  a: b;
+}
 :not(*|bar) {
-  a: b; }
-
+  a: b;
+}
 :not(foo|*) {
-  a: b; }
-
+  a: b;
+}
 :not(*|*) {
-  a: b; }
-
+  a: b;
+}
 :not(#blah) {
-  a: b; }
-
+  a: b;
+}
 :not(.blah) {
-  a: b; }
-
+  a: b;
+}
 :not(.blah) {
-  a: b; }
-
+  a: b;
+}
 :not([foo]) {
-  a: b; }
-
+  a: b;
+}
 :not([foo^="bar"]) {
-  a: b; }
-
+  a: b;
+}
 :not([baz|foo~="bar"]) {
-  a: b; }
-
+  a: b;
+}
 :not(:hover) {
-  a: b; }
-
+  a: b;
+}
 :not(:nth-child(2n + 3)) {
-  a: b; }
-
+  a: b;
+}
 :not(:not(#foo)) {
-  a: b; }
-
+  a: b;
+}
 :not(a#foo.bar) {
-  a: b; }
-
+  a: b;
+}
 :not(#foo .bar > baz) {
-  a: b; }
-
+  a: b;
+}
 :not(#foo .bar > baz) {
-  a: b; }
-
+  a: b;
+}
 :not(h1, h2, h3) {
-  a: b; }
-
+  a: b;
+}
 foo {
-  a: "bang 1 bar  bip"; }
-
+  a: "bang 1 bar  bip";
+}
 :nth-child(-n) {
-  a: b; }
-
+  a: b;
+}
 :nth-child(+n) {
-  a: b; }
-
+  a: b;
+}
 :nth-child(even) {
-  a: b; }
-
+  a: b;
+}
 :nth-child(odd) {
-  a: b; }
-
+  a: b;
+}
 :nth-child(50) {
-  a: b; }
-
+  a: b;
+}
 :nth-child(-50) {
-  a: b; }
-
+  a: b;
+}
 :nth-child(+50) {
-  a: b; }
-
+  a: b;
+}
 :nth-child(2n+3) {
-  a: b; }
-
+  a: b;
+}
 :nth-child(2n-3) {
-  a: b; }
-
+  a: b;
+}
 :nth-child(+2n-3) {
-  a: b; }
-
+  a: b;
+}
 :nth-child(-2n+3) {
-  a: b; }
-
+  a: b;
+}
 :nth-child(-2n+ 3) {
-  a: b; }
-
+  a: b;
+}
 :nth-child(2n + 3) {
-  a: b; }
-
+  a: b;
+}
 foo {
   a: foo bar baz;
   b: foo, #aabbcc, -12;
   c: 1px/2px/-3px;
-  d: foo bar, baz/bang; }
-
+  d: foo bar, baz/bang;
+}
 @page {
   prop1: val;
-  prop2: val; }
+  prop2: val;
+}
 @page flap {
   prop1: val;
-  prop2: val; }
+  prop2: val;
+}
 @page :first {
   prop1: val;
-  prop2: val; }
+  prop2: val;
+}
 @page flap:first {
   prop1: val;
-  prop2: val; }
-
+  prop2: val;
+}
 .foo {
   /* Foo */
-  a: b; }
-
+  a: b;
+}
 .foo {
   /* Foo
    * Bar */
-  a: b; }
-
+  a: b;
+}
 /* Foo */
 .foo {
-  a: b; }
-
+  a: b;
+}
 /* Foo
  * Bar */
 .foo {
-  a: b; }
-
+  a: b;
+}
 .foo #bar:baz(bip) {
-  a: b; }
-
+  a: b;
+}
 > E {
-  a: b; }
-
+  a: b;
+}
 + E {
-  a: b; }
-
+  a: b;
+}
 ~ E {
-  a: b; }
-
+  a: b;
+}
 > > E {
-  a: b; }
-
+  a: b;
+}
 >> E {
-  a: b; }
-
+  a: b;
+}
 E* {
-  a: b; }
-
+  a: b;
+}
 E*.foo {
-  a: b; }
-
+  a: b;
+}
 E*:hover {
-  a: b; }
-
+  a: b;
+}
 E, F {
-  a: b; }
-
+  a: b;
+}
 E F {
-  a: b; }
-
+  a: b;
+}
 E, F G, H {
-  a: b; }
-
+  a: b;
+}
 body {
   /*
   //comment here
-  */ }
-
+  */
+}
 E > F {
-  a: b; }
-
+  a: b;
+}
 E ~ F {
-  a: b; }
-
+  a: b;
+}
 E + F {
-  a: b; }
-
+  a: b;
+}
 * {
-  a: b; }
-
+  a: b;
+}
 E {
-  a: b; }
-
+  a: b;
+}
 E[foo] {
-  a: b; }
-
+  a: b;
+}
 E[foo="bar"] {
-  a: b; }
-
+  a: b;
+}
 E[foo~="bar"] {
-  a: b; }
-
+  a: b;
+}
 E[foo^="bar"] {
-  a: b; }
-
+  a: b;
+}
 E[foo$="bar"] {
-  a: b; }
-
+  a: b;
+}
 E[foo*="bar"] {
-  a: b; }
-
+  a: b;
+}
 E[foo|="en"] {
-  a: b; }
-
+  a: b;
+}
 E:root {
-  a: b; }
-
+  a: b;
+}
 E:nth-child(n) {
-  a: b; }
-
+  a: b;
+}
 E:nth-last-child(n) {
-  a: b; }
-
+  a: b;
+}
 E:nth-of-type(n) {
-  a: b; }
-
+  a: b;
+}
 E:nth-last-of-type(n) {
-  a: b; }
-
+  a: b;
+}
 E:first-child {
-  a: b; }
-
+  a: b;
+}
 E:last-child {
-  a: b; }
-
+  a: b;
+}
 E:first-of-type {
-  a: b; }
-
+  a: b;
+}
 E:last-of-type {
-  a: b; }
-
+  a: b;
+}
 E:only-child {
-  a: b; }
-
+  a: b;
+}
 E:only-of-type {
-  a: b; }
-
+  a: b;
+}
 E:empty {
-  a: b; }
-
+  a: b;
+}
 E:link {
-  a: b; }
-
+  a: b;
+}
 E:visited {
-  a: b; }
-
+  a: b;
+}
 E:active {
-  a: b; }
-
+  a: b;
+}
 E:hover {
-  a: b; }
-
+  a: b;
+}
 E:focus {
-  a: b; }
-
+  a: b;
+}
 E:target {
-  a: b; }
-
+  a: b;
+}
 E:lang(fr) {
-  a: b; }
-
+  a: b;
+}
 E:enabled {
-  a: b; }
-
+  a: b;
+}
 E:disabled {
-  a: b; }
-
+  a: b;
+}
 E:checked {
-  a: b; }
-
+  a: b;
+}
 E::first-line {
-  a: b; }
-
+  a: b;
+}
 E::first-letter {
-  a: b; }
-
+  a: b;
+}
 E::before {
-  a: b; }
-
+  a: b;
+}
 E::after {
-  a: b; }
-
+  a: b;
+}
 E.warning {
-  a: b; }
-
+  a: b;
+}
 E#myid {
-  a: b; }
-
+  a: b;
+}
 E:not(s) {
-  a: b; }
-
+  a: b;
+}
 E F {
-  a: b; }
-
+  a: b;
+}
 E > F {
-  a: b; }
-
+  a: b;
+}
 E + F {
-  a: b; }
-
+  a: b;
+}
 E ~ F {
-  a: b; }
-
+  a: b;
+}
 @supports (a: b) and (c: d) or (not (d: e)) and ((not (f: g)) or (not ((h: i) and (j: k)))) {
   .foo {
-    a: b; } }
+    a: b;
+  }
+}
 @-prefix-supports (a: b) and (c: d) or (not (d: e)) and ((not (f: g)) or (not ((h: i) and (j: k)))) {
   .foo {
-    a: b; } }
-
+    a: b;
+  }
+}
 foo {
   foo: bar;
   #baz: bang;
-  #bip: bop; }
-
+  #bip: bop;
+}
 foo {
   a: -2;
   b: -2.3em;
   c: -50%;
-  d: -foo(bar baz); }
-
+  d: -foo(bar baz);
+}
 foo {
   a: -0.5em;
   b: 0.5em;
   c: -foo(12px);
-  d: +foo(12px); }
-
+  d: +foo(12px);
+}
 foo {
   -moz-foo-bar: blat;
-  -o-flat-blang: wibble; }
-
+  -o-flat-blang: wibble;
+}
 foo {
   a: foo();
-  b: bar baz-bang() bip; }
-
+  b: bar baz-bang() bip;
+}
 .alpha {
   color: #1f2526bf;
-  background-color: #1f2526ff; }
-
+  background-color: #1f2526ff;
+}
 .shortcode-4c29f540779d8549daf934275faea11 {
-  color: red; }
+  color: red;
+}

--- a/tests/outputs/selector_functions.css
+++ b/tests/outputs/selector_functions.css
@@ -2,128 +2,131 @@
   content: ".foo";
   content: ".bar";
   content: ".foo2 .bar2";
-  content: ".foo3 > .bar3"; }
-
+  content: ".foo3 > .bar3";
+}
 .main aside:hover, .sidebar p {
   content: ".main aside:hover";
-  content: ".sidebar p"; }
-
+  content: ".sidebar p";
+}
 .is-superselector {
   content: false;
-  /* false */ }
-
+  /* false */
+}
 .is-superselector1 {
   content: true;
-  /*true*/ }
-
+  /*true*/
+}
 .is-superselector2 {
   content: true;
-  /*true*/ }
-
+  /*true*/
+}
 .is-superselector3 {
   content: true;
-  /*true*/ }
-
+  /*true*/
+}
 .is-superselector4 {
   content: false;
-  /*false*/ }
-
+  /*false*/
+}
 .is-superselector5 {
   content: true;
-  /* true*/ }
-
+  /* true*/
+}
 .is-superselector6 {
   content: false;
-  /* false*/ }
-
+  /* false*/
+}
 .is-superselector7 {
   content: true;
-  /* true*/ }
-
+  /* true*/
+}
 .is-superselector8 {
   content: false;
-  /* false*/ }
-
+  /* false*/
+}
 .is-superselector9 {
   content: true;
-  /* true*/ }
-
+  /* true*/
+}
 a.disabled {
-  content: 'a.disabled'; }
-
+  content: 'a.disabled';
+}
 .accordion__copy {
-  content: '.accordion__copy'; }
-
+  content: '.accordion__copy';
+}
 .accordion__copy, .accordion__image {
-  content: '.accordion__copy, .accordion__image'; }
-
+  content: '.accordion__copy, .accordion__image';
+}
 .accordion__copy, .slider__copy, .accordion__image, .slider__image {
-  content: '.accordion__copy, .slider__copy, .accordion__image, .slider__image'; }
-
+  content: '.accordion__copy, .slider__copy, .accordion__image, .slider__image';
+}
 a.disabled, .disabled.link {
-  content: "a.disabled, .link.disabled"; }
-
+  content: "a.disabled, .link.disabled";
+}
 a.disabled {
-  content: "a.disabled"; }
-
+  content: "a.disabled";
+}
 .guide .info, .guide .content nav.sidebar, .content .guide nav.sidebar {
-  content: ".guide .info, .guide .content nav.sidebar, .content .guide nav.sidebar"; }
-
+  content: ".guide .info, .guide .content nav.sidebar, .content .guide nav.sidebar";
+}
 ul li {
-  content: "ul li"; }
-
+  content: "ul li";
+}
 .alert p, .warning p {
-  content: ".alert p, .warning p"; }
-
+  content: ".alert p, .warning p";
+}
 .alert:hover {
-  content: ".alert:hover"; }
-
+  content: ".alert:hover";
+}
 .accordion__copy {
-  content: ".accordion__copy"; }
-  .main aside:hover {
-    content: ".main";
-    content: "aside:hover"; }
-  .sidebar p {
-    content: ".sidebar";
-    content: "p"; }
-
+  content: ".accordion__copy";
+}
+.main aside:hover {
+  content: ".main";
+  content: "aside:hover";
+}
+.sidebar p {
+  content: ".sidebar";
+  content: "p";
+}
 .disabled.link {
-  content: ".link.disabled"; }
-
+  content: ".link.disabled";
+}
 a.disabled {
-  content: "a.disabled"; }
-
+  content: "a.disabled";
+}
 .guide .content nav.sidebar, .content .guide nav.sidebar {
-  content: ".guide .content nav.sidebar, .content .guide nav.sidebar"; }
-
+  content: ".guide .content nav.sidebar, .content .guide nav.sidebar";
+}
 a, .disabled {
   /* a, .disabled */
   content: "a";
-  content: ".disabled"; }
-
+  content: ".disabled";
+}
 main, .blog, :after {
   /* main, .blog, :after */
   content: "main";
   content: ".blog";
-  content: ":after"; }
-
+  content: ":after";
+}
 a.disabled {
-  content: "a.disabled"; }
-
+  content: "a.disabled";
+}
 a.disabled.outgoing {
-  content: "a.disabled.outgoing"; }
-
+  content: "a.disabled.outgoing";
+}
  {
-  content: "null"; }
-
+  content: "null";
+}
 .warning main a, main .warning a {
-  content: ".warning main a, main .warning a"; }
-
+  content: ".warning main a, main .warning a";
+}
 main.warning a.disabled {
-  content: "main.warning a.disabled"; }
-
+  content: "main.warning a.disabled";
+}
 main .warning a {
-  content: "main .warning a"; }
-
+  content: "main .warning a";
+}
 .class .par1 {
-  content: .class .par1 .test .test2, .par1 .test .class .test2; }
+  content: .class .par1 .test .test2, .par1 .test .class .test2;
+}

--- a/tests/outputs/selectors.css
+++ b/tests/outputs/selectors.css
@@ -1,377 +1,387 @@
 @charset "UTF-8";
 * {
-  color: blue; }
-
+  color: blue;
+}
 E {
-  color: blue; }
-
+  color: blue;
+}
 E:not(:link) {
-  color: blue; }
-
+  color: blue;
+}
 E:not(:link):not(:visited) {
-  color: blue; }
-
+  color: blue;
+}
 E:not(:link, :visited) {
-  color: blue; }
-
+  color: blue;
+}
 E:matches(:hover, :focus) {
-  color: blue; }
-
+  color: blue;
+}
 E.warning {
-  color: blue; }
-
+  color: blue;
+}
 E#id {
-  color: blue; }
-
+  color: blue;
+}
 E[foo] {
-  color: blue; }
-
+  color: blue;
+}
 E[foo="barbar"] {
-  color: blue; }
-
+  color: blue;
+}
 E[foo="barbar" i] {
-  color: blue; }
-
+  color: blue;
+}
 E[foo~="hello#$@%@$#^"] {
-  color: blue; }
-
+  color: blue;
+}
 E[foo^="color: green;"] {
-  color: blue; }
-
+  color: blue;
+}
 E[foo$="239023"] {
-  color: blue; }
-
+  color: blue;
+}
 E[foo*="29302"] {
-  color: blue; }
-
+  color: blue;
+}
 E[foo|="239032"] {
-  color: blue; }
-
+  color: blue;
+}
 [foo] {
-  color: blue; }
-
+  color: blue;
+}
 [foo] .helloWorld {
-  color: blue; }
-
+  color: blue;
+}
 [foo].helloWorld {
-  color: blue; }
-
+  color: blue;
+}
 [foo="barbar"] {
-  color: blue; }
-
+  color: blue;
+}
 [foo~="hello#$@%@$#^"] {
-  color: blue; }
-
+  color: blue;
+}
 [foo^="color: green;"] {
-  color: blue; }
-
+  color: blue;
+}
 [foo$="239023"] {
-  color: blue; }
-
+  color: blue;
+}
 [foo*="29302"] {
-  color: blue; }
-
+  color: blue;
+}
 [foo|="239032"] {
-  color: blue; }
-
+  color: blue;
+}
 E:dir(ltr) {
-  color: blue; }
-
+  color: blue;
+}
 E:lang(en) {
-  color: blue; }
-
+  color: blue;
+}
 E:lang(en, fr) {
-  color: blue; }
-
+  color: blue;
+}
 E:any-link {
-  color: blue; }
-
+  color: blue;
+}
 E:link {
-  color: blue; }
-
+  color: blue;
+}
 E:visited {
-  color: blue; }
-
+  color: blue;
+}
 E:local-link {
-  color: blue; }
-
+  color: blue;
+}
 E:local-link(0) {
-  color: red; }
-
+  color: red;
+}
 E:local-link(1) {
-  color: white; }
-
+  color: white;
+}
 E:local-link(2) {
-  color: red; }
-
+  color: red;
+}
 E:target {
-  color: blue; }
-
+  color: blue;
+}
 E:scope {
-  color: blue; }
-
+  color: blue;
+}
 E:current {
-  color: blue; }
-
+  color: blue;
+}
 E:current(:link) {
-  color: blue; }
-
+  color: blue;
+}
 E:past {
-  color: blue; }
-
+  color: blue;
+}
 E:future {
-  color: blue; }
-
+  color: blue;
+}
 E:active {
-  color: blue; }
-
+  color: blue;
+}
 E:hover {
-  color: blue; }
-
+  color: blue;
+}
 E:focus {
-  color: blue; }
-
+  color: blue;
+}
 E:enabled {
-  color: blue; }
-
+  color: blue;
+}
 E:disabled {
-  color: blue; }
-
+  color: blue;
+}
 E:indeterminate {
-  color: blue; }
-
+  color: blue;
+}
 E:default {
-  color: blue; }
-
+  color: blue;
+}
 E:in-range {
-  color: blue; }
-
+  color: blue;
+}
 E:out-of-range {
-  color: blue; }
-
+  color: blue;
+}
 E:required {
-  color: blue; }
-
+  color: blue;
+}
 E:optional {
-  color: blue; }
-
+  color: blue;
+}
 E:read-only {
-  color: blue; }
-
+  color: blue;
+}
 E:read-write {
-  color: blue; }
-
+  color: blue;
+}
 E:root {
-  color: blue; }
-
+  color: blue;
+}
 E:empty {
-  color: blue; }
-
+  color: blue;
+}
 E:first-child {
-  color: blue; }
-
+  color: blue;
+}
 E:nth-child(odd) {
-  color: blue; }
-
+  color: blue;
+}
 E:nth-child(2n+1) {
-  color: blue; }
-
+  color: blue;
+}
 E:nth-child(5) {
-  color: blue; }
-
+  color: blue;
+}
 E:last-child {
-  color: blue; }
-
+  color: blue;
+}
 E:nth-last-child(-n+2) {
-  color: blue; }
-
+  color: blue;
+}
 E:only-child {
-  color: blue; }
-
+  color: blue;
+}
 E:first-of-type {
-  color: blue; }
-
+  color: blue;
+}
 E:nth-of-type(2n) {
-  color: blue; }
-
+  color: blue;
+}
 E:last-of-type {
-  color: blue; }
-
+  color: blue;
+}
 E:nth-last-of-type(n) {
-  color: blue; }
-
+  color: blue;
+}
 E:only-of-type {
-  color: blue; }
-
+  color: blue;
+}
 E:nth-match(odd) {
-  color: blue; }
-
+  color: blue;
+}
 E:nth-last-match(odd) {
-  color: blue; }
-
+  color: blue;
+}
 E:column(n) {
-  color: blue; }
-
+  color: blue;
+}
 E:nth-column(n) {
-  color: blue; }
-
+  color: blue;
+}
 E:nth-last-column(n) {
-  color: blue; }
-
+  color: blue;
+}
 E F {
-  color: blue; }
-
+  color: blue;
+}
 E > F {
-  color: blue; }
-
+  color: blue;
+}
 E + F {
-  color: blue; }
-
+  color: blue;
+}
 E ~ F {
-  color: blue; }
-
+  color: blue;
+}
 E! > F {
-  color: blue; }
-
+  color: blue;
+}
 [foo|att=val] {
-  color: blue; }
-
+  color: blue;
+}
 [*|att] {
-  color: yellow; }
-
+  color: yellow;
+}
 [|att] {
-  color: green; }
-
+  color: green;
+}
 [att] {
-  color: green; }
-
+  color: green;
+}
 E::first-line {
-  color: blue; }
-
+  color: blue;
+}
 E::first-letter {
-  color: blue; }
-
+  color: blue;
+}
 E::before {
-  color: blue; }
-
+  color: blue;
+}
 E::after {
-  color: blue; }
-
+  color: blue;
+}
 E::choices {
-  color: blue; }
-
+  color: blue;
+}
 E::value {
-  color: blue; }
-
+  color: blue;
+}
 E::repeat-index {
-  color: blue; }
-
+  color: blue;
+}
 E::repeat-item {
-  color: blue; }
-
+  color: blue;
+}
 E:first {
-  color: blue; }
-
+  color: blue;
+}
 E:first-line {
-  color: blue; }
-
+  color: blue;
+}
 E:first-letter {
-  color: blue; }
-
+  color: blue;
+}
 E:before {
-  color: blue; }
-
+  color: blue;
+}
 E:after {
-  color: blue; }
-
+  color: blue;
+}
 E:checked {
-  color: blue; }
-
+  color: blue;
+}
 E:invalid {
-  color: blue; }
-
+  color: blue;
+}
 E:valid {
-  color: blue; }
-
+  color: blue;
+}
 E:left {
-  color: blue; }
-
+  color: blue;
+}
 E:right {
-  color: blue; }
-
+  color: blue;
+}
 E:any(ol) {
-  color: blue; }
-
+  color: blue;
+}
 E::selection {
-  color: blue; }
-
+  color: blue;
+}
 div {
   font: something;
-    font-size: 30em; }
-  div font:something {
-    size: 30em; }
-
+  font-size: 30em;
+}
+div font:something {
+  size: 30em;
+}
 .something.world {
-  color: blue; }
+  color: blue;
+}
 .something .mold {
-  height: 200px; }
+  height: 200px;
+}
 .dog .something {
-  color: blue; }
-
+  color: blue;
+}
 .dad .simple .wolf {
-  color: blue; }
+  color: blue;
+}
 .rad.simple.bad {
-  color: blue; }
-
+  color: blue;
+}
 .something div .what.world {
-  color: blue; }
-
+  color: blue;
+}
 div.foo div {
-  color: blue; }
+  color: blue;
+}
 div + div {
-  color: green; }
-
+  color: green;
+}
 .nice-fonts .main .message div .title, .nice-fonts div .message div .title {
-  font-size: 24px; }
-
+  font-size: 24px;
+}
 .escape\% {
-  color: red; }
-
+  color: red;
+}
 .escape-plan\% {
-  color: green; }
-
+  color: green;
+}
 .element .one, .element .two {
-  property: value; }
-
+  property: value;
+}
 #secondary h1, #secondary h2, #secondary h3, #secondary h4, #secondary h5, #secondary h6 {
-  color: #e6e6e6; }
-
+  color: #e6e6e6;
+}
 .test foo, .test bar {
-  border: 1px dashed red; }
-
+  border: 1px dashed red;
+}
 span a, p a, div a {
-  color: red; }
-
+  color: red;
+}
 .parent.self {
-  content: "should match .parent.self"; }
+  content: "should match .parent.self";
+}
 .parent .child {
-  content: "should match .parent .child"; }
+  content: "should match .parent .child";
+}
 .parent.self2 {
-  content: "should match .parent.self2"; }
-
+  content: "should match .parent.self2";
+}
 .parent.self1, .parent.self2 {
-  content: "should match .parent.self1, .parent.self2"; }
+  content: "should match .parent.self1, .parent.self2";
+}
 .self1 .parent {
-  content: "should match .self1 .parent"; }
+  content: "should match .self1 .parent";
+}
 .parent + .parent {
-  content: "should match .parent + .parent"; }
-
+  content: "should match .parent + .parent";
+}
 ul ul, ol ul, ul ol, ol ol {
-  display: block; }
-
+  display: block;
+}
 .👤 {
-  display: inline-block; }
-
+  display: inline-block;
+}
 .❮ {
   display: inline;
-  content: '↦'; }
+  content: '↦';
+}

--- a/tests/outputs/shorthand.css
+++ b/tests/outputs/shorthand.css
@@ -52,4 +52,5 @@ div {
   border-radius: 10px 2.5% 30px;
   /* these are shorthands with wrong values (lack of unit but more than 4 values if this is a division)*/
   border-radius: 10px 5px 2em / 20 25px 30%;
-  border-radius: 10px 5% / 20 25em 30px 35em; }
+  border-radius: 10px 5% / 20 25em 30px 35em;
+}

--- a/tests/outputs/string_escaping.css
+++ b/tests/outputs/string_escaping.css
@@ -149,4 +149,5 @@
   content: ",";
   content: "-";
   content: ".";
-  content: "/"; }
+  content: "/";
+}

--- a/tests/outputs/supports.css
+++ b/tests/outputs/supports.css
@@ -1,72 +1,120 @@
 @supports (animation-name: test) {
   foo {
-    a: b; } }
+    a: b;
+  }
+}
 @supports (transform-origin: 5% 5%) {
   foo {
-    a: b; } }
+    a: b;
+  }
+}
 @supports selector(A > B) {
   foo {
-    a: b; } }
+    a: b;
+  }
+}
 @supports not (transform-origin: 10em 10em 10em) {
   foo {
-    a: b; } }
+    a: b;
+  }
+}
 @supports not (not (transform-origin: 2px)) {
   foo {
-    a: b; } }
+    a: b;
+  }
+}
 @supports (display: grid) and (display: inline-grid) {
   foo {
-    a: b; } }
+    a: b;
+  }
+}
 @supports (display: grid) and (not (display: inline-grid)) {
   foo {
-    a: b; } }
+    a: b;
+  }
+}
 @supports (display: table-cell) and (display: list-item) {
   foo {
-    a: b; } }
+    a: b;
+  }
+}
 @supports (display: table-cell) and (display: list-item) and (display:run-in) {
   foo {
-    a: b; } }
+    a: b;
+  }
+}
 @supports (display: table-cell) and ((display: list-item) and (display:run-in)) {
   foo {
-    a: b; } }
+    a: b;
+  }
+}
 @supports (display: table-cell) and ((display: list-item) or (display:run-in)) {
   foo {
-    a: b; } }
+    a: b;
+  }
+}
 @supports (transform-style: preserve) or (-moz-transform-style: preserve) {
   foo {
-    a: b; } }
+    a: b;
+  }
+}
 @supports (transform-style: preserve) or (-moz-transform-style: preserve) or (-o-transform-style: preserve) or (-webkit-transform-style: preserve) {
   foo {
-    a: b; } }
+    a: b;
+  }
+}
 @supports (transform-style: preserve-3d) or ((-moz-transform-style: preserve-3d) or ((-o-transform-style: preserve-3d) or (-webkit-transform-style: preserve-3d))) {
   foo {
-    a: b; } }
+    a: b;
+  }
+}
 @supports not ((text-align-last: justify) or (-moz-text-align-last: justify)) {
   foo {
-    a: b; } }
+    a: b;
+  }
+}
 @supports (--foo: green) {
   foo {
-    a: b; } }
+    a: b;
+  }
+}
 @supports not selector(:is(a, b)) {
   foo {
-    a: b; } }
+    a: b;
+  }
+}
 @supports selector(:nth-child(1n of a, b)) {
   foo {
-    a: b; } }
+    a: b;
+  }
+}
 @supports (feature1: val) {
   foo {
-    a: b; } }
+    a: b;
+  }
+}
 @supports ((feature1: val)) {
   foo {
-    a: b; } }
+    a: b;
+  }
+}
 @supports (feature2: val) {
   foo {
-    a: b; } }
+    a: b;
+  }
+}
 @supports (not (feature23: val4)) {
   foo {
-    a: b; } }
+    a: b;
+  }
+}
 @supports ((feature1: val) and (feature2: val)) {
   foo {
-    a: b; } }
+    a: b;
+  }
+}
 @supports ((feature1: val) and (feature2: val)) or (not (feature23: val4)) {
   foo {
-    a: b; } }
+    a: b;
+  }
+}

--- a/tests/outputs/values.css
+++ b/tests/outputs/values.css
@@ -13,8 +13,8 @@
   margin: 4, 3, 1;
   content: "This is a multiline string.";
   border-radius: -1px -1px -1px black;
-  grid-template-columns: [avatar] 2fr [body] 6fr; }
-
+  grid-template-columns: [avatar] 2fr [body] 6fr;
+}
 #subtraction {
   lit: 10 -11;
   lit: -1;
@@ -23,22 +23,23 @@
   var: -90;
   var: -90;
   var: -90;
-  var: -90; }
-
+  var: -90;
+}
 #special {
-  a: 12px expression(1 + (3 / Foo.bar("baz" + "bang") + function() {return 12;}) % 12); }
-
+  a: 12px expression(1 + (3 / Foo.bar("baz" + "bang") + function() {return 12;}) % 12);
+}
 #unary {
   b: 0.5em;
   c: -foo(12px);
-  d: +foo(12px); }
-
+  d: +foo(12px);
+}
 #self {
-  content: "#self"; }
-
+  content: "#self";
+}
 @font-face {
   unicode-range: U+26;
   unicode-range: U+0-7F;
   unicode-range: U+0025-00FF;
   unicode-range: U+4??;
-  unicode-range: U+0025-00FF, U+4??; }
+  unicode-range: U+0025-00FF, U+4??;
+}

--- a/tests/outputs/variables.css
+++ b/tests/outputs/variables.css
@@ -1,39 +1,41 @@
 div {
-  height: red, two, three; }
-
+  height: red, two, three;
+}
 div {
-  num: 1000; }
-
+  num: 1000;
+}
 div {
-  num: 2000; }
-
+  num: 2000;
+}
 pre {
-  color: blue; }
-
+  color: blue;
+}
 cool: 100px;
 del {
-  color: blue; }
-  del div pre {
-    color: red; }
-
+  color: blue;
+}
+del div pre {
+  color: red;
+}
 body {
   font-family: Arial;
   font-family: Helvetica Neue;
   font-family: "Helvetica Neue";
   font-family: Helvetica, Arial, sans-serif;
-  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif; }
-
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
 #main {
-  width: 5em; }
-
+  width: 5em;
+}
 #sidebar {
-  width: 5em; }
-
+  width: 5em;
+}
 A {
-  color: green; }
-
+  color: green;
+}
 body {
-  color: #000; }
-
+  color: #000;
+}
 * {
-  data: 12; }
+  data: 12;
+}


### PR DESCRIPTION
Closes #162 

TODOs:
- [x] Decide whether `setFormatter($className)` should be deprecated in favor of an API allowing only supported output styles (see the discussion in the issue) and implement it if needed