### PR TITLE
Clean assertions in color functions

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -6735,9 +6735,6 @@ class Compiler
         }
 
         if ($value->unitless()) {
-            if ($forceTo === 'percent') {
-                $value = new Number($value->getDimension() * 100, '%');
-            }
             return $value;
         }
         if ($value->hasUnit('%')) {

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -6712,14 +6712,16 @@ class Compiler
     }
 
     /**
-     * Assert a value is % or unitless and optionnaly force it to one or the other
+     * Assert a value is % or unitless and optionally force it to one or the other
+     *
      * @param array|Number $value
-     * @param null $varName
+     * @param string|null $varName
      * @param null|string $forceTo
      * @return Number
      * @throws CompilerException
      */
-    public function assertPercentOrUnitless($value, $varName=null, $forceTo = null, $acceptButDeprecated = false) {
+    public function assertPercentOrUnitless($value, $varName = null, $forceTo = null, $acceptButDeprecated = false)
+    {
         $this->assertNumber($value, $varName);
 
         if ($acceptButDeprecated) {

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -6720,7 +6720,7 @@ class Compiler
      * @return Number
      * @throws CompilerException
      */
-    public function assertPercentOrUnitless($value, $varName = null, $forceTo = null, $acceptButDeprecated = false)
+    private function assertPercentOrUnitless($value, $varName = null, $forceTo = null, $acceptButDeprecated = false)
     {
         $this->assertNumber($value, $varName);
 


### PR DESCRIPTION
This cleans things for the helper added in https://github.com/scssphp/scssphp/pull/264:

- fix the phpdoc
- make the helper private as it is an internal one. that avoids having to preserve BC for it
- remove an unused broken unit coercion (keeping a broken coercion in the code would create bugs if we start using it later)