### PR TITLE
Refactor compilation result

### DIFF
--- a/scss.inc.php
+++ b/scss.inc.php
@@ -12,6 +12,7 @@ if (! class_exists('ScssPhp\ScssPhp\Version', false)) {
     include_once __DIR__ . '/src/Colors.php';
     include_once __DIR__ . '/src/Compiler.php';
     include_once __DIR__ . '/src/Compiler/Environment.php';
+    include_once __DIR__ . '/src/Compiler/CompilationResult.php';
     include_once __DIR__ . '/src/Exception/SassException.php';
     include_once __DIR__ . '/src/Exception/SassScriptException.php';
     include_once __DIR__ . '/src/Exception/CompilerException.php';

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -425,8 +425,7 @@ class Compiler
                 }
             }
 
-            $this->compilationResult->setCss($prefix);
-            $this->compilationResult->appendCss($out);
+            $this->compilationResult->setCss($prefix . $out);
 
             if (! empty($out) && $this->sourceMap && $this->sourceMap !== self::SOURCE_MAP_NONE) {
                 $sourceMap    = $sourceMapGenerator->generateJson($prefix);

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -211,6 +211,11 @@ class Compiler
     protected $cache;
 
     /**
+     * @var bool
+     */
+    protected $cacheCheckImportResolutions = false;
+
+    /**
      * @var int
      */
     protected $indentLevel;
@@ -295,6 +300,9 @@ class Compiler
 
         if ($cacheOptions) {
             $this->cache = new Cache($cacheOptions);
+            if (!empty($cacheOptions['checkImportResolutions'])) {
+                $this->cacheCheckImportResolutions = true;
+            }
         }
 
         $this->stderr = fopen('php://stderr', 'w');
@@ -350,8 +358,11 @@ class Compiler
             $compileOptions = $this->getCompileOptions();
             $cache          = $this->cache->getCache('compile', $cacheKey, $compileOptions);
 
-            if (!empty($cache) && $cache instanceof CompilationResult && $cache->checkValid()) {
-                return $cache;
+            if (!empty($cache) && $cache instanceof CompilationResult) {
+                $cache->setIsCached(true);
+                if ($cache->checkValid($this->cacheCheckImportResolutions, $this)) {
+                    return $cache;
+                }
             }
         }
 

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -2476,7 +2476,9 @@ class Compiler
                 return true;
             }
 
-            $this->appendRootDirective('@import ' . $this->compileImportPath($rawPath) . ';', $out);
+            $path = $this->compileImportPath($rawPath);
+            $this->appendRootDirective('@import ' . $path . ';', $out);
+            $this->compilationResult->addIncludedFile($path);
 
             return false;
         }
@@ -2489,7 +2491,9 @@ class Compiler
 
             foreach ($rawPath[2] as $path) {
                 if ($path[0] !== Type::T_STRING) {
-                    $this->appendRootDirective('@import ' . $this->compileImportPath($rawPath) . ';', $out);
+                    $path = $this->compileImportPath($rawPath);
+                    $this->appendRootDirective('@import ' . $path . ';', $out);
+                    $this->compilationResult->addIncludedFile($path);
 
                     return false;
                 }
@@ -2502,7 +2506,9 @@ class Compiler
             return true;
         }
 
