### PR TITLE
Fix the behavior of to-uppercase and to-lowercase

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -7663,7 +7663,7 @@ class Compiler
         $string = $this->coerceString($args[0]);
         $stringContent = $this->compileStringContent($string);
 
-        $string[2] = [\function_exists('mb_strtolower') ? mb_strtolower($stringContent) : strtolower($stringContent)];
+        $string[2] = [strtolower($stringContent)];
 
         return $string;
     }
@@ -7674,7 +7674,7 @@ class Compiler
         $string = $this->coerceString($args[0]);
         $stringContent = $this->compileStringContent($string);
 
-        $string[2] = [\function_exists('mb_strtoupper') ? mb_strtoupper($stringContent) : strtoupper($stringContent)];
+        $string[2] = [strtoupper($stringContent)];
 
         return $string;
     }

--- a/tests/specs/sass-spec-exclude.txt
+++ b/tests/specs/sass-spec-exclude.txt
@@ -714,9 +714,7 @@ core_functions/string/slice/error/type/start_at
 core_functions/string/slice/error/type/string
 core_functions/string/slice/start/positive/after_end
 core_functions/string/to_lower_case/error/type
-core_functions/string/to_lower_case/non_ascii
 core_functions/string/to_upper_case/error/type
-core_functions/string/to_upper_case/non_ascii
 core_functions/string/unique_id/error/too_many_args
 core_functions/string/unquote/error/type
 css/comment/error/loud/unterminated/scss


### PR DESCRIPTION
These Sass functions are meant to change case of ASCII chars only.