### PR TITLE
Update website

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,1 +1,3 @@
 Gemfile.lock
+vendor/bundle/
+_site

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,3 +1,6 @@
-serve:
+serve: vendor/bundle
 	# site should be available at http://localhost:4000/scssphp
 	bundle exec jekyll serve
+
+vendor/bundle:
+	bundle install

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,6 +1,10 @@
+.PHONY: serve highlight-css
 serve: vendor/bundle
 	# site should be available at http://localhost:4000/scssphp
 	bundle exec jekyll serve
+
+highlight-css: vendor/bundle
+	bundle exec rougify style github > _sass/_rouge.scss
 
 vendor/bundle:
 	bundle install

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -3,7 +3,7 @@ title: SCSS Compiler in PHP
 current_version: 1.3
 description: >
   SCSS compiler written in PHP
-url: http://scssphp.github.io
+url: https://scssphp.github.io
 baseurl: /scssphp
 repo_url: https://github.com/scssphp/scssphp
 
@@ -18,7 +18,6 @@ exclude:
 - vendor/
 
 # Github Pages
-ghlighter: pygments
 github: [Repository metadata]
 gems:
 - jekyll-mentions

--- a/docs/_sass/_leafo.scss
+++ b/docs/_sass/_leafo.scss
@@ -263,63 +263,10 @@ p {
 }
 
 .highlight {
-    background: #333;
-    color: white;
-    font-size: 14px;
-    padding: 10px;
-    margin: 0 0 15px;
-    box-shadow: 0px 1px 3px rgba(0,0,0, 0.7), inset 0px 0px 0px 1px rgba(255,255,255,0.3);
-    border-radius: 2px;
-    border: 1px solid #222;
-
-    @media (min-width: #{$desktop_width}) {
-        margin: 0 2em 15px;
-    }
-
     pre {
-        margin-top: 0px;
-        margin-bottom: 0px;
-    }
-
-    // builtins
-    .nb {
-        color: #FFA67C;
-    }
-
-    // strings
-    .s, .s1, .s2, .se, .nt {
-        color: #ffe898;
-    }
-
-    // proper names
-    .nc, .vc, .bp {
-        color: #98d9ff;
-    }
-
-    // true, false, nil
-    .kc {
-        color: #acfff0;
-    }
-
-    // function lit, braces, parens
-    .nf, .kt {
-        color: #9fff98;
-    }
-
-    .nv {
-        color: #ff9898;
-    }
-
-    // keywords
-    .k, .kd, .na {
-        color: #cb98ff;
-    }
-
-    .c1, .c2 {
-        color: #929292;
-    }
-
-    .m, .mi, .mf, .mh, .o {
-        color: #9495ff;
+        border-radius: 2px;
+        border: 1px solid #222;
+        padding: 10px;
+        margin: 0 0 15px;
     }
 }

--- a/docs/_sass/_rouge.scss
+++ b/docs/_sass/_rouge.scss
@@ -1,0 +1,209 @@
+.highlight table td { padding: 5px; }
+.highlight table pre { margin: 0; }
+.highlight .cm {
+  color: #999988;
+  font-style: italic;
+}
+.highlight .cp {
+  color: #999999;
+  font-weight: bold;
+}
+.highlight .c1 {
+  color: #999988;
+  font-style: italic;
+}
+.highlight .cs {
+  color: #999999;
+  font-weight: bold;
+  font-style: italic;
+}
+.highlight .c, .highlight .ch, .highlight .cd, .highlight .cpf {
+  color: #999988;
+  font-style: italic;
+}
+.highlight .err {
+  color: #a61717;
+  background-color: #e3d2d2;
+}
+.highlight .gd {
+  color: #000000;
+  background-color: #ffdddd;
+}
+.highlight .ge {
+  color: #000000;
+  font-style: italic;
+}
+.highlight .gr {
+  color: #aa0000;
+}
+.highlight .gh {
+  color: #999999;
+}
+.highlight .gi {
+  color: #000000;
+  background-color: #ddffdd;
+}
+.highlight .go {
+  color: #888888;
+}
+.highlight .gp {
+  color: #555555;
+}
+.highlight .gs {
+  font-weight: bold;
+}
+.highlight .gu {
+  color: #aaaaaa;
+}
+.highlight .gt {
+  color: #aa0000;
+}
+.highlight .kc {
+  color: #000000;
+  font-weight: bold;
+}
+.highlight .kd {
+  color: #000000;
+  font-weight: bold;
+}
+.highlight .kn {
+  color: #000000;
+  font-weight: bold;
+}
+.highlight .kp {
+  color: #000000;
+  font-weight: bold;
+}
+.highlight .kr {
+  color: #000000;
+  font-weight: bold;
+}
+.highlight .kt {
+  color: #445588;
+  font-weight: bold;
+}
+.highlight .k, .highlight .kv {
+  color: #000000;
+  font-weight: bold;
+}
+.highlight .mf {
+  color: #009999;
+}
+.highlight .mh {
+  color: #009999;
+}
+.highlight .il {
+  color: #009999;
+}
+.highlight .mi {
+  color: #009999;
+}
+.highlight .mo {
+  color: #009999;
+}
+.highlight .m, .highlight .mb, .highlight .mx {
+  color: #009999;
+}
+.highlight .sb {
+  color: #d14;
+}
+.highlight .sc {
+  color: #d14;
+}
+.highlight .sd {
+  color: #d14;
+}
+.highlight .s2 {
+  color: #d14;
+}
+.highlight .se {
+  color: #d14;
+}
+.highlight .sh {
+  color: #d14;
+}
+.highlight .si {
+  color: #d14;
+}
+.highlight .sx {
+  color: #d14;
+}
+.highlight .sr {
+  color: #009926;
+}
+.highlight .s1 {
+  color: #d14;
+}
+.highlight .ss {
+  color: #990073;
+}
+.highlight .s, .highlight .sa, .highlight .dl {
+  color: #d14;
+}
+.highlight .na {
+  color: #008080;
+}
+.highlight .bp {
+  color: #999999;
+}
+.highlight .nb {
+  color: #0086B3;
+}
+.highlight .nc {
+  color: #445588;
+  font-weight: bold;
+}
+.highlight .no {
+  color: #008080;
+}
+.highlight .nd {
+  color: #3c5d5d;
+  font-weight: bold;
+}
+.highlight .ni {
+  color: #800080;
+}
+.highlight .ne {
+  color: #990000;
+  font-weight: bold;
+}
+.highlight .nf, .highlight .fm {
+  color: #990000;
+  font-weight: bold;
+}
+.highlight .nl {
+  color: #990000;
+  font-weight: bold;
+}
+.highlight .nn {
+  color: #555555;
+}
+.highlight .nt {
+  color: #000080;
+}
+.highlight .vc {
+  color: #008080;
+}
+.highlight .vg {
+  color: #008080;
+}
+.highlight .vi {
+  color: #008080;
+}
+.highlight .nv, .highlight .vm {
+  color: #008080;
+}
+.highlight .ow {
+  color: #000000;
+  font-weight: bold;
+}
+.highlight .o {
+  color: #000000;
+  font-weight: bold;
+}
+.highlight .w {
+  color: #bbbbbb;
+}
+.highlight {
+  background-color: #f8f8f8;
+}