-        $this->appendRootDirective('@import ' . $this->compileImportPath($rawPath) . ';', $out);
+        $path = $this->compileImportPath($rawPath);
+        $this->appendRootDirective('@import ' . $path . ';', $out);
+        $this->compilationResult->addIncludedFile($path);
 
         return false;
     }

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -5069,6 +5069,8 @@ class Compiler
      */
     public function addParsedFile($path)
     {
+        @trigger_error('addParsedFile() is no longer a method from Compiler but from CompilationResult.'
+            . ' Please update your code', E_USER_DEPRECATED);
         if ($this->compilationResult) {
             $this->compilationResult->addParsedFile($path);
         }
@@ -5084,6 +5086,8 @@ class Compiler
      */
     public function getParsedFiles()
     {
+        @trigger_error('addParsedFile() is no longer a method from Compiler but from CompilationResult.'
+            . ' Please update your code', E_USER_DEPRECATED);
         return $this->compilationResult ? $this->compilationResult->getParsedFiles() : [];
     }
 

--- a/src/Compiler/CompilationResult.php
+++ b/src/Compiler/CompilationResult.php
@@ -97,7 +97,7 @@ class CompilationResult
      */
     public function addParsedFile($path)
     {
-        if (isset($path) && is_file($path)) {
+        if (! \is_null($path) && is_file($path)) {
             $this->parsedFiles[realpath($path)] = filemtime($path);
         }
     }

--- a/src/Compiler/CompilationResult.php
+++ b/src/Compiler/CompilationResult.php
@@ -101,7 +101,7 @@ class CompilationResult
      *
      * @api
      *
-     * @param string $path
+     * @param string|null $path
      *
      * @return void
      */
@@ -193,7 +193,7 @@ class CompilationResult
 
     /**
      * Store the sourceMap and its storage data
-     * @param $sourceMap
+     * @param string $sourceMap
      * @param null|string $sourceMapFile
      * @param null|string $sourceMapUrl
      */
@@ -211,7 +211,7 @@ class CompilationResult
     /**
      * The sourceMap content, if it was generated
      *
-     * @return string
+     * @return null|string
      */
     public function getSourceMap()
     {

--- a/src/Compiler/CompilationResult.php
+++ b/src/Compiler/CompilationResult.php
@@ -1,0 +1,219 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Compiler;
+
+use ScssPhp\ScssPhp\Util;
+use ScssPhp\ScssPhp\Exception\CompilerException;
+
+/**
+ * Compiler environment
+ *
+ */
+class CompilationResult
+{
+    /**
+     * @var string
+     */
+    protected $css = '';
+
+    /**
+     * @var string
+     */
+    protected $sourceMap = '';
+
+    protected $sourceMapFile;
+    protected $sourceMapUrl;
+
+
+    /**
+     * All the effective parsedfiles
+     * @var array
+     */
+    protected $parsedFiles = [];
+
+    /**
+     * All the @import files and urls seen in the compilation result
+     * @var array
+     */
+    protected $includedFiles = [];
+
+    /**
+     * All the @import files resolved and imported (use to check the once condition)
+     * @var array
+     */
+    protected $importedFiles = [];
+
+
+    /**
+     * @param string $css
+     */
+    public function setCss($css)
+    {
+        $this->css = $css;
+    }
+
+    /**
+     * @param string $css
+     */
+    public function appendCss($css)
+    {
+        $this->css .= $css;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCss()
+    {
+        return $this->css . $this->getSourceMapCss();
+    }
+
+    /**
+     * Adds to list of parsed files
+     *
+     * @api
+     *
+     * @param string $path
+     *
+     * @return void
+     */
+    public function addParsedFile($path)
+    {
+        if (isset($path) && is_file($path)) {
+            $this->parsedFiles[realpath($path)] = filemtime($path);
+        }
+    }
+
+    /**
+     * Returns list of parsed files
+     *
+     * @api
+     *
+     * @return array
+     */
+    public function getParsedFiles()
+    {
+        return $this->parsedFiles;
+    }
+
+
+
+    // name matching the JS API
+    // The set that will eventually populate the JS API's
+    // `result.stats.includedFiles` field.
+    //
+    // For filesystem imports, this contains the import path. For all other
+    // imports, it contains the URL passed to the `@import`.
+    public function getIncludedFiles()
+    {
+        // ...
+    }
+
+    // A map from source file URLs to the corresponding [SourceFile]s.
+    //
+    // This can be passed to [sourceMap]'s [Mapping.spanFor] method. It's `null`
+    // if source mapping was disabled for this compilation.
+    public function getSourceFiles()
+    {
+
+    }
+
+
+    public function __toString()
+    {
+        return $this->getCss(); // To reduce the impact of the BC break
+    }
+
+
+    /**
+     * Store the sourceMap and its storage data
+     * @param $sourceMap
+     * @param null|string $sourceMapFile
+     * @param null|string $sourceMapUrl
+     */
+    public function setSourceMap($sourceMap, $sourceMapFile = null, $sourceMapUrl = null)
+    {
+        $this->sourceMap = $sourceMap;
+        if (empty($sourceMapFile) || empty($sourceMapUrl)) {
+            $this->sourceMapUrl = $this->sourceMapFile = null;
+        } else {
+            $this->sourceMapFile = $sourceMapFile;
+            $this->sourceMapUrl = $sourceMapUrl;
+        }
+    }
+
+    /**
+     * The sourceMap content, if it was generated
+     *
+     * @return string
+     */
+    public function getSourceMap()
+    {
+        return $this->sourceMap;
+    }
+
+    /**
+     * The sourceMap Css content, if there is a sourceMap
+     * @return string
+     */
+    public function getSourceMapCss()
+    {
+        if ($this->sourceMap) {
+            if ($this->sourceMapFile) {
+                $sourceMapurl = $this->sourceMapUrl;
+                $dir  = \dirname($this->sourceMapFile);
+
+                // directory does not exist
+                if (! is_dir($dir)) {
+                    // FIXME: create the dir automatically?
+                    throw new CompilerException(
+                        sprintf('The directory "%s" does not exist. Cannot save the source map.', $dir)
+                    );
+                }
+
+                // FIXME: proper saving, with dir write check!
+                if (file_put_contents($this->sourceMapFile, $this->sourceMap) === false) {
+                    throw new CompilerException(sprintf('Cannot save the source map to "%s"', $this->sourceMapFile));
+                }
+            }
+            else {
+                $sourceMapurl = Util::encodeURIComponent($this->sourceMap);
+            }
+
+            if ($sourceMapurl) {
+                return sprintf('/*# sourceMappingURL=%s */', $sourceMapurl);
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * Check if this result is still valid
+     * ie no file has been modified
+     *
+     * @return bool
+     */
+    public function checkValid()
+    {
+        // check if any dependency file changed before accepting the cache
+        foreach ($this->parsedFiles as $file => $mtime) {
+            if (! is_file($file) || filemtime($file) !== $mtime) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+}

--- a/src/Compiler/CompilationResult.php
+++ b/src/Compiler/CompilationResult.php
@@ -21,41 +21,41 @@ use ScssPhp\ScssPhp\Exception\CompilerException;
  */
 class CompilationResult
 {
-    protected static $resolvedImport = [];
+    private static $resolvedImport = [];
 
-    protected $isCached = false;
-
-    /**
-     * @var string
-     */
-    protected $css = '';
+    private $isCached = false;
 
     /**
      * @var string
      */
-    protected $sourceMap = '';
+    private $css = '';
 
-    protected $sourceMapFile;
-    protected $sourceMapUrl;
+    /**
+     * @var string
+     */
+    private $sourceMap = '';
+
+    private $sourceMapFile;
+    private $sourceMapUrl;
 
 
     /**
      * All the effective parsedfiles
      * @var array
      */
-    protected $parsedFiles = [];
+    private $parsedFiles = [];
 
     /**
      * All the @import files and urls seen in the compilation process
      * @var array
      */
-    protected $includedFiles = [];
+    private $includedFiles = [];
 
     /**
      * All the @import files resolved and imported (use to check the once condition)
      * @var array
      */
-    protected $importedFiles = [];
+    private $importedFiles = [];
 
 
     /**

--- a/src/Compiler/CompilationResult.php
+++ b/src/Compiler/CompilationResult.php
@@ -21,8 +21,6 @@ use ScssPhp\ScssPhp\Exception\CompilerException;
  */
 class CompilationResult
 {
-    private static $resolvedImport = [];
-
     private $isCached = false;
 
     /**
@@ -271,10 +269,7 @@ class CompilationResult
 
         // check that all the findImport would resolve the same way
         if ($deepCheck && $compiler) {
-            // hash is linked to the compiler options, including the importPath
-            // use json_encode and not serialize as the importPath can include a Closure
-            // thus we can not distinguish two different importPath differing only by a different Closure
-            $hash = md5(json_encode($compiler->getCompileOptions()));
+            $resolvedImport = [];
             foreach ($this->importedFiles as $imported) {
 
                 $currentDir = $imported['currentDir'];
@@ -282,11 +277,11 @@ class CompilationResult
                 // store the check accros all the results in memory to avoid multiple findImport() on the same path
                 // with same context
                 // this is happening in a same hit with multiples compilation (especially with big frameworks)
-                if (empty(CompilationResult::$resolvedImport[$hash][$currentDir][$path])) {
-                    CompilationResult::$resolvedImport[$hash][$currentDir][$path] = $compiler->findImport($path, $currentDir);
+                if (empty($resolvedImport[$currentDir][$path])) {
+                    $resolvedImport[$currentDir][$path] = $compiler->findImport($path, $currentDir);
                 }
 
-                if (CompilationResult::$resolvedImport[$hash][$currentDir][$path] !== $imported['filePath']) {
+                if ($resolvedImport[$currentDir][$path] !== $imported['filePath']) {
                     return false;
                 }
             }

--- a/src/Compiler/CompilationResult.php
+++ b/src/Compiler/CompilationResult.php
@@ -79,14 +79,6 @@ class CompilationResult
     }
 
     /**
-     * @param string $css
-     */
-    public function appendCss($css)
-    {
-        $this->css .= $css;
-    }
-
-    /**
      * @return string
      */
     public function getCss()

--- a/src/Compiler/CompilationResult.php
+++ b/src/Compiler/CompilationResult.php
@@ -115,6 +115,7 @@ class CompilationResult
     public function addImportedFile($currentDirectory, $path, $filePath)
     {
         $this->importedFiles[] = ['currentDir' => $currentDirectory, 'path' => $path, 'filePath' => $filePath];
+        $this->addIncludedFile($filePath);
     }
 
 
@@ -128,16 +129,32 @@ class CompilationResult
         return array_column($this->importedFiles, 'filePath');
     }
 
+    /**
+     * Save the included files
+     * @param string $path
+     */
+    public function addIncludedFile($path)
+    {
+        // unquote the included path if needed
+        foreach (['"', '"'] as $quote) {
+            if (strpos($path, $quote) === 0 && substr($path, -1) === $quote) {
+                $path = substr($path, 1, -1);
+                break;
+            }
+        }
 
-    // name matching the JS API
-    // The set that will eventually populate the JS API's
-    // `result.stats.includedFiles` field.
-    //
-    // For filesystem imports, this contains the import path. For all other
-    // imports, it contains the URL passed to the `@import`.
+        $this->includedFiles[] = $path;
+    }
+
+    /**
+     * For filesystem imports, this contains the import path. For all other
+     * imports, it contains the URL passed to the `@import`.
+     *
+     * @return array
+     */
     public function getIncludedFiles()
     {
-        // ...
+        return $this->includedFiles;
     }
 
     // A map from source file URLs to the corresponding [SourceFile]s.

--- a/src/Compiler/CompilationResult.php
+++ b/src/Compiler/CompilationResult.php
@@ -42,7 +42,7 @@ class CompilationResult
     protected $parsedFiles = [];
 
     /**
-     * All the @import files and urls seen in the compilation result
+     * All the @import files and urls seen in the compilation process
      * @var array
      */
     protected $includedFiles = [];
@@ -106,6 +106,27 @@ class CompilationResult
         return $this->parsedFiles;
     }
 
+    /**
+     * Save the imported files with their resolving path context
+     * @param string $currentDirectory
+     * @param string $path
+     * @param string $filePath
+     */
+    public function addImportedFile($currentDirectory, $path, $filePath)
+    {
+        $this->importedFiles[] = ['currentDir' => $currentDirectory, 'path' => $path, 'filePath' => $filePath];
+    }
+
+
+    /**
+     * Get the list of the already imported Files
+     * used by the compiler to check the once condition on @import
+     * @return array
+     */
+    public function getImportedFiles()
+    {
+        return array_column($this->importedFiles, 'filePath');
+    }
 
 
     // name matching the JS API

--- a/src/SourceMap/SourceMapGenerator.php
+++ b/src/SourceMap/SourceMapGenerator.php
@@ -129,6 +129,7 @@ class SourceMapGenerator
      * @return string
      *
      * @throws \ScssPhp\ScssPhp\Exception\CompilerException If the file could not be saved
+     * @deprecated
      */
     public function saveMap($content)
     {


### PR DESCRIPTION
This is an implementation of #222 and fixing #268 in a efficient way

As a matter of fact, there is no BC break.
The CompilationResult is storing 3 differents lists:
- parsedFiles, as it was in the Compiler Class, listing the parsed files with their timestamp
- importedFiles which list all the findImport resolved as a file, with the current dir and search path. This is used for a deep check of cache validity
- includedFiles which list all the `@import` path, whether it's resolved as a file (then it is in the importedFiles as well) or a just kept as a css `@import` directive. We are not using this list, but this is an output of dart-sass and while refactoring I tried to stay as close as possible.

I think that importedFiles and parsedFiles could probably be merged, but I didn't had a deep check on that and prefered to not introduce any breaking in this refactoring. 
This is probably an optimisation for later.