### PR TITLE
Improve the pscss CLI

### DIFF
--- a/bin/pscss
+++ b/bin/pscss
@@ -32,6 +32,8 @@ $inputFile = null;
 $changeDir = false;
 $encoding = false;
 $sourceMap = false;
+$embedSources = false;
+$embedSourceMap = false;
 
 /**
  * Parse argument
@@ -60,12 +62,14 @@ function parseArgument(&$i, $options) {
     }
 }
 
+$arguments = [];
+
 for ($i = 1; $i < $argc; $i++) {
     if ($argv[$i] === '-?' || $argv[$i] === '-h' || $argv[$i] === '--help') {
         $exe = $argv[0];
 
         $HELP = <<<EOT
-Usage: $exe [options] [input-file]
+Usage: $exe [options] [input-file] [output-file]
 
 Options include:
 
@@ -78,6 +82,8 @@ Options include:
     --load-path=PATH    Set import path [-I]
     --precision=N       [deprecated] Ignored. (default 10) [-p]
     --sourcemap         Create source map file
+    --embed-sources     Embed source file contents in source maps
+    --embed-source-map  Embed the source map contents in CSS (default if writing to stdout)
     --style=FORMAT      Set the output style (compressed or expanded) [-s, -t]
     --version           Print the version [-v]
 
@@ -117,6 +123,16 @@ EOT;
         continue;
     }
 
+    if ($argv[$i] === '--embed-sources') {
+        $embedSources = true;
+        continue;
+    }
+
+    if ($argv[$i] === '--embed-source-map') {
+        $embedSourceMap = true;
+        continue;
+    }
+
     if ($argv[$i] === '-T' || $argv[$i] === '--dump-tree') {
         $dumpTree = true;
         continue;
@@ -144,14 +160,12 @@ EOT;
         continue;
     }
 
-    if (file_exists($argv[$i])) {
-        $inputFile = $argv[$i];
-        continue;
-    }
+    $arguments[] = $argv[$i];
 }
 
 
-if ($inputFile) {
+if (isset($arguments[0]) && file_exists($arguments[0])) {
+    $inputFile = $arguments[0];
     $data = file_get_contents($inputFile);
 } else {
     $data = '';
@@ -184,8 +198,25 @@ if ($style) {
     }
 }
 
+$outputFile = isset($arguments[1]) ? $arguments[1] : null;
+
 if ($sourceMap) {
-    $scss->setSourceMap(Compiler::SOURCE_MAP_INLINE);
+    $sourceMapOptions = array(
+        'outputSourceFiles' => $embedSources,
+    );
+    if ($embedSourceMap || $outputFile === null) {
+        $scss->setSourceMap(Compiler::SOURCE_MAP_INLINE);
+    } else {
+        $sourceMapFile = $outputFile . '.map';
+        $sourceMapOptions['sourceMapWriteTo'] = $sourceMapFile;
+        $sourceMapOptions['sourceMapURL'] = basename($sourceMapFile);
+        $sourceMapOptions['sourceMapBasepath'] = getcwd();
+        $sourceMapOptions['sourceMapFilename'] = basename($outputFile);
+
+        $scss->setSourceMap(Compiler::SOURCE_MAP_FILE);
+    }
+
+    $scss->setSourceMapOptions($sourceMapOptions);
 }
 
 if ($encoding) {
@@ -193,8 +224,14 @@ if ($encoding) {
 }
 
 try {
-    echo $scss->compile($data, $inputFile);
+    $output = $scss->compile($data, $inputFile);
 } catch (SassException $e) {
     fwrite(STDERR, $e->getMessage()."\n");
     exit(1);
+}
+
+if ($outputFile) {
+    file_put_contents($outputFile, $output);
+} else {
+    echo $output;
 }


### PR DESCRIPTION
- add support for writing the output to a file rather than stdout. Closes #267
- add support for choosing between a source map file or an inline source map when writing to a file (defaults to a map file for consistency with the official sass CLI)
- add support for embedding sources in source maps