### PR TITLE
Fix spec compliance for the call function

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -5369,7 +5369,7 @@ class Compiler
         }
         @list($sorted, $kwargs) = $sorted_kwargs;
 
-        if ($name !== 'if' && $name !== 'call') {
+        if ($name !== 'if') {
             $inExp = true;
 
             if ($name === 'join') {
@@ -6416,10 +6416,10 @@ class Compiler
     protected static $libCall = ['function', 'args...'];
     protected function libCall($args, $kwargs)
     {
-        $functionReference = $this->reduce(array_shift($args), true);
+        $functionReference = array_shift($args);
 
         if (in_array($functionReference[0], [Type::T_STRING, Type::T_KEYWORD])) {
-            $name = $this->compileStringContent($this->coerceString($this->reduce($functionReference, true)));
+            $name = $this->compileStringContent($this->coerceString($functionReference));
             $warning = "DEPRECATION WARNING: Passing a string to call() is deprecated and will be illegal\n"
                 . "in Sass 4.0. Use call(function-reference($name)) instead.";
             fwrite($this->stderr, "$warning\n\n");
@@ -6457,11 +6457,11 @@ class Compiler
     ];
     protected function libGetFunction($args)
     {
-        $name = $this->compileStringContent($this->coerceString($this->reduce(array_shift($args), true)));
+        $name = $this->compileStringContent($this->coerceString(array_shift($args)));
         $isCss = false;
 
         if (count($args)) {
-            $isCss = $this->reduce(array_shift($args), true);
+            $isCss = array_shift($args);
             $isCss = (($isCss === static::$true) ? true : false);
         }
 


### PR DESCRIPTION
The call function does not have any special evaluation behavior for its arguments, even when calling the special if() function.

Fixes #216 
Specs for that issue have been submitted upstream at https://github.com/sass/sass-spec/pull/1588. I confirmed locally that these specs are indeed failing without this patch and passing with it.