### PR TITLE
Forbid using our own deprecated APIs outside legacy tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
         "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5 || ^8.3 || ^9.4",
         "sass/sass-spec": "2020.10.29",
         "squizlabs/php_codesniffer": "~3.5",
+        "symfony/phpunit-bridge": "^5.1",
         "twbs/bootstrap": "~4.3",
         "zurb/foundation": "~6.5"
     },

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -6903,7 +6903,7 @@ class Compiler
         $color = $this->coerceColor($args[0]);
 
         if (\is_null($color)) {
-            $this->throwError('Error: argument `$color` of `ie-hex-str($color)` must be a color');
+            throw $this->error('Error: argument `$color` of `ie-hex-str($color)` must be a color');
         }
 
         $color[4] = isset($color[4]) ? round(255 * $color[4]) : 255;
@@ -6917,7 +6917,7 @@ class Compiler
         $color = $this->coerceColor($args[0]);
 
         if (\is_null($color)) {
-            $this->throwError('Error: argument `$color` of `red($color)` must be a color');
+            throw $this->error('Error: argument `$color` of `red($color)` must be a color');
         }
 
         return $color[1];
@@ -6929,7 +6929,7 @@ class Compiler
         $color = $this->coerceColor($args[0]);
 
         if (\is_null($color)) {
-            $this->throwError('Error: argument `$color` of `green($color)` must be a color');
+            throw $this->error('Error: argument `$color` of `green($color)` must be a color');
         }
 
         return $color[2];
@@ -6941,7 +6941,7 @@ class Compiler
         $color = $this->coerceColor($args[0]);
 
         if (\is_null($color)) {
-            $this->throwError('Error: argument `$color` of `blue($color)` must be a color');
+            throw $this->error('Error: argument `$color` of `blue($color)` must be a color');
         }
 
         return $color[3];


### PR DESCRIPTION
When using an API for which we trigger a deprecation warning, the testsuite will now report a failure, unless the test triggering it is in the `legacy` group (we don't have any right now, as we don't have BC tests ensuring the deprecated APIs keep working the same). This ensures that the core does not trigger its own deprecations.

Here is how the output looks like (that's what I got when running tests locally before fixing the `Compiler.php` code): 
![image](https://user-images.githubusercontent.com/439401/97816262-59aa4280-1c94-11eb-903c-27bcea4cace5.png)
