### PR TITLE
Expose SassScriptException as a non internal class

### DIFF
--- a/src/Exception/SassScriptException.php
+++ b/src/Exception/SassScriptException.php
@@ -3,11 +3,12 @@
 namespace ScssPhp\ScssPhp\Exception;
 
 /**
- * Internal exception thrown in places not having access to reporting the location.
+ * An exception thrown by SassScript.
  *
- * This class does not implement SassException on purpose, as it should never be returned to the outside code.
- *
- * @internal
+ * This class does not implement SassException on purpose, as it should
+ * never be returned to the outside code. The compilation will catch it
+ * and replace it with a SassException reporting the location of the
+ * error.
  */
 class SassScriptException extends \Exception
 {


### PR DESCRIPTION
When I introduced `SassScriptException` in #188, I tagged it as `@internal`. But that was a mistake. For developers *using* the library, this exception is indeed an internal implementation detail that they will never see. But for developers *extending* SassScript with custom functions, this exception is absolutely not an internal implementation detail. It should actually be the go-to exception for custom function rather than relying on `Compiler::error()`. It avoids needing access to the Compiler to trigger errors (which is why `Number` uses it, and why `SassScriptException` exists in `dart-sass` too, where I got the idea).