--- a/docs/css/main.scss
+++ b/docs/css/main.scss
@@ -3,6 +3,4 @@
 ---
 @charset "utf-8";
 
-@import
-    "leafo"
-;
+@import "leafo", "rouge";

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -5,7 +5,7 @@ title: Changelog
 
 ## Changelog
 
-* **1.3** -- Oct 29, 2020
+### **1.3** -- Oct 29, 2020
   * Better `quote()` compliance (Cerdic)
   * Improve string compliance with sass-spec (Cerdic)
   * Fix issue with argument values being swapped (jljr222, Cerdic)
@@ -20,7 +20,8 @@ title: Changelog
   * Deprecate `Compiler::addFeature()` (stof)
   * Move `gh-pages` to `/docs` folder on main branch (stof, robocoder)
   * Add php 8 support for phpunit (adlenton)
-* **1.2.1** -- Sep 7, 2020
+
+### **1.2.1** -- Sep 7, 2020
   * Fix `@import url()` parsing (leonardfischer, Cerdic)
   * Fix various directive parsing issues (zoglo, CatoTH, Cerdic)
   * Fix `min()`, `max()` (Cerdic)
@@ -29,7 +30,8 @@ title: Changelog
   * Fix `call()` argument name (Cerdic)
   * Fix `random()` (Cerdic)
   * Fix `list-separator()` on empty or one element list (Cerdic)
-* **1.2** -- Aug 26, 2020
+
+### **1.2** -- Aug 26, 2020
   * Many, many sass-spec test improvements (stof, Cerdic)
   * Partial fix of special cases in hsl/hsla functions (Cerdic)
   * In certain interpolations, the spec seems to prefer to force a double quote for output strings (Cerdic)
@@ -80,38 +82,44 @@ g to manipulate as a map (Cerdic)
   * Update sass-spec tests (2020.08.20)
   * Update to PSR-12 (robocoder)
   * Add php 8 nightly to Travis CI (robocoder)
-* **1.1.1** -- Jun 4, 2020
+
+### **1.1.1** -- Jun 4, 2020
   * Fix extend and class concatenation (develth, Cerdic)
   * Fix arguments selector issue (stempora, Cerdic)
   * Fix regression when members units are not normalizable (jszczypk, Cerdic)
   * Remove box.json.dist from .gitattributes (reedy)
   * 32-bit fixes for Base64VLQ `encode()` and `unique-id()` (remicollet, robocoder)
   * Fix index of map within list of maps (stempora, robocoder)
-* **1.1.0** -- Apr 21, 2020
+
+### **1.1.0** -- Apr 21, 2020
   * Fix the handling of call traces for exceptions of native functions (stof)
   * Add named call stack entries for imports (stof)
   * Fix leaks in the call stack (stof)
   * Qualify function calls when the compiler can optimize them (stof)
   * Remove deprecated Parser::to() and Parser::show() methods (robocoder)
-* **1.0.9** -- Apr 1, 2020
+
+### **1.0.9** -- Apr 1, 2020
   * Fix parsing issues around `#, +, -, --` (Cerdic)
   * Fix `@import` compatibility (Cerdic)
   * Add vendor-prefixed `scssphp-glob()` function (havutcuoglu, robocoder)
   * Remove PHP version and mbstring.func_overload checks (KryukovDS, robocoder)
   * Fix multiple issues with Bootstrap 4.4.1 and master (fuzegit, Cerdic)
   * Fix variables interpolation bug (Seonic, Cerdic)
