### PR TITLE
Fix the implementation of == and != between number and colors

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -3766,6 +3766,14 @@ class Compiler
      */
     protected function opColorNumber($op, $left, Number $right)
     {
+        if ($op === '==') {
+            return static::$false;
+        }
+
+        if ($op === '!=') {
+            return static::$true;
+        }
+
         $value = $right->getDimension();
 
         return $this->opColorColor(
@@ -3786,6 +3794,14 @@ class Compiler
      */
     protected function opNumberColor($op, Number $left, $right)
     {
+        if ($op === '==') {
+            return static::$false;
+        }
+
+        if ($op === '!=') {
+            return static::$true;
+        }
+
         $value = $left->getDimension();
 
         return $this->opColorColor(

--- a/tests/inputs/operators.scss
+++ b/tests/inputs/operators.scss
@@ -48,6 +48,11 @@ div {
 
     color: blue + 34;
 
+    color: #fff == 255;
+    color: #fff != 255;
+    color: 255 == #fff;
+    color: 255 != #fff;
+
     color: #fff == #000;
     color: #fff == #fff;
 

--- a/tests/outputs/operators.css
+++ b/tests/outputs/operators.css
@@ -38,6 +38,10 @@ div {
   color: #22f;
   color: false;
   color: true;
+  color: false;
+  color: true;
+  color: false;
+  color: true;
   color: true;
   color: false; }
 


### PR DESCRIPTION
Converting the number to a color and calling `opColorColor` is not OK for `==` and `!=` operators. Even when supporting color arithmetic, a number was never equal to a color.