### PR TITLE
Fix #245 : discard comments at the start of re-parsed selectors

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -334,6 +334,11 @@ class Parser
         $this->saveEncoding();
         $this->extractLineNumbers($this->buffer);
 
+        // discard space/comments at the start
+        $this->discardComments = true;
+        $this->whitespace();
+        $this->discardComments = false;
+
         $selector = $this->selectors($out);
 
         $this->restoreEncoding();

--- a/tests/inputs/selectors.scss
+++ b/tests/inputs/selectors.scss
@@ -296,3 +296,10 @@ ul, ol {
   display:inline;
   content:'↦';
 }
+
+// interpolated
+$selector: " ul li";
+$end: ' ';
+#{$selector} a .tocnumber #{$end} {
+        min-width: 100%;
+}

--- a/tests/outputs/selectors.css
+++ b/tests/outputs/selectors.css
@@ -385,3 +385,6 @@ ul ul, ol ul, ul ol, ol ol {
   display: inline;
   content: '↦';
 }
+ul li a .tocnumber {
+  min-width: 100%;
+}


### PR DESCRIPTION
+ test for this case