### PR TITLE
Fix support for absolute paths in import rules

### DIFF
--- a/scss.inc.php
+++ b/scss.inc.php
@@ -33,6 +33,7 @@ if (! class_exists('ScssPhp\ScssPhp\Version', false)) {
     include_once __DIR__ . '/src/SourceMap/Base64VLQ.php';
     include_once __DIR__ . '/src/SourceMap/SourceMapGenerator.php';
     include_once __DIR__ . '/src/Type.php';
+    include_once __DIR__ . '/src/Util/Path.php';
     include_once __DIR__ . '/src/Util.php';
     include_once __DIR__ . '/src/Version.php';
 }

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -22,6 +22,7 @@ use ScssPhp\ScssPhp\Formatter\Expanded;
 use ScssPhp\ScssPhp\Formatter\OutputBlock;
 use ScssPhp\ScssPhp\Node\Number;
 use ScssPhp\ScssPhp\SourceMap\SourceMapGenerator;
+use ScssPhp\ScssPhp\Util\Path;
 
 /**
  * The scss compiler and parser.
@@ -5384,7 +5385,7 @@ class Compiler
      */
     private function resolveImportPath($url, $baseDir)
     {
-        $path = rtrim($baseDir, '/').'/'.ltrim($url, '/');
+        $path = Path::join($baseDir, $url);
 
         $hasExtension = preg_match('/.scss$/', $url);
 

--- a/src/Util/Path.php
+++ b/src/Util/Path.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace ScssPhp\ScssPhp\Util;
+
+/**
+ * @internal
+ */
+class Path
+{
+    /**
+     * @param string $path
+     *
+     * @return bool
+     */
+    public static function isAbsolute($path)
+    {
+        if ($path === '') {
+            return false;
+        }
+
+        if ($path[0] === '/') {
+            return true;
+        }
+
+        if (\DIRECTORY_SEPARATOR !== '\\') {
+            return false;
+        }
+
+        if ($path[0] === '\\') {
+            return true;
+        }
+
+        if (\strlen($path) < 3) {
+            return false;
+        }
+
+        if ($path[1] !== ':') {
+            return false;
+        }
+
+        if ($path[2] !== '/' && $path[2] !== '\\') {
+            return false;
+        }
+
+        if (!preg_match('/^[A-Za-z]$/', $path[0])) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @param string $part1
+     * @param string $part2
+     *
+     * @return string
+     */
+    public static function join($part1, $part2)
+    {
+        if ($part1 === '' || self::isAbsolute($part2)) {
+            return $part2;
+        }
+
+        if ($part2 === '') {
+            return $part1;
+        }
+
+        $last = $part1[\strlen($part1) - 1];
+        $separator = \DIRECTORY_SEPARATOR;
+
+        if ($last === '/' || $last === \DIRECTORY_SEPARATOR) {
+            $separator = '';
+        }
+
+        return $part1 . $separator . $part2;
+    }
+}

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -85,6 +85,19 @@ class ApiTest extends TestCase
         );
     }
 
+    public function testImportAbsolutePath()
+    {
+        $this->scss = new Compiler();
+
+        $this->scss->setVariables(['base-path' => __DIR__ . \DIRECTORY_SEPARATOR . 'inputs']);
+        $this->scss->addImportPath(__DIR__ . \DIRECTORY_SEPARATOR . 'inputs');
+
+        $this->assertEquals(
+            trim(file_get_contents(__DIR__ . '/outputs/variables.css')),
+            $this->compile('@import $base-path + "/variables.scss";')
+        );
+    }
+
     /**
      * @dataProvider provideSetVariables
      */

--- a/tests/Util/PathTest.php
+++ b/tests/Util/PathTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace ScssPhp\ScssPhp\Tests\Util;
+
+use ScssPhp\ScssPhp\Util\Path;
+use PHPUnit\Framework\TestCase;
+
+class PathTest extends TestCase
+{
+    /**
+     * @dataProvider provideAbsoluteCases
+     */
+    public function testAbsolute($path, $expected)
+    {
+        $this->assertSame($expected, Path::isAbsolute($path));
+    }
+
+    public static function provideAbsoluteCases()
+    {
+        yield ['', false];
+        yield ['.', false];
+        yield ['..', false];
+        yield ['~', false];
+        yield ['/', true];
+        yield ['/a', true];
+        yield ['a/b', false];
+        yield ['\\', \DIRECTORY_SEPARATOR === '\\'];
+        yield ['\\\\share\a', \DIRECTORY_SEPARATOR === '\\'];
+        yield ['c:\\', \DIRECTORY_SEPARATOR === '\\'];
+        yield ['c:\\a', \DIRECTORY_SEPARATOR === '\\'];
+        yield ['c:/a', \DIRECTORY_SEPARATOR === '\\'];
+        yield ['d:/', \DIRECTORY_SEPARATOR === '\\'];
+        yield ['c:', false];
+        yield ['cd:/a', false];
+        yield ['cd/a', false];
+        yield ['cd\\a', false];
+    }
+
+    /**
+     * @dataProvider provideJoinCases
+     */
+    public function testJoin($part1, $part2, $expected)
+    {
+        $this->assertSame($expected, Path::join($part1, $part2));
+    }
+
+    public static function provideJoinCases()
+    {
+        yield ['', '', ''];
+        yield ['foo', '', 'foo'];
+        yield ['foo/', '', 'foo/'];
+        yield ['', 'foo', 'foo'];
+        yield ['', 'foo/', 'foo/'];
+        yield ['foo', 'bar', 'foo/bar'];
+        yield ['foo', 'bar/', 'foo/bar/'];
+        yield ['foo/', 'bar', 'foo/bar'];
+        yield ['/foo/', 'bar', '/foo/bar'];
+        yield ['/foo/', '/bar', '/bar'];
+        yield ['foo', '/bar', '/bar'];
+    }
+}


### PR DESCRIPTION
The new logic for imports was ported from the dart-sass code, but missed the behavior of path.join in dart when an absolute path is provided. This logic has now been ported as well.