### PR TITLE
Add a factory method for SassScriptException with an argument name

### DIFF
--- a/src/Exception/SassScriptException.php
+++ b/src/Exception/SassScriptException.php
@@ -11,4 +11,21 @@ namespace ScssPhp\ScssPhp\Exception;
  */
 class SassScriptException extends \Exception
 {
+    /**
+     * Creates a SassScriptException with support for an argument name.
+     *
+     * This helper ensures a consistent handling of argument names in the
+     * error message, without duplicating it.
+     *
+     * @param string      $message
+     * @param string|null $name    The argument name, without $
+     *
+     * @return SassScriptException
+     */
+    public static function forArgument($message, $name = null)
+    {
+        $varDisplay = !\is_null($name) ? "\${$name}: " : '';
+
+        return new self($varDisplay . $message);
+    }
 }

--- a/src/Node/Number.php
+++ b/src/Node/Number.php
@@ -254,9 +254,7 @@ class Number extends Node implements \ArrayAccess
             return;
         }
 
-        $varDisplay = !\is_null($varName) ? "\${$varName}: " : '';
-
-        throw new SassScriptException(sprintf('%sExpected %s to have no units', $varDisplay, $this));
+        throw SassScriptException::forArgument(sprintf('Expected %s to have no units', $this), $varName);
     }
 
     /**


### PR DESCRIPTION
This ensures consistent formatting of the error with argument name.

For now, this is used only once, but this is because our functions are not using `SassScriptException` yet. But looking in dart-sass, this pattern of using an argument name for the error reporting is very common.
Adding the factory method now rather than when refactoring values allows custom functions to start using it if they want (see #239 making this non-internal).