### PR TITLE
Fix the registration of load paths in pscss

### DIFF
--- a/bin/pscss
+++ b/bin/pscss
@@ -178,7 +178,9 @@ if ($dumpTree) {
 $scss = new Compiler();
 
 if ($loadPaths) {
-    $scss->setImportPaths(explode(PATH_SEPARATOR, $loadPaths));
+    foreach (explode(PATH_SEPARATOR, $loadPaths) as $loadPath) {
+        $scss->addImportPath($loadPath);
+    }
 }
 
 if ($style) {


### PR DESCRIPTION
By making calls to `addImportPath` rather than using `setImportPaths`, the import path based on the current working directory is preserved. While this does not ensure spec compliance for imports (see #242), it makes relative imports mostly work.

I discovered that while trying to use the official sass-spec running with `-c /path/to/bin/pscss`, as that was easier to run a spec that I was working on in my sass-spec clone (the runnner passes the root path of specs as a load path). With this patch applied, such workflow works.