-* **1.0.8** -- Feb 20, 2020
+
+### **1.0.8** -- Feb 20, 2020
   * Import of valid scss files fails silently (oyejorge, Cerdic)
   * Undefined $libName (enricobono, robocoder)
   * Fix division and modulo per sass-spec (Cerdic)
   * Fix expressions in at directives (Cerdic)
   * Introduce support for custom properties (Cerdic)
   * Function compatibility issues with functions (abs, ceil, floor, max, min, percentage, random, round), units, and conversions. (Cerdic)
-* **1.0.7** -- Jan 31, 2020
+
+### **1.0.7** -- Jan 31, 2020
   * Fix problem with Bootstrap 4.4 / Responsive containers (nvindice, Cerdic)
   * Fix issue with pseudoelement selectors order in `@extend`'ed elements (CrazyManLabs, Cerdic)
   * `example/Server.php` moved to https://github.com/scssphp/server
-* **1.0.6** -- Dec 12, 2019
+
+### **1.0.6** -- Dec 12, 2019
   * Many sass-spec compatibility fixes (Cerdic)
   * Discriminate shorthands vs real divisions in border-radius property (joakipe, Cerdic)
   * Base64VLQ - 32-bit overflow fixes from Closure implementation (remicollet, robocoder)
@@ -119,12 +127,14 @@ g to manipulate as a map (Cerdic)
   * Variables scope issues (jducro, Cerdic)
   * Using `@extend` creates invalid output with nested classnames (bmbrands, Cerdic)
   * Fixed sourceMapGenerator bug if semicolons are stripped. (ugogon)
-* **1.0.5** -- Oct 3, 2019
+
+### **1.0.5** -- Oct 3, 2019
   * interpolation fixes (Cerdic)
   * phpunit test updates (stof)
   * undefined sourceIndex (connerbw, robocoder)
   * using is_null(), is_dir(), is_file() for consistency (robocoder)
-* **1.0.4** -- Sep 6, 2019
+
+### **1.0.4** -- Sep 6, 2019
   * `border-radius` shorthand support (alex-shul, Cerdic)
   * allow `zip()` function to use all types as arguments (devdot, Cerdic)
   * `@each` forcing unwanted type conversion (devdot)
@@ -132,26 +142,31 @@ g to manipulate as a map (Cerdic)
   * `str-splice` broken in php 7.4
   * composer and travis configuration updates
   * remove obsolete `Base64VLQEncoder` class
-* **1.0.3** -- Aug 7, 2019
+
+### **1.0.3** -- Aug 7, 2019
   * `@at-root`, `@import`, and `url(//host/image.png)` fixes (Cerdic)
   * join operator with interpolated values vs vars or static values (julienmru, Cerdic)
   * Implemented passing Arguments to Content Blocks (jensniedling, Cerdic)
   * Support whitespaces inside :not() (schliesser)
   * Compile non-roots comments also (fabsn182, Cerdic)
-* **1.0.2** -- July 6, 2019
+
+### **1.0.2** -- July 6, 2019
   * Version: actually bump the version number
-* **1.0.1** -- July 6, 2019
+
+### **1.0.1** -- July 6, 2019
   * Fix iteration on map (alexsaalberg049 , Cerdic)
   * More compatibility with reference implementation (Cerdic)
   * Cache: bump `CACHE_VERSION` (Cerdic)
   * `bin/pscss` requires php 5.6+ (robocder)
   * travis updates and improved tests (Cerdic)
   * Nested formatted improvements (Cerdic)
-* **1.0.0** -- June 4, 2019
+
+### **1.0.0** -- June 4, 2019
   * Moving development to ScssPhp organization, https://github.com/scssphp/
   * Online documentation can be found at http://scssphp.github.com/scssphp/
   * Renamed namespace from Leafo to ScssPhp
-* **0.8.4** -- June 18, 2019
+
+### **0.8.4** -- June 18, 2019
   * This is the final tag on the leafo/scssphp repo; PHP requirements downgraded to 5.4+ for this repo/package only.
   * Support parent selector and selector functions (Cerdic)
   * Improve `and`/`or` compatibility (robocoder)
@@ -164,7 +179,8 @@ g to manipulate as a map (Cerdic)
   * Parsing missing http(s) protocol from `url()` (sebastianwebb, robocoder)
   * Add source column to thrown error message (slprime, robocoder)
   * Detect invalid CSS outside of selector (JMitnik, robocoder)
-* **0.8.3** -- May 31, 2019
+
+### **0.8.3** -- May 31, 2019
   * grid-template-columns (gKreator, Cerdic)
   * `self` in selector and parse improvements (designerno1, Cerdic)
   * invalid css output when using interpolation with mixins (Jasonkoolman, Cerdic)
@@ -180,9 +196,11 @@ g to manipulate as a map (Cerdic)
   * line comments for `@media` statements (gajcapuder, Cerdic)
   * failed interpolation in placeholder (GuidoJansen, Cerdic)
   * parentheses in selector causes loss of whitespace (Netmosfera, Cerdic)
-* **0.8.2** -- May 9, 2019
+
+### **0.8.2** -- May 9, 2019
   * requires php 5.6+
-* **0.8.1** -- May 9, 2019
+
+### **0.8.1** -- May 9, 2019
   * grid-row & grid-column shorthand (claytron5000, Cerdic)
   * `@`mixin `@`supports `@`include compilation error (geoidesic, Cerdic)
   * `@`media expression slicing (tdutrion, Cerdic)
