### PR TITLE
Fix #273 and escaped selector sass-spec test

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -15,6 +15,7 @@ namespace ScssPhp\ScssPhp;
 use ScssPhp\ScssPhp\Base\Range;
 use ScssPhp\ScssPhp\Compiler\Environment;
 use ScssPhp\ScssPhp\Exception\CompilerException;
+use ScssPhp\ScssPhp\Exception\ParserException;
 use ScssPhp\ScssPhp\Exception\SassScriptException;
 use ScssPhp\ScssPhp\Formatter\Compressed;
 use ScssPhp\ScssPhp\Formatter\Expanded;
@@ -1809,7 +1810,7 @@ class Compiler
 
             try {
                 $isValid = $parser->parseSelector($buffer, $newSelectors, true);
-            } catch (\Exception $e) {
+            } catch (ParserException $e) {
                 throw $this->error($e->getMessage());
             }
 

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -1807,7 +1807,13 @@ class Compiler
             $buffer    = $this->collapseSelectors($selectors);
             $parser    = $this->parserFactory(__METHOD__);
 
-            if ($parser->parseSelector($buffer, $newSelectors, true)) {
+            try {
+                $isValid = $parser->parseSelector($buffer, $newSelectors, true);
+            } catch (\Exception $e) {
+                throw $this->error($e->getMessage());
+            }
+
+            if ($isValid) {
                 $selectors = array_map([$this, 'evalSelector'], $newSelectors);
             }
         }

--- a/tests/inputs/selectors.scss
+++ b/tests/inputs/selectors.scss
@@ -303,3 +303,13 @@ $end: ' ';
 #{$selector} a .tocnumber #{$end} {
         min-width: 100%;
 }
+
+
+// escaped
+.\31u\$ {clear: left;}
+.\31 u\$ {clear: left;}
+.\31u\24 {  clear: right;}
+.\31 u\24 {  clear: right;}
+.a\31 u\24 {  clear: both;}
+$x: '\\28' + 'xlarge' + '\\29';
+.\31 2u#{$x}, .\31 2u\24#{$x} { width: 100%; clear: none; margin-left: 0; }

--- a/tests/outputs/selectors.css
+++ b/tests/outputs/selectors.css
@@ -388,3 +388,23 @@ ul ul, ol ul, ul ol, ol ol {
 ul li a .tocnumber {
   min-width: 100%;
 }
+.\31 u\$ {
+  clear: left;
+}
+.\31 u\$ {
+  clear: left;
+}
+.\31 u\$ {
+  clear: right;
+}
+.\31 u\$ {
+  clear: right;
+}
+.a\31 u\$ {
+  clear: both;
+}
+.\31 2u\(xlarge\), .\31 2u\$\(xlarge\) {
+  width: 100%;
+  clear: none;
+  margin-left: 0;
+}

--- a/tests/outputs/selectors.css
+++ b/tests/outputs/selectors.css
@@ -400,7 +400,7 @@ ul li a .tocnumber {
 .\31 u\$ {
   clear: right;
 }
-.a\31 u\$ {
+.a1u\$ {
   clear: both;
 }
 .\31 2u\(xlarge\), .\31 2u\$\(xlarge\) {

--- a/tests/specs/sass-spec-exclude.txt
+++ b/tests/specs/sass-spec-exclude.txt
@@ -1233,7 +1233,6 @@ non_conformant/extend-tests/237_extend_with_universal_selector_different_namespa
 non_conformant/extend-tests/238_unify_root_pseudoelement
 non_conformant/extend-tests/compound-unification-in-not
 non_conformant/extend-tests/does_not_move_page_block_in_media
-non_conformant/extend-tests/escaped_selector
 non_conformant/extend-tests/extend-loop
 non_conformant/extend-tests/extend-result-of-extend
 non_conformant/extend-tests/extend-self


### PR DESCRIPTION
Escaped chars in selectors should not been systematically unescaped in the output, leading to unvalid selectors that the parser itself is refusing as valid. 

For now we are keeping the escaped sequence in the selector, in a normalize way, to not take the risk to produce an unvalid selector 

The target and safer should be to have the same way of managing escaping as in string and keyword: store the real char in a non escaped form in the selector representation, and escape in the output what should be escaped only.

But this require a better structure for representation of selectors out of the parser, otherwise this would more or less implie to reparse in the compiler to know what to escape, which would be a shame
(ie for instance escape non alpha first chars of identifiers and non allowed chars in identifier, but without escaping attributes content matching)