### PR TITLE
apply realpath() to the input path to use the same in the parser also

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -375,7 +375,8 @@ class Compiler
         $this->ignoreCallStackMessage = false;
 
         if (!\is_null($path) && is_file($path)) {
-            $this->currentDirectory = dirname(realpath($path) ?: $path);
+            $path = realpath($path) ?: $path;
+            $this->currentDirectory = dirname($path);
         } else {
             $this->currentDirectory = getcwd();
         }


### PR DESCRIPTION
Following https://github.com/scssphp/scssphp/commit/de45205 test suite was broken in my environment:

```
There were 12 failures:

1) ScssPhp\ScssPhp\Tests\SassSpecTest::testTests with data set "4051/5713. libsass-closed-issues/issue_1243/debug" ('4051/5713. libsass-closed-iss.../debug', array('', '@debug("foo")\n\n', array(), ''), array('', 'input.scss:1 DEBUG: foo\n', '', array()))
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'input.scss:1 DEBUG: foo'
+'/var/folders/wh/ypj7kkt52dxf98t071c53lhm0000gn/T/sass-spec/libsass-closed-issues/issue_1243/debug/input.scss:1 DEBUG: foo'

/Users/cedric/Sites/libs/scssphp/tests/SassSpecTest.php:360
...
```

This is because the tmp folder  `/var/folders/wh/ypj7kkt52dxf98t071c53lhm0000gn/..` becomes `/private/var/folders/wh/ypj7kkt52dxf98t071c53lhm0000gn/...` after the `realpath()` call and thus we are not providing the parser we same path we are having in the currentDirectory/rootDirectory
