### PR TITLE
Introduce a LoggerInterface

### DIFF
--- a/scss.inc.php
+++ b/scss.inc.php
@@ -26,6 +26,9 @@ if (! class_exists('ScssPhp\ScssPhp\Version', false)) {
     include_once __DIR__ . '/src/Formatter/Expanded.php';
     include_once __DIR__ . '/src/Formatter/Nested.php';
     include_once __DIR__ . '/src/Formatter/OutputBlock.php';
+    include_once __DIR__ . '/src/Logger/LoggerInterface.php';
+    include_once __DIR__ . '/src/Logger/QuietLogger.php';
+    include_once __DIR__ . '/src/Logger/StreamLogger.php';
     include_once __DIR__ . '/src/Node.php';
     include_once __DIR__ . '/src/Node/Number.php';
     include_once __DIR__ . '/src/Parser.php';

--- a/src/Logger/LoggerInterface.php
+++ b/src/Logger/LoggerInterface.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Logger;
+
+/**
+ * Interface implemented by loggers for warnings and debug messages.
+ *
+ * The official Sass implementation recommends that loggers report the
+ * messages immediately rather than waiting for the end of the
+ * compilation, to provide a better debugging experience when the
+ * compilation does not end (error or infinite loop after the warning
+ * for instance).
+ */
+interface LoggerInterface
+{
+    /**
+     * Emits a warning with the given message.
+     *
+     * If $deprecation is true, it indicates that this is a deprecation
+     * warning. Implementations should surface all this information to
+     * the end user.
+     *
+     * @param string $message
+     * @param bool  $deprecation
+     */
+    public function warn($message, $deprecation = false);
+
+    /**
+     * Emits a debugging message.
+     *
+     * @param string $message
+     */
+    public function debug($message);
+}

--- a/src/Logger/QuietLogger.php
+++ b/src/Logger/QuietLogger.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Logger;
+
+/**
+ * A logger that silently ignores all messages.
+ */
+class QuietLogger implements LoggerInterface
+{
+    public function warn($message, $deprecation = false)
+    {
+    }
+
+    public function debug($message)
+    {
+    }
+}

--- a/src/Logger/StreamLogger.php
+++ b/src/Logger/StreamLogger.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Logger;
+
+/**
+ * A logger that prints to a PHP stream (for instance stderr)
+ */
+class StreamLogger implements LoggerInterface
+{
+    private $stream;
+    private $closeOnDestruct;
+
+    /**
+     * @param resource $stream          A stream resource
+     * @param bool     $closeOnDestruct If true, takes ownership of the stream and close it on destruct to avoid leaks.
+     */
+    public function __construct($stream, $closeOnDestruct = false)
+    {
+        $this->stream = $stream;
+        $this->closeOnDestruct = $closeOnDestruct;
+    }
+
+    public function __destruct()
+    {
+        if ($this->closeOnDestruct) {
+            fclose($this->stream);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function warn($message, $deprecation = false)
+    {
+        $prefix = ($deprecation ? 'DEPRECATION ' : '') . 'WARNING: ';
+
+        fwrite($this->stream, $prefix . $message . "\n\n");
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function debug($message)
+    {
+        fwrite($this->stream, $message . "\n");
+    }
+}

--- a/tests/ExceptionTest.php
+++ b/tests/ExceptionTest.php
@@ -14,6 +14,7 @@ namespace ScssPhp\ScssPhp\Tests;
 
 use PHPUnit\Framework\TestCase;
 use ScssPhp\ScssPhp\Compiler;
+use ScssPhp\ScssPhp\Logger\QuietLogger;
 
 /**
  * Exception test
@@ -143,15 +144,9 @@ END_OF_SCSS
 
     private function compile($str)
     {
-        $errorStream = fopen("php://memory", 'r+');
-
         $scss = new Compiler();
-        $scss->setErrorOuput($errorStream);
+        $scss->setLogger(new QuietLogger());
 
-        try {
-            return trim($scss->compile($str));
-        } finally {
-            fclose($errorStream);
-        }
+        return trim($scss->compile($str));
     }
 }

--- a/tests/InputTest.php
+++ b/tests/InputTest.php
@@ -15,6 +15,7 @@ namespace ScssPhp\ScssPhp\Tests;
 use PHPUnit\Framework\TestCase;
 use ScssPhp\ScssPhp\Compiler;
 use ScssPhp\ScssPhp\Formatter\Expanded;
+use ScssPhp\ScssPhp\Logger\QuietLogger;
 
 function _dump($value)
 {
@@ -48,9 +49,7 @@ class InputTest extends TestCase
 
         $this->scss = new Compiler();
         $this->scss->addImportPath(self::$inputDir);
-
-        $fp_err_stream = fopen("php://memory", 'r+');
-        $this->scss->setErrorOuput($fp_err_stream);
+        $this->scss->setLogger(new QuietLogger());
 
         if (getenv('BUILD')) {
             $this->buildInput($inFname, $outFname);
@@ -66,7 +65,6 @@ class InputTest extends TestCase
         $output = file_get_contents($outFname);
 
         $css = $this->scss->compile($input, substr($inFname, strlen(__DIR__) + 1));
-        fclose($fp_err_stream);
         $this->assertEquals($output, $css);
     }
 

--- a/tests/SassSpecTest.php
+++ b/tests/SassSpecTest.php
@@ -15,6 +15,7 @@ namespace ScssPhp\ScssPhp\Tests;
 use PHPUnit\Framework\TestCase;
 use ScssPhp\ScssPhp\Compiler;
 use ScssPhp\ScssPhp\Exception\SassException;
+use ScssPhp\ScssPhp\Logger\StreamLogger;
 
 /**
  * Sass Spec Test - extracts tests from https://github.com/sass/sass-spec
@@ -300,7 +301,7 @@ class SassSpecTest extends TestCase
         $compiler->addImportPath($this->sassSpecDir());
 
         $fp_err_stream = fopen("php://memory", 'r+');
-        $compiler->setErrorOuput($fp_err_stream);
+        $compiler->setLogger(new StreamLogger($fp_err_stream));
 
         if (! strlen($error)) {
             if (getenv('BUILD')) {


### PR DESCRIPTION
The object-oriented interface makes it simpler to customize the reporting of warnings (no need to use a special stream wrapper to keep it realtime). It will also simplify future internal refactorings as object references are easier to share than PHP resources.
As a nice benefit, the stderr stream opened automatically by the compiler is now properly closed when it is not used anymore.

Closes #223 