@@ -192,7 +210,8 @@ g to manipulate as a map (Cerdic)
   * wrap successive inline assign into one block (Cerdic)
   * :not(), :nth-child() and other selectors before `@`extend (STV11C, Cerdic)
   * commentsSeen and phpdoc update (nextend)
-* **0.8.0** -- May 2, 2019
+
+### **0.8.0** -- May 2, 2019
   * Variables from inner override variables in parents (Daijobou, Cerdic)
   * Bootstrap issues with `@`at-root, self (l2a, Cerdic)
   * `@`supports inside rule (Marat-Tanalin, Cerdic)
@@ -200,7 +219,8 @@ g to manipulate as a map (Cerdic)
   * Number parsing (ange007, robocoder)
   * Travis test updates (Cerdic)
   * Add Bootstrap and Foundation framework tests (Cerdic)
-* **0.7.8** -- April 24, 2019
+
+### **0.7.8** -- April 24, 2019
   * Partial support for #rrggbbaa CSS Level 4 colors with alpha (charlymz)
   * Avoid infinitely duplicating parts when extending selector (cyberalien)
   * Fix rooted SCSS URIs normalized incorrectly with double slashes (evanceit)
@@ -216,77 +236,94 @@ g to manipulate as a map (Cerdic)
   * Change Base64 VLQ encoder/decoder implementation
   * Generate inline sourcemap in command-line (dexxa)
   * Fix backslash escape (bastianjoel)
-* **0.7.7** -- July 21, 2018
+
+### **0.7.7** -- July 21, 2018
   * Actually merge maps instead of concatenating (s7eph4n)
   * Treat 0 as special unitless number (of2607)
   * Partial fix for call() with ellipsis (gabor-udvari)
   * Misc peephole optimization
-* **0.7.6** -- May 23, 2018
+
+### **0.7.6** -- May 23, 2018
   * `mix()` alpha fix (Uriziel01)
   * `transparentize()` alpha sensitive to locale (leonardfischer, timelsass)
   * notices when compiling UIKit (azjezz)
   * faster parsing for base64 data: url()s (wout)
-* **0.7.5** -- February 8, 2018
+
+### **0.7.5** -- February 8, 2018
   * Fix `for` loop with units (of2607)
   * Fix side-effects in abs(), ceil(), floor(), and round() (jugyhead)
   * Add option for custom SourceMapGenerator (dleffler)
-* **0.7.4** -- December 21, 2017
+
+### **0.7.4** -- December 21, 2017
   * Fat fingered cleanup; broke source maps (dleffler)
-* **0.7.3** -- December 19, 2017
+
+### **0.7.3** -- December 19, 2017
   * Add inline sourcemaps (oyejorge, NicolaF)
   * Add file-based sourcemaps (dleffler)
-* **0.7.2** -- December 14, 2017
+
+### **0.7.2** -- December 14, 2017
   * Change default precision to 10 to match scss 3.5.0
   * Use number_format instead of locale (Arlisaha)
-* **0.7.1** -- October 13, 2017
+
+### **0.7.1** -- October 13, 2017
   * Server moved to exoample/ folder
   * Server::serveFrom() helper removed
   * Removed .phar build
   * Workaround `each()` deprecated in PHP 7.2RC (marinaglancy)
-* **0.6.7** -- February 23, 2017
+
+### **0.6.7** -- February 23, 2017
   * fix list interpolation
   * pscss: enable --line-numbers and --debug-info for stdin
   * checkRange() throws RangeException
-* **0.6.6** -- September 10, 2016
+
+### **0.6.6** -- September 10, 2016
   * Do not extend decorated tags with another tag (FMCorz)
   * Merge shared direct relationship when extending (FMCorz)
   * Extend resolution was generating invalid selectors (FMCorz)
   * Resolve function arguments using mixin content scope (FMCorz)
   * Let `@`content work when a block isn’t passed in. (diemer)
-* **0.6.5** -- June 20, 2016
+
+### **0.6.5** -- June 20, 2016
   * ignore BOM (nwiborg)
   * fix another mixin and variable scope issue (mahagr)
   * Compiler: coerceValue support for #rgb values (thesjg)
   * preserve un-normalized variable name for error message (kissifrot)
-* **0.6.4** -- June 15, 2016
+
+### **0.6.4** -- June 15, 2016
   * parsing multiple assignment flags (Limych)
   * `@`warn should not write to stdout (atomicalnet)
   * evaluating null and/or 'foo' (micranet)
   * case insensitive directives regression (Limych)
   * Compiler: scope change to some properties and methods to facilitate subclassing (jo)
-* **0.6.3** -- January 14, 2016
+
+### **0.6.3** -- January 14, 2016
   * extend + parent + placeholder fix (atna)
   * nested content infinite loop (Lusito)
   * only divide by 100 if percent (jkrehm)
   * Parser: refactoring and performance optimizations (oyejorge)
-* **0.6.2** -- December 16, 2015
+
+### **0.6.2** -- December 16, 2015
   * bin/pscss --iso8859-1
   * add rebeccapurple (from css color draft)
   * improve utf-8 support
-* **0.6.1** -- December 13, 2015
+
+### **0.6.1** -- December 13, 2015
   * bin/pscss --continue-on-error
   * fix BEM and `@`extend infinite loop
   * Compiler: setIgnoreErrors(boolean)
   * exception refactoring
   * implement `@`extend !optional and `keywords($args)` built-in
