### PR TITLE
Fix the matching of the space ending an escape sequence

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -3004,6 +3004,10 @@ class Parser
                 }
             }
 
+            // CSS allows Unicode escape sequences to be followed by a delimiter space
+            // (necessary in some cases for shorter sequences to disambiguate their end)
+            $this->matchChar(' ', false);
+
             $value = hexdec($hex);
 
             if (!$inKeywords && ($value == 0 || ($value >= 0xD800 && $value <= 0xDFFF) || $value >= 0x10FFFF)) {
@@ -3678,8 +3682,8 @@ class Parser
         $s = $this->count;
         $match = $this->match(
             $this->utf8
-                ? '(([\pL\w\x{00A0}-\x{10FFFF}_\-\*!"\']|[\\\\].)([\pL\w\x{00A0}-\x{10FFFF}\-_"\']|[\\\\].)*)'
-                : '(([\w_\-\*!"\']|[\\\\].)([\w\-_"\']|[\\\\].)*)',
+                ? '(([\pL\w\x{00A0}-\x{10FFFF}_\-\*!"\']|\\\\[a-f0-9]{6} ?|\\\\[a-f0-9]{1,5}(?![a-f0-9]) ?|[\\\\].)([\pL\w\x{00A0}-\x{10FFFF}\-_"\']|\\\\[a-f0-9]{6} ?|\\\\[a-f0-9]{1,5}(?![a-f0-9]) ?|[\\\\].)*)'
+                : '(([\w_\-\*!"\']|\\\\[a-f0-9]{6} ?|\\\\[a-f0-9]{1,5}(?![a-f0-9]) ?|[\\\\].)([\w\-_"\']|\\\\[a-f0-9]{6} ?|\\\\[a-f0-9]{1,5}(?![a-f0-9]) ?|[\\\\].)*)',
             $m,
             false
         );

--- a/tests/outputs/scss_css.css
+++ b/tests/outputs/scss_css.css
@@ -149,14 +149,14 @@ E > F, G > H {
 foo {
   a: \f oo bar;
   b: foo\ bar;
-  c: •  ;
+  c: • ;
   d: foo\\bar;
   e: foo\"\'bar; }
 
 foo {
   a: "\foo bar";
   b: "foo bar";
-  c: "•  ";
+  c: "• ";
   d: "foo\\bar";
   e: "foo\"'bar"; }
 

--- a/tests/specs/sass-spec-exclude.txt
+++ b/tests/specs/sass-spec-exclude.txt
@@ -840,8 +840,6 @@ libsass-closed-issues/issue_1415/variable
 libsass-closed-issues/issue_1417
 libsass-closed-issues/issue_1418/dynamic
 libsass-closed-issues/issue_1418/static
-libsass-closed-issues/issue_1419/quoted
-libsass-closed-issues/issue_1419/unquoted
 libsass-closed-issues/issue_1422
 libsass-closed-issues/issue_1425
 libsass-closed-issues/issue_1452
@@ -1320,7 +1318,6 @@ non_conformant/scss/simple-inheritance
 non_conformant/scss/strings
 non_conformant/scss/vars
 non_conformant/scss/while_without_condition
-values/identifiers/escape/script
 values/maps/duplicate-keys
 values/maps/errors
 values/maps/invalid-key


### PR DESCRIPTION
Unicode escape sequence can end with a space to delimit them from the next char. This space is always allowed, and is necessary when the sequence is shorter than 6 chars and the next char would be is part of the hex alphabet (as it would be valid as part of the sequence). See https://drafts.csswg.org/css-syntax/#consume-escaped-code-point

This fixes will allow #226 to also validate the `core_functions/string/index/combining_character` spec (which uses such an escape sequence).