### PR TITLE
Fix the behavior of str-index

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -7599,7 +7599,7 @@ class Compiler
         if (! \strlen($substringContent)) {
             $result = 0;
         } else {
-            $result = strpos($stringContent, $substringContent);
+            $result = Util::mbStrpos($stringContent, $substringContent);
         }
 
         return $result === false ? static::$null : new Number($result + 1, '');

--- a/src/Util.php
+++ b/src/Util.php
@@ -157,4 +157,17 @@ class Util
 
         return substr($string, $start, $length);
     }
+
+    public static function mbStrpos($haystack, $needle, $offset = 0)
+    {
+        if (\function_exists('mb_strpos')) {
+            return mb_strpos($haystack, $needle, $offset, 'UTF-8');
+        }
+
+        if (\function_exists('iconv_strpos')) {
+            return iconv_strpos($haystack, $needle, $offset, 'UTF-8');
+        }
+
+        return strpos($haystack, $needle, $offset);
+    }
 }

--- a/tests/specs/sass-spec-exclude.txt
+++ b/tests/specs/sass-spec-exclude.txt
@@ -701,8 +701,6 @@ core_functions/selector/unify/simple/universal/and_universal/empty/and_explicit
 core_functions/selector/unify/simple/universal/and_universal/explicit/and_any
 core_functions/selector/unify/simple/universal/and_universal/explicit/and_default
 core_functions/selector/unify/simple/universal/and_universal/explicit/and_empty
-core_functions/string/index/combining_character
-core_functions/string/index/double_width_character
 core_functions/string/quote/error/type
 core_functions/string/slice/double_width_character
 core_functions/string/slice/empty/end/0


### PR DESCRIPTION
It must count unicode codepoints, not bytes. The implementation is now compliant with mbstring or with iconv.