### PR TITLE
Improve the Makefile to ensure vendors are uptodate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
-install-test:
-	mkdir -p vendor/sass
-	cd vendor/sass && git clone https://github.com/sass/sass-spec.git && cd ../..
-
-test:
+test: vendor
 	vendor/bin/phpunit --colors tests
 
-sass-spec:
+sass-spec: vendor
 	TEST_SASS_SPEC=1 vendor/bin/phpunit --colors tests 2>&1 | tee /tmp/sass-spec.log | tail -2
 
-standard:
+standard: vendor
 	vendor/bin/phpcs -s --standard=PSR12 --exclude=PSR12.Properties.ConstantVisibility --extensions=php bin src tests *.php
+
+vendor: composer.json
+	composer update
+	touch $@


### PR DESCRIPTION
Refs #246 

Running `make test` or `make sass-spec` will not automatically run `composer update` if the composer.json was modified since the last time the vendor folder was updated. This avoids forgetting it when a PR is merged to upgrade sass-spec for instance.

For contributors not using `make`, this won't help of course. They will still need to remember running `composer update`, just like the current status quo.