-* **0.6.0** -- December 5, 2015
+
+### **0.6.0** -- December 5, 2015
   * handle escaped quotes inside quoted strings (with and without interpolation present)
   * Compiler: undefined sourceParser when re-using a single Compiler instance
   * Parser: `getLineNo()` removed
-* **0.5.1** -- November 11, 2015
+
+### **0.5.1** -- November 11, 2015
   * `@`scssphp-import-once
   * avoid notices with custom error handlers that don't check if `error_reporting()` returns 0
-* **0.5.0** -- November 11, 2015
+
+### **0.5.0** -- November 11, 2015
   * Raise minimum supported version to PHP 5.4
   * Drop HHVM support/hacks
   * Remove deprecated classmap.php
@@ -294,7 +331,8 @@ g to manipulate as a map (Cerdic)
   * Compiler: treat `! null === true`
   * Compiler: `str-splice()` fixes
   * Node\Number: fixes incompatible units
-* **0.4.0** -- November 8, 2015
+
+### **0.4.0** -- November 8, 2015
   * Parser: remove deprecated `show()` and `to()` methods
   * Parser, Compiler: convert stdClass to Block, Node, and OutputBlock abstractions
   * New control directives: `@`break, `@`continue, and naked `@`return
@@ -304,14 +342,16 @@ g to manipulate as a map (Cerdic)
   * Compiler: output literal string instead of division-by-zero exception
   * Compiler: `str-slice()` - handle negative index
   * Compiler: pass kwargs to built-ins and user registered functions as 2nd argument (instead of Compiler instance)
-* **0.3.3** -- October 23, 2015
+
+### **0.3.3** -- October 23, 2015
   * Compiler: add `getVariables()` and `addFeature()` API methods
   * Compiler: can pass negative indices to `nth()` and `set-nth()`
   * Compiler: can pass map as args to mixin expecting varargs
   * Compiler: add coerceList(map)
   * Compiler: improve `@`at-root support
   * Nested formatter: suppress empty blocks
-* **0.3.2** -- October 4, 2015
+
+### **0.3.2** -- October 4, 2015
   * Fix `@`extend behavior when interpolating a variable that contains a selector list
   * Hoist `@`keyframes so children selectors are not prefixed by parent selector
   * Don't wrap `@`import inside `@`media query
@@ -320,31 +360,38 @@ g to manipulate as a map (Cerdic)
   * String-based keys mismatch in map functions
   * Short-circuit evaluation for `and`, `or`, and `if()`
   * Compiler: getParsedFiles() now includes the main file
-* **0.3.1** -- September 11, 2015
+
+### **0.3.1** -- September 11, 2015
   * Fix bootstrap v4-dev regression from 0.3.0
-* **0.3.0** -- September 6, 2015
+
+### **0.3.0** -- September 6, 2015
   * Compiler getParsedFiles() now returns a map of imported files and their corresponding timestamps
   * Fix multiple variable scope bugs, including `@`each
   * Fix regression from 0.2.1
-* **0.2.1** -- September 5, 2015
+
+### **0.2.1** -- September 5, 2015
   * Fix map-get(null)
   * Fix nested function definition (variable scoping)
   * Fix extend bug with BEM syntax
   * Fix selector regression from 0.1.9
-* **0.2.0** -- August 25, 2015
+
+### **0.2.0** -- August 25, 2015
   * Smaller git archives
   * Detect `@`import loops
   * Doc blocks everywhere!
-* **0.1.10** -- August 23, 2015
+
+### **0.1.10** -- August 23, 2015
   * Fix 3 year old `@`extend bug
   * Fix autoloader. (ext)
-* **0.1.9** -- August 1, 2015
+
+### **0.1.9** -- August 1, 2015
   * Adoption of the Sass Community Guidelines
   * Nested selector fixes with lists, interpolated string, and parent selector
   * Implement list-separator() and set-nth() built-ins
   * Implement `@`warn and `@`error
   * Removed spaceship operator pending discussion with reference implementators
-* **0.1.8** -- July 18, 2015
+
+### **0.1.8** -- July 18, 2015
   * Online documentation moved to http://leafo.github.com/scssphp/
   * Fix index() - map support; now returns null (instead of false) when value not found
   * Fix lighten(), darken() - percentages don't require % unit
@@ -353,58 +400,72 @@ g to manipulate as a map (Cerdic)
   * Fix !=
   * Fix `@`return inside `@`each
   * Add box support to generate .phar
-* **0.1.7** -- July 1, 2015
+
+### **0.1.7** -- July 1, 2015
   * bin/pscss: added --line-numbers and --debug-info options
   * Compiler: added setLineNumberStyle() and 'q' unit
   * Parser: deprecated show() and to() methods
   * simplified licensing (MIT)
   * refactoring internals and misc bug fixes (maps, empty list, function-exists())
-* **0.1.6** -- June 22, 2015
+
+### **0.1.6** -- June 22, 2015
   * !global
   * more built-in functions
   * Server: checkedCachedCompile() (zimzat)
   * Server: showErrorsAsCSS() to display errors in a pseudo-element (khamer)
   * misc bug fixes
-* **0.1.5** -- June 2, 2015
+
+### **0.1.5** -- June 2, 2015
   * misc bug fixes
-* **0.1.4** -- June 2, 2015
+
+### **0.1.4** -- June 2, 2015
   * add new string functions (okj579)
   * add compileFile() and checkCompile() (NoxNebula, saas786, panique)
   * fix regular expression in findImport() (lucvn)
   * needsCompile() shouldn't compare meta-etag with browser etag (edwinveldhuizen)
-* **0.1.3** -- May 31, 2015
+
+### **0.1.3** -- May 31, 2015
   * map support (okj579)
   * misc bug fixes (etu, bgarret, aaukt)
-* **0.1.1** -- Aug 12, 2014
+
+### **0.1.1** -- Aug 12, 2014
   * add stub classes -- a backward compatibility layer (vladimmi)
-* **0.1.0** -- Aug 9, 2014
+
+### **0.1.0** -- Aug 9, 2014
   * raise PHP requirement (5.3+)
   * reformat/reorganize source files to be PSR-2 compliant
-* **0.0.15** -- Aug 6, 2014
+
+### **0.0.15** -- Aug 6, 2014
   * fix regression with default values in functions (torkiljohnsen)
-* **0.0.14** -- Aug 5, 2014
+
+### **0.0.14** -- Aug 5, 2014
   * `@`keyframes $name - didn't work inside mixin (sergeylukin)
   * Bourbon transform(translateX()) didn't work (dovy and greynor)
-* **0.0.13** -- Aug 4, 2014
+
+### **0.0.13** -- Aug 4, 2014
   * handle If-None-Match in client request, and send ETag in response (NSmithUK)
   * normalize quotation marks (NoxNebula)
   * improve handling of escape sequence in selectors (matt3224)
   * add "scss_formatter_crunched" which strips comments
   * internal: generate more accurate parse tree
-* **0.0.12** -- July 6, 2014
+
+### **0.0.12** -- July 6, 2014
   * revert erroneous import-partials-fix (smuuf)
   * handle If-Modified-Since in client request, and send Last-Modified in response (braver)
   * add hhvm to travis-ci testing
-* **0.0.11** -- July 5, 2014
+
+### **0.0.11** -- July 5, 2014
   * support multi-line continuation character (backslash) per CSS2.1 and CSS3 spec (caiosm1005)
   * imported partials should not be compiled (squarestar)
   * add setVariables() and unsetVariable() to interface (leafo/lessphp)
   * micro-optimizing is_null() (Yahasana)
-* **0.0.10** -- April 14, 2014
+
+### **0.0.10** -- April 14, 2014
   * fix media query merging (timonbaetz)
   * inline if should treat null as false (wonderslug)
   * optimizing toHSL() (jfsullivan)
-* **0.0.9** -- December 23, 2013
+
+### **0.0.9** -- December 23, 2013
   * fix `@`for/`@`while inside `@`content block (sergeylukin)
   * fix functions in mixin_content (timonbaetz)
   * fix infinite loop when target extends itself (oscherler)
@@ -412,12 +473,14 @@ g to manipulate as a map (Cerdic)
   * allow setting number precision (kasperisager)
   * add public function helpers (toBool, get, findImport, assertList, assertColor, assertNumber, throwError) (Burgov, atdt)
   * add optional cache buster prefix to serve() method (iMoses)
-* **0.0.8** -- September 16, 2013
+
+### **0.0.8** -- September 16, 2013
   * Avoid IE7 content: counter bug
   * Support transparent as color name
   * Recursively create cache dir (turksheadsw)
   * Fix for INPUT NOT FOUND (morgen32)
-* **0.0.7** -- May 24, 2013
+
+### **0.0.7** -- May 24, 2013
   * Port various fixes from leafo/lessphp.
   * Improve filter precision.
   * Parsing large image data-urls does not work.
@@ -428,7 +491,8 @@ g to manipulate as a map (Cerdic)
   * Fix mixin content includes (James Shannon, Christian Brandt).
   * Fix passing of varargs to another mixin.
   * Fix interpolation bug in expToString() (Matti Jarvinen).
-* **0.0.5** -- March 11, 2013
+
+### **0.0.5** -- March 11, 2013
   * Better compile time errors
   * Fix top level properties inside of a nested `@media` (Anthon Pang)
   * Fix some issues with `@extends` (Anthon Pang)
@@ -439,7 +503,8 @@ g to manipulate as a map (Cerdic)
   * Add variable argument support (Martin Hasoň)
   * Add zip, index, comparable functions (Martin Hasoň)
   * A bunch of parser and bug fixes
-* **0.0.4** -- Nov 3nd, 2012
+
+### **0.0.4** -- Nov 3nd, 2012
   * [Import path can be a function](docs/#import-paths) (Christian Lück).
   * Correctly parse media queries with more than one item (Christian Lück).
   * Add `ie_hex_str`, `abs`, `min`, `max` functions (Martin Hasoň)
@@ -447,14 +512,17 @@ g to manipulate as a map (Cerdic)
   * Improve operator evaluation (Martin Hasoň)
   * Add [`@content`](http://sass-lang.com/docs/yardoc/file.SASS_REFERENCE.html#mixin-content) support.
   * Misc bug fixes.
-* **0.0.3** -- August 2nd, 2012
+
+### **0.0.3** -- August 2nd, 2012
   * Add missing and/or/not operators.
   * Expression evaluation happens correctly.
   * Import file caching and _partial filename support.
   * Misc bug fixes.
-* **0.0.2** -- July 30th, 2012
+
+### **0.0.2** -- July 30th, 2012
   * SCSS server is aware of imports
   * added custom function interface
   * compressed formatter
   * wrote <a href="{{ site.baseurl }}/docs/">documentation</a>
-* **0.0.1** -- July 29th, 2012 -- Initial Release
+
+### **0.0.1** -- July 29th, 2012 -- Initial Release

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -14,9 +14,9 @@ The project can be loaded through a `composer` generated auto-loader.
 Alternatively, the entire project can be loaded through a utility file.
 Just include it somewhere to start using it:
 
-{% highlight php startinline=true %}
+```php
 require_once 'scssphp/scss.inc.php';
-{% endhighlight %}
+```
 
 ### Compiling
 
@@ -24,7 +24,7 @@ In order to manually compile code from PHP you must create an instance of the
 `Compiler` class. The typical flow is to create the instance, set any compile time
 options, then run the compiler with the `compile` method.
 
-{% highlight php startinline=true %}
+```php
 use ScssPhp\ScssPhp\Compiler;
 
 $scss = new Compiler();
@@ -33,7 +33,7 @@ echo $scss->compile('
   $color: #abc;
   div { color: lighten($color, 20%); }
 ');
-{% endhighlight %}
+```
 
 * `compile($scssCode)` will attempt to compile a string of SCSS code. If it
   succeeds, the CSS will be returned as a string. If there is any error, an
@@ -55,7 +55,7 @@ In case you want to load files from other folders, there are two methods for
   `$pathArray`. The value of `$pathArray` will be converted to an array if it
   isn't one already.
 
-{% highlight php startinline=true %}
+```php
 use ScssPhp\ScssPhp\Compiler;
 
 $scss = new Compiler();
@@ -63,13 +63,13 @@ $scss->setImportPaths('assets/stylesheets/');
 
 // will search for 'assets/stylesheets/mixins.scss'
 echo $scss->compile('{% raw %}@{% endraw %}import "mixins.scss";');
-{% endhighlight %}
+```
 
 Besides adding static import paths, it's also possible to add custom import
 functions. This allows you to load paths from a database, or HTTP, or using
 files that SCSS would otherwise not process (such as vanilla CSS imports).
 
-{% highlight php startinline=true %}
+```php
 use ScssPhp\ScssPhp\Compiler;
 
 $scss = new Compiler();
@@ -80,7 +80,7 @@ $scss->addImportPath(function($path) {
 
 // will import 'stylesheets/vanilla.css'
 echo $scss->compile('{% raw %}@{% endraw %}import "vanilla.css";');
-{% endhighlight %}
+```
 
 A list of the compiled files (both the primary file and its imports) can be
 retrieved using the `getParsedFiles` method.
@@ -95,16 +95,16 @@ You can preset variables before compilation by using the `setVariables($vars)`
 method. If the variable is also defined in your scss source, use the `!default`
 flag to prevent your preset variables from being overridden.
 
-{% highlight php startinline=true %}
+```php
 use ScssPhp\ScssPhp\Compiler;
--
+
 $scss = new Compiler();
 $scss->setVariables(array(
     'var' => 'false',
 ));
 
 echo $scss->compile('$var: true !default;');
-{% endhighlight %}
+```
 
 Note: the value is the scss source to be parsed. If you want to parse a string,
 you have to represent it as a string, e.g. `'var' => '"string"'`.
@@ -120,7 +120,7 @@ The output formatting can be configured using the `setOutputStyle` method.
 
 Given the following SCSS:
 
-{% highlight scss %}
+```scss
 /*! Comment */
 .navigation {
     ul {
@@ -137,13 +137,13 @@ Given the following SCSS:
         color: silver;
     }
 }
-{% endhighlight %}
+```
 
 The output will look like that:
 
 `OutputStyle::EXPANDED`:
 
-{% highlight css %}
+```css
 /*! Comment */
 .navigation ul {
   line-height: 20px;
@@ -155,13 +155,13 @@ The output will look like that:
 .footer .copyright {
   color: silver;
 }
-{% endhighlight %}
+```
 
 `OutputStyle::COMPRESSED`:
 
-{% highlight css %}
+```css
 /* Comment*/.navigation ul{line-height:20px;color:blue;}.navigation ul a{color:red;}.footer .copyright{color:silver;}
-{% endhighlight %}
+```
 
 ### Source Maps
 
@@ -169,7 +169,7 @@ Source Maps are useful in debugging compiled css files using browser developer t
 
 To enable source maps, use the `setSourceMap()` and `setSourceMapOptions()` methods.
 
-{% highlight php startinline=true %}
+```php
 use ScssPhp\ScssPhp\Compiler;
 
 $scss = new Compiler();
@@ -192,7 +192,7 @@ $scss->setSourceMapOptions([
 ]);
 
 // use Compiler::SOURCE_MAP_INLINE for inline (comment-based) source maps
-{% endhighlight %}
+```
 
 ### Custom Functions
 
@@ -232,7 +232,7 @@ automatically to the corresponding SCSS type.
 As an example, a function called `add-two` is registered, which adds two numbers
 together. PHP's anonymous function syntax is used to define the function.
 
-{% highlight php startinline=true %}
+```php
 use ScssPhp\ScssPhp\Compiler;
 
 $scss = new Compiler();
@@ -247,12 +247,12 @@ $scss->registerFunction(
 );
 
 $scss->compile('.ex1 { result: add-two(10, 10); }');
-{% endhighlight %}
+```
 
 Using a prototype and kwargs, functions can take named parameters. In this next example,
 we register a function called `divide` which divides a named dividend by a named divisor.
 
-{% highlight php startinline=true %}
+```php
 use ScssPhp\ScssPhp\Compiler;
 
 $scss = new Compiler();
@@ -266,7 +266,7 @@ $scss->registerFunction(
 );
 
 $scss->compile('.ex2 { result: divide($divisor: 2, $dividend: 30); }');
-{% endhighlight %}
+```
 
 Note: in the above examples, we lose the units of the number, and we
 also don't do any type checking. This will have undefined results if we give it
@@ -279,7 +279,7 @@ exceptions thrown by the Compiler. This is especially important in a production
 environment where the content may be untrusted (e.g., user uploaded) because
 the exception stack trace may contain sensitive data.
 
-{% highlight php startinline=true %}
+```php
 use ScssPhp\ScssPhp\Compiler;
 
 try {
@@ -290,7 +290,7 @@ try {
     echo '';
     syslog(LOG_ERR, 'scssphp: Unable to compile content');
 }
-{% endhighlight %}
+```
 
 If your web application allows for arbitrary `@import` paths, you should
 tighten the `open_basedir` setting at run-time to mitigate vulnerability to

--- a/docs/docs/server.md
+++ b/docs/docs/server.md
@@ -12,14 +12,14 @@ a directory that you specify.
 
 Create a file, like `style.php`:
 
-{% highlight php startinline=true %}
+```php
 use ScssPhp\Server\Server;
 
 $directory = "stylesheets";
 
 $server = new Server($directory);
 $server->serve();
-{% endhighlight %}
+```
 
 Create the directory set in the script alongside the script, then add your
 `scss` files to it.
@@ -34,16 +34,16 @@ Going to the URL `example.com/style.php/style.scss` will attempt to compile
 
 If it can not find the file it will return an HTTP 404 page:
 
-{% highlight text %}
+```
 /* INPUT NOT FOUND scss v0.0.1 */
-{% endhighlight %}
+```
 
 If the file can't be compiled due to an error, then an HTTP 500 page is
 returned. Similar to the following:
 
-{% highlight text %}
+```
 Parse error: failed at 'height: ;' stylesheets/test.scss on line 8
-{% endhighlight %}
+```
 
 Also, because SCSS server writes headers, make sure no output is written before
 it runs.
@@ -62,7 +62,7 @@ Just call the `serve` method to let it render its output.
 
 Here's an example of creating a SCSS server that outputs compressed CSS:
 
-{% highlight php startinline=true %}
+```php
 use ScssPhp\ScssPhp\Compiler;
 use ScssPhp\ScssPhp\OutputStyle;
 use ScssPhp\Server\Server;
@@ -72,4 +72,4 @@ $scss->setOutputStyle(OutputStyle::COMPRESSED);
 
 $server = new Server('stylesheets', null, $scss);
 $server->serve();
-{% endhighlight %}
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -68,7 +68,7 @@ $ bin/pscss -s compressed < styles.scss
 ```
 
 The flag `-I` (or `--load_path`) can be used to set import paths for the loader. On Unix/Linux systems,
-the paths are colon separated.
+the paths are colon separated. On Windows, they are separate by a semi-colon.
 
 ## SCSSPHP Library Reference
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,13 +27,13 @@ You can also find the latest source online:
 
 If you use [Packagist][2] for installing packages, then you can update your `composer.json` like so:
 
-{% highlight json %}
+```json
 {
     "require": {
         "scssphp/scssphp": "^{{ site.current_version }}"
     }
 }
-{% endhighlight %}
+```
 
 Note: git archives of stable versions no longer include the `tests/` folder.
 To install the unit tests, download the complete package source using `composer`'s
@@ -63,9 +63,9 @@ If passed the flag `-T`, a formatted parse tree is returned instead of the compi
 
 The flag `-s` (or `--style`) can be used to set the [output style](docs/#output-formatting):
 
-{% highlight bash %}
+```bash
 $ bin/pscss -s compressed < styles.scss
-{% endhighlight %}
+```
 
 The flag `-I` (or `--load_path`) can be used to set import paths for the loader. On Unix/Linux systems,
 the paths are colon separated.
@@ -77,7 +77,7 @@ Complete documentation for **scssphp** is located at <a href="{{ site.baseurl }}
 To use the scssphp library either require `scss.inc.php` or use your `composer` generated auto-loader, and then
 invoke the `Compiler` class:
 
-{% highlight php startinline=true %}
+```php
 require_once "scssphp/scss.inc.php";
 
 use ScssPhp\ScssPhp\Compiler;
@@ -88,7 +88,7 @@ echo $scss->compile('
   $color: #abc;
   div { color: lighten($color, 20%); }
 ');
-{% endhighlight %}
+```
 
 The `compile` method takes `SCSS` as a string, and returns the `CSS`. If there
 is an error when compiling, an exception is thrown with an appropriate


### PR DESCRIPTION
This updates the website sources to use markdown code blocks rather than `{% highlight %}` tags, to make it nicer to work in them in an IDE supporting markdown (for instance PHPStorm) which recognizes code blocks. Github Pages supports syntax highlighting with Rouge by default for markdown.
The rendering of syntax highlighting is changed to use the github theme rather than a custom one (which would have need to be fixed).