### PR TITLE
Fix sourcemaps for the compressed output

### DIFF
--- a/src/Formatter.php
+++ b/src/Formatter.php
@@ -342,7 +342,7 @@ abstract class Formatter
                 );
             }
 
-            $this->currentColumn = \strlen($lastLine);
+            $this->currentColumn += \strlen($lastLine);
         }
 
         echo $str;


### PR DESCRIPTION
When writing new output to the same line that the previous output, the current column needs to be incremented rather than reset.
For the expanded output, the code was fine as the current column is almost always 0 at that point (due to the resetting happening when writing a new line). But the compressed output is writing everything as a single line.

Closes #275