### PR TITLE
Add a better error rendering of sass errors in pscss

### DIFF
--- a/bin/pscss
+++ b/bin/pscss
@@ -20,6 +20,7 @@ if (version_compare(PHP_VERSION, '5.6') < 0) {
 include __DIR__ . '/../scss.inc.php';
 
 use ScssPhp\ScssPhp\Compiler;
+use ScssPhp\ScssPhp\Exception\SassException;
 use ScssPhp\ScssPhp\OutputStyle;
 use ScssPhp\ScssPhp\Parser;
 use ScssPhp\ScssPhp\Version;
@@ -199,7 +200,12 @@ if ($encoding) {
     $scss->setEncoding($encoding);
 }
 
-echo $scss->compile($data, $inputFile);
+try {
+    echo $scss->compile($data, $inputFile);
+} catch (SassException $e) {
+    fwrite(STDERR, $e->getMessage()."\n");
+    exit(1);
+}
 
 if ($changeDir) {
     chdir($oldWorkingDir);


### PR DESCRIPTION
Instead of relying on PHP's rendering of an uncaught exception, the SassException is caught and its message is displayed. This avoids showing the PHP stack trace which is not relevant for fixing an issue in the sass file.

Before:
```
PHP Fatal error:  Uncaught ScssPhp\ScssPhp\Exception\CompilerException: $number: Expected 25px to have no units: imports/simple.scss on line 4, at column 5
Call Stack:
#0 import imports/simple.scss import.scss on line 10 in /home/stof/src/scssphp/scssphp/src/Compiler.php:5413
Stack trace:
#0 /home/stof/src/scssphp/scssphp/src/Compiler.php(413): ScssPhp\ScssPhp\Compiler->error()
#1 /home/stof/src/scssphp/scssphp/bin/pscss(196): ScssPhp\ScssPhp\Compiler->compile()
#2 {main}
  thrown in /home/stof/src/scssphp/scssphp/src/Compiler.php on line 5413
```

After:
```
$number: Expected 25px to have no units: imports/simple.scss on line 4, at column 5
Call Stack:
#0 import imports/simple.scss import.scss on line 10
```