### PR TITLE
Upgrade sass-spec for the testsuite

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5 || ^8.3 || ^9.4",
-        "sass/sass-spec": "2020.12.29",
+        "sass/sass-spec": "2021.01.20",
         "squizlabs/php_codesniffer": "~3.5",
         "symfony/phpunit-bridge": "^5.1",
         "twbs/bootstrap": "~4.3",
@@ -43,16 +43,16 @@
             "type": "package",
             "package": {
                 "name": "sass/sass-spec",
-                "version": "2020.12.29",
+                "version": "2021.01.20",
                 "source": {
                     "type": "git",
                     "url": "https://github.com/sass/sass-spec.git",
-                    "reference": "d975d33146fb679a6b359ceca329012f02e4a794"
+                    "reference": "a74ad63f2f77a0a6cc3b2e5422c0eb4c848e7809"
                 },
                 "dist": {
                     "type": "zip",
-                    "url": "https://api.github.com/repos/sass/sass-spec/zipball/d975d33146fb679a6b359ceca329012f02e4a794",
-                    "reference": "d975d33146fb679a6b359ceca329012f02e4a794",
+                    "url": "https://api.github.com/repos/sass/sass-spec/zipball/a74ad63f2f77a0a6cc3b2e5422c0eb4c848e7809",
+                    "reference": "a74ad63f2f77a0a6cc3b2e5422c0eb4c848e7809",
                     "shasum": ""
                 }
             }

--- a/tests/SassSpecTest.php
+++ b/tests/SassSpecTest.php
@@ -259,6 +259,8 @@ class SassSpecTest extends TestCase
         }
 
         if (
+            strpos($name, 'directives/for/error/from_float') ||
+            strpos($name, 'directives/for/error/to_float') ||
             strpos($name, 'libsass-closed-issues/issue_1801/import-cycle') ||
             strpos($name, 'libsass-todo-issues/issue_1801/simple-import-loop') ||
             // The loop in issue_221260 is not technically infinite, but we go over the xdebug

--- a/tests/specs/sass-spec-exclude.txt
+++ b/tests/specs/sass-spec-exclude.txt
@@ -702,6 +702,8 @@ css/unicode_range/error/too_many_digits_after_minus
 css/unicode_range/error/too_many_hex_digits
 css/unicode_range/simple
 directives/extend/after_target/multiple_recursive
+directives/for/unit/compatible
+directives/for/unit/from_unitless
 directives/forward/escaped
 directives/if/escaped/if_only
 directives/if/escaped/with_else


### PR DESCRIPTION
New skipped specs (either due to infinite loops or to not implementing the right behavior) should be fixed when working on #194 