### PR TITLE
Add an object-oriented representation of sass values

### DIFF
--- a/src/Collection/Map.php
+++ b/src/Collection/Map.php
@@ -1,0 +1,163 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Collection;
+
+use ScssPhp\ScssPhp\Value\Value;
+
+/**
+ * A map using Sass values as keys based on Value::equals.
+ *
+ * The map can be either modifiable or unmodifiable. For unmodifiable
+ * maps, all mutators will throw a LogicException.
+ *
+ * Iteration preserves the order in which keys have been inserted.
+ *
+ * @template T
+ * @template-implements \IteratorAggregate<Value, T>
+ */
+final class Map implements \Countable, \IteratorAggregate
+{
+    /**
+     * @var bool
+     */
+    private $modifiable = true;
+
+    // TODO implement a better internal storage to allow reading keys in O(1).
+
+    /**
+     * @var array<int, array{Value, T}>
+     */
+    private $pairs = [];
+
+    /**
+     * Returns a modifiable version of the Map.
+     *
+     * @template V
+     * @param Map<V> $map
+     *
+     * @return Map<V>
+     */
+    public static function of(Map $map): Map
+    {
+        $modifiableMap = clone $map;
+        $modifiableMap->modifiable = true;
+
+        return $modifiableMap;
+    }
+
+    /**
+     * Returns an unmodifiable version of the Map.
+     *
+     * All mutators will throw a LogicException when trying to use them.
+     *
+     * @template V
+     * @param Map<V> $map
+     *
+     * @return Map<V>
+     */
+    public static function unmodifiable(Map $map): Map
+    {
+        if (!$map->modifiable) {
+            return $map;
+        }
+
+        $unmodifiableMap = clone $map;
+        $unmodifiableMap->modifiable = false;
+
+        return $unmodifiableMap;
+    }
+
+    public function getIterator(): \Traversable
+    {
+        foreach ($this->pairs as $pair) {
+            yield $pair[0] => $pair[1];
+        }
+    }
+
+    public function count(): int
+    {
+        return \count($this->pairs);
+    }
+
+    /**
+     * The value for the given key, or `null` if $key is not in the map.
+     *
+     * @return T|null
+     */
+    public function get(Value $key)
+    {
+        foreach ($this->pairs as $pair) {
+            if ($key->equals($pair[0])) {
+                return $pair[1];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Associates the key with the given value.
+     *
+     * If the key was already in the map, its associated value is changed.
+     * Otherwise the key/value pair is added to the map.
+     *
+     * @param T $value
+     */
+    public function put(Value $key, $value): void
+    {
+        $this->assertModifiable();
+
+        foreach ($this->pairs as $i => $pair) {
+            if ($key->equals($pair[0])) {
+                $this->pairs[$i][1] = $value;
+
+                return;
+            }
+        }
+
+        $this->pairs[] = [$key, $value];
+    }
+
+    /**
+     * Removes $key and its associated value, if present, from the map.
+     *
+     * Returns the value associated with `key` before it was removed.
+     * Returns `null` if `key` was not in the map.
+     *
+     * Note that some maps allow `null` as a value,
+     * so a returned `null` value doesn't always mean that the key was absent.
+     *
+     * @return T|null
+     */
+    public function remove(Value $key)
+    {
+        $this->assertModifiable();
+
+        foreach ($this->pairs as $i => $pair) {
+            if ($key->equals($pair[0])) {
+                unset($this->pairs[$i]);
+
+                return $pair[1];
+            }
+        }
+
+        return null;
+    }
+
+    private function assertModifiable(): void
+    {
+        if (!$this->modifiable) {
+            throw new \LogicException('Mutating an unmodifiable Map is not supported. Use Map::of to create a modifiable copy.');
+        }
+    }
+}

--- a/src/Serializer/Serializer.php
+++ b/src/Serializer/Serializer.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2018-2020 Anthon Pang
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Serializer;
+
+use ScssPhp\ScssPhp\Exception\SassScriptException;
+use ScssPhp\ScssPhp\Value\Value;
+
+/**
+ * @internal
+ */
+final class Serializer
+{
+    /**
+     * Converts [value] to a CSS string.
+     *
+     * If $inspect is `true`, this will emit an unambiguous representation of the
+     * source structure. Note however that, although this will be valid SCSS, it
+     * may not be valid CSS. If $inspect is `false` and $value can't be
+     * represented in plain CSS, throws a {@see SassScriptException}.
+     *
+     * If $quote is `false`, quoted strings are emitted without quotes.
+     */
+    public static function serializeValue(Value $value, bool $inspect = false, bool $quote = true): string
+    {
+        $visitor = new SerializeVisitor($inspect, $quote);
+        $value->accept($visitor);
+
+        return (string) $visitor->getBuffer();
+    }
+}

--- a/src/Serializer/SimpleStringBuffer.php
+++ b/src/Serializer/SimpleStringBuffer.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2018-2020 Anthon Pang
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Serializer;
+
+class SimpleStringBuffer implements StringBuffer
+{
+    /**
+     * @var string
+     */
+    private $text = '';
+
+    public function getLength(): int
+    {
+        return \strlen($this->text);
+    }
+
+    public function write(string $string): void
+    {
+        $this->text .= $string;
+    }
+
+    public function writeChar(string $char): void
+    {
+        $this->text .= $char;
+    }
+
+    public function __toString(): string
+    {
+        return $this->text;
+    }
+}

--- a/src/Serializer/StringBuffer.php
+++ b/src/Serializer/StringBuffer.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2018-2020 Anthon Pang
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Serializer;
+
+/**
+ * @internal
+ */
+interface StringBuffer
+{
+    /**
+     * Returns the length of the content that has been accumulated so far.
+     */
+    public function getLength(): int;
+
+    public function write(string $string): void;
+
+    /**
+     * Writes a single char to the buffer.
+     */
+    public function writeChar(string $char): void;
+
+    public function __toString(): string;
+}

--- a/src/Util.php
+++ b/src/Util.php
@@ -105,6 +105,43 @@ final class Util
     }
 
     /**
+     * mb_ord() wrapper
+     *
+     * @param string $string
+     *
+     * @return int
+     */
+    public static function mbOrd(string $string): int
+    {
+        if (\function_exists('mb_ord')) {
+            return mb_ord($string, 'UTF-8');
+        }
+
+        if (1 === \strlen($string)) {
+            return \ord($string);
+        }
+
+        $s = unpack('C*', substr($string, 0, 4));
+
+        if (!$s) {
+            return 0;
+        }
+
+        $code = $s[1];
+        if (0xF0 <= $code) {
+            return (($code - 0xF0) << 18) + (($s[2] - 0x80) << 12) + (($s[3] - 0x80) << 6) + $s[4] - 0x80;
+        }
+        if (0xE0 <= $code) {
+            return (($code - 0xE0) << 12) + (($s[2] - 0x80) << 6) + $s[3] - 0x80;
+        }
+        if (0xC0 <= $code) {
+            return (($code - 0xC0) << 6) + $s[2] - 0x80;
+        }
+
+        return $code;
+    }
+
+    /**
      * mb_strlen() wrapper
      *
      * @param string $string

--- a/src/Util/Character.php
+++ b/src/Util/Character.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Util;
+
+/**
+ * @internal
+ */
+final class Character
+{
+    /**
+     * Returns whether $character is a digit.
+     */
+    public static function isDigit(string $character): bool
+    {
+        $charCode = \ord($character);
+
+        return $charCode >= \ord('0') && $charCode <= \ord('9');
+    }
+
+    /**
+     * Returns whether $character is a hexadecimal digit.
+     */
+    public static function isHex(string $character): bool
+    {
+        if (self::isDigit($character)) {
+            return true;
+        }
+
+        $charCode = \ord($character);
+
+        if ($charCode >= \ord('a') && $charCode <= \ord('f')) {
+            return true;
+        }
+
+        if ($charCode >= \ord('A') && $charCode <= \ord('F')) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Util/Equatable.php
+++ b/src/Util/Equatable.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Util;
+
+/**
+ * @internal
+ */
+interface Equatable
+{
+    public function equals(object $other): bool;
+}

--- a/src/Util/ErrorUtil.php
+++ b/src/Util/ErrorUtil.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2018-2020 Anthon Pang
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Util;
+
+/**
+ * @internal
+ */
+class ErrorUtil
+{
+    /**
+     * @throws \OutOfRangeException
+     */
+    public static function checkIntInInterval(int $value, int $minValue, int $maxValue, ?string $name = null): void
+    {
+        if ($value < $minValue || $value > $maxValue) {
+            $nameDisplay = $name ? " $name" : '';
+
+            throw new \OutOfRangeException("Invalid value:$nameDisplay must be between $minValue and $maxValue: $value.");
+        }
+    }
+}

--- a/src/Util/NumberUtil.php
+++ b/src/Util/NumberUtil.php
@@ -1,0 +1,233 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2018-2020 Anthon Pang
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Util;
+
+/**
+ * Utilities to deal with numbers with fuzziness for the Sass precision
+ *
+ * @internal
+ */
+class NumberUtil
+{
+    public const EPSILON = 0.00000000001; // 10^(-PRECISION-1)
+
+    /**
+     * @param int|float $number1
+     * @param int|float $number2
+     *
+     * @return bool
+     */
+    public static function fuzzyEquals($number1, $number2): bool
+    {
+        return abs($number1 - $number2) < self::EPSILON;
+    }
+
+    /**
+     * @param int|float $number1
+     * @param int|float $number2
+     *
+     * @return bool
+     */
+    public static function fuzzyLessThan($number1, $number2): bool
+    {
+        return $number1 < $number2 && !self::fuzzyEquals($number1, $number2);
+    }
+
+    /**
+     * @param int|float $number1
+     * @param int|float $number2
+     *
+     * @return bool
+     */
+    public static function fuzzyLessThanOrEquals($number1, $number2): bool
+    {
+        return $number1 <= $number2 || self::fuzzyEquals($number1, $number2);
+    }
+
+    /**
+     * @param int|float $number1
+     * @param int|float $number2
+     *
+     * @return bool
+     */
+    public static function fuzzyGreaterThan($number1, $number2): bool
+    {
+        return $number1 > $number2 && !self::fuzzyEquals($number1, $number2);
+    }
+
+    /**
+     * @param int|float $number1
+     * @param int|float $number2
+     *
+     * @return bool
+     */
+    public static function fuzzyGreaterThanOrEquals($number1, $number2): bool
+    {
+        return $number1 >= $number2 || self::fuzzyEquals($number1, $number2);
+    }
+
+    /**
+     * @param int|float $number
+     *
+     * @return bool
+     */
+    public static function fuzzyIsInt($number): bool
+    {
+        if (\is_int($number)) {
+            return true;
+        }
+
+        // Check against 0.5 rather than 0.0 so that we catch numbers that are both
+        // very slightly above an integer, and very slightly below.
+        return self::fuzzyEquals(fmod(abs($number - 0.5), 1), 0.5);
+    }
+
+    /**
+     * @param int|float $number
+     *
+     * @return int|null
+     */
+    public static function fuzzyAsInt($number): ?int
+    {
+        if (\is_int($number)) {
+            return $number;
+        }
+
+        if (self::fuzzyIsInt($number)) {
+            return (int) round($number);
+        }
+
+        return null;
+    }
+
+    /**
+     * @param int|float $number
+     *
+     * @return int
+     */
+    public static function fuzzyRound($number): int
+    {
+        if (\is_int($number)) {
+            return $number;
+        }
+
+        if ($number > 0) {
+            return intval(self::fuzzyLessThan(fmod($number, 1), 0.5) ? floor($number) : ceil($number));
+        }
+
+        return intval(self::fuzzyLessThanOrEquals(fmod($number, 1), 0.5) ? floor($number) : ceil($number));
+    }
+
+    /**
+     * @param int|float $number
+     * @param int|float $min
+     * @param int|float $max
+     *
+     * @return int|float|null
+     */
+    public static function fuzzyCheckRange($number, $min, $max)
+    {
+        if (self::fuzzyEquals($number, $min)) {
+            return $min;
+        }
+
+        if (self::fuzzyEquals($number, $max)) {
+            return $max;
+        }
+
+        if ($number > $min && $number < $max) {
+            return $number;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param int|float $number
+     * @param int|float $min
+     * @param int|float $max
+     * @param string|null $name
+     *
+     * @return int|float
+     *
+     * @throws \OutOfRangeException
+     */
+    public static function fuzzyAssertRange($number, $min, $max, ?string $name = null)
+    {
+        $result = self::fuzzyCheckRange($number, $min, $max);
+
+        if (!\is_null($result)) {
+            return $result;
+        }
+
+        $nameDisplay = $name ? " $name" : '';
+
+        throw new \OutOfRangeException("Invalid value:$nameDisplay must be between $min and $max: $number.");
+    }
+
+    /**
+     * Returns $num1 / $num2, using Sass's division semantic.
+     *
+     * Sass allows dividing by 0.
+     *
+     * @param int|float $num1
+     * @param int|float $num2
+     *
+     * @return int|float
+     */
+    public static function divideLikeSass($num1, $num2)
+    {
+        if ($num2 == 0) {
+            if ($num1 == 0) {
+                return NAN;
+            }
+
+            if ($num1 > 0) {
+                return INF;
+            }
+
+            return -INF;
+        }
+
+        return $num1 / $num2;
+    }
+
+    /**
+     * Returns $num1 module $num2, using Sass's modulo semantic, which is inherited from Ruby.
+     *
+     * PHP's fdiv has a different semantic when the 2 numbers have a different sign.
+     *
+     * @param int|float $num1
+     * @param int|float $num2
+     *
+     * @return int|float
+     */
+    public static function moduloLikeSass($num1, $num2)
+    {
+        if ($num2 == 0) {
+            return NAN;
+        }
+
+        $result = fmod($num1, $num2);
+
+        if ($result == 0) {
+            return 0;
+        }
+
+        if ($num2 < 0 xor $num1 < 0) {
+            $result += $num2;
+        }
+
+        return $result;
+    }
+}

--- a/src/Value/CalculationInterpolation.php
+++ b/src/Value/CalculationInterpolation.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Value;
+
+use ScssPhp\ScssPhp\Util\Equatable;
+
+/**
+ * A string injected into a {@see SassCalculation} using interpolation.
+ *
+ * This is tracked separately from string arguments because it requires
+ * additional parentheses when used as an operand of a {@see CalculationOperation}.
+ */
+final class CalculationInterpolation implements Equatable
+{
+    /**
+     * @var string
+     */
+    private $value;
+
+    public function __construct(string $value)
+    {
+        $this->value = $value;
+    }
+
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+
+    public function equals(object $other): bool
+    {
+        return $other instanceof CalculationInterpolation && $this->value === $other->value;
+    }
+}

--- a/src/Value/CalculationOperation.php
+++ b/src/Value/CalculationOperation.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Value;
+
+use ScssPhp\ScssPhp\Util\Equatable;
+
+/**
+ * A binary operation that can appear in a {@see SassCalculation}.
+ */
+final class CalculationOperation implements Equatable
+{
+    /**
+     * @phpstan-var CalculationOperator::*
+     */
+    private $operator;
+
+    /**
+     * The left-hand operand.
+     *
+     * This is either a {@see SassNumber}, a {@see SassCalculation}, an unquoted
+     * {@see SassString}, a {@see CalculationOperation}, or a {@see CalculationInterpolation}.
+     *
+     * @var object
+     */
+    private $left;
+
+    /**
+     * The right-hand operand.
+     *
+     * This is either a {@see SassNumber}, a {@see SassCalculation}, an unquoted
+     * {@see SassString}, a {@see CalculationOperation}, or a {@see CalculationInterpolation}.
+     *
+     * @var object
+     */
+    private $right;
+
+    /**
+     * @param string $operator
+     * @param object $left
+     * @param object $right
+     *
+     * @phpstan-param CalculationOperator::* $operator
+     */
+    public function __construct(string $operator, object $left, object $right)
+    {
+        $this->operator = $operator;
+        $this->left = $left;
+        $this->right = $right;
+    }
+
+    /**
+     * @phpstan-return CalculationOperator::*
+     */
+    public function getOperator(): string
+    {
+        return $this->operator;
+    }
+
+    public function getLeft(): object
+    {
+        return $this->left;
+    }
+
+    public function getRight(): object
+    {
+        return $this->right;
+    }
+
+    public function equals(object $other): bool
+    {
+        assert($this->left instanceof Equatable);
+        assert($this->right instanceof Equatable);
+
+        return $other instanceof CalculationOperation && $this->operator === $other->operator && $this->left->equals($other->left) && $this->right->equals($other->right);
+    }
+}

--- a/src/Value/CalculationOperator.php
+++ b/src/Value/CalculationOperator.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Value;
+
+/**
+ * An enumeration of possible operators for {@see CalculationOperation}.
+ */
+final class CalculationOperator
+{
+    public const PLUS = '+';
+    public const MINUS = '-';
+    public const TIMES = '*';
+    public const DIVIDED_BY = '/';
+
+    /**
+     * The precedence of the operator
+     *
+     * An operator with higher precedence binds tighter.
+     *
+     * @phpstan-param CalculationOperator::* $operator
+     *
+     * @internal
+     */
+    public static function getPrecedence(string $operator): int
+    {
+        switch ($operator) {
+            case self::PLUS:
+            case self::MINUS:
+                return 1;
+
+            case self::TIMES:
+            case self::DIVIDED_BY:
+                return 2;
+        }
+
+        throw new \InvalidArgumentException(sprintf('Unknown operator "%s".', $operator));
+    }
+}

--- a/src/Value/ComplexSassNumber.php
+++ b/src/Value/ComplexSassNumber.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Value;
+
+/**
+ * A specialized subclass of {@see SassNumber} for numbers that are neither {@see UnitlessSassNumber} nor {@see SingleUnitSassNumber}.
+ *
+ * @internal
+ */
+final class ComplexSassNumber extends SassNumber
+{
+    /**
+     * @var list<string>
+     */
+    private $numeratorUnits;
+
+    /**
+     * @var list<string>
+     */
+    private $denominatorUnits;
+
+    /**
+     * @param int|float                          $value
+     * @param list<string>                       $numeratorUnits
+     * @param list<string>                       $denominatorUnits
+     * @param array{SassNumber, SassNumber}|null $asSlash
+     */
+    public function __construct($value, array $numeratorUnits, array $denominatorUnits, array $asSlash = null)
+    {
+        assert(\count($numeratorUnits) > 1 || \count($denominatorUnits) > 0);
+
+        parent::__construct($value, $asSlash);
+        $this->numeratorUnits = $numeratorUnits;
+        $this->denominatorUnits = $denominatorUnits;
+    }
+
+    public function getNumeratorUnits(): array
+    {
+        return $this->numeratorUnits;
+    }
+
+    public function getDenominatorUnits(): array
+    {
+        return $this->denominatorUnits;
+    }
+
+    public function hasUnits(): bool
+    {
+        return true;
+    }
+
+    public function hasUnit(string $unit): bool
+    {
+        return false;
+    }
+
+    public function compatibleWithUnit(string $unit): bool
+    {
+        return false;
+    }
+
+    public function hasPossiblyCompatibleUnits(SassNumber $other): bool
+    {
+        // This logic is well-defined, and we could implement it in principle.
+        // However, it would be fairly complex and there's no clear need for it yet.
+        throw new \BadMethodCallException(__METHOD__ . 'is not implemented.');
+    }
+
+    protected function withValue($value): SassNumber
+    {
+        return new self($value, $this->numeratorUnits, $this->denominatorUnits);
+    }
+
+    public function withSlash(SassNumber $numerator, SassNumber $denominator): SassNumber
+    {
+        return new self($this->getValue(), $this->numeratorUnits, $this->denominatorUnits, array($numerator, $denominator));
+    }
+}

--- a/src/Value/ListSeparator.php
+++ b/src/Value/ListSeparator.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Value;
+
+final class ListSeparator
+{
+    const COMMA = ',';
+    const SPACE = ' ';
+    const SLASH = '/';
+    const UNDECIDED = '';
+}

--- a/src/Value/SassArgumentList.php
+++ b/src/Value/SassArgumentList.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Value;
+
+final class SassArgumentList extends SassList
+{
+    /**
+     * @var array<string, Value>
+     */
+    private $keywords;
+
+    /**
+     * @var bool
+     */
+    private $keywordAccessed = false;
+
+    /**
+     * SassArgumentList constructor.
+     *
+     * @param list<Value>          $contents
+     * @param array<string, Value> $keywords
+     * @param string               $separator
+     *
+     * @phpstan-param ListSeparator::* $separator
+     */
+    public function __construct(array $contents, array $keywords, string $separator)
+    {
+        parent::__construct($contents, $separator);
+        $this->keywords = $keywords;
+    }
+
+    /**
+     * @return array<string, Value>
+     */
+    public function getKeywords(): array
+    {
+        $this->keywordAccessed = true;
+
+        return $this->keywords;
+    }
+
+    /**
+     * @return bool
+     *
+     * @internal
+     */
+    public function wereKeywordAccessed(): bool
+    {
+        return $this->keywordAccessed;
+    }
+}

--- a/src/Value/SassBoolean.php
+++ b/src/Value/SassBoolean.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Value;
+
+use ScssPhp\ScssPhp\Visitor\ValueVisitor;
+
+final class SassBoolean extends Value
+{
+    /**
+     * @var SassBoolean|null
+     */
+    private static $trueInstance;
+
+    /**
+     * @var SassBoolean|null
+     */
+    private static $falseInstance;
+
+    /**
+     * @var bool
+     */
+    private $value;
+
+    public static function create(bool $value): SassBoolean
+    {
+        if ($value) {
+            if (self::$trueInstance === null) {
+                self::$trueInstance = new self(true);
+            }
+
+            return self::$trueInstance;
+        }
+
+        if (self::$falseInstance === null) {
+            self::$falseInstance = new self(false);
+        }
+
+        return self::$falseInstance;
+    }
+
+    private function __construct(bool $value)
+    {
+        $this->value = $value;
+    }
+
+    public function getValue(): bool
+    {
+        return $this->value;
+    }
+
+    public function isTruthy(): bool
+    {
+        return $this->value;
+    }
+
+    public function accept(ValueVisitor $visitor)
+    {
+        return $visitor->visitBoolean($this);
+    }
+
+    public function assertBoolean(?string $name = null): SassBoolean
+    {
+        return $this;
+    }
+
+    public function unaryNot(): Value
+    {
+        return self::create(!$this->value);
+    }
+
+    public function equals(object $other): bool
+    {
+        if (!$other instanceof SassBoolean) {
+            return false;
+        }
+
+        return $this->value === $other->value;
+    }
+}

--- a/src/Value/SassCalculation.php
+++ b/src/Value/SassCalculation.php
@@ -1,0 +1,506 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Value;
+
+use ScssPhp\ScssPhp\Exception\SassScriptException;
+use ScssPhp\ScssPhp\Util\Equatable;
+use ScssPhp\ScssPhp\Util\NumberUtil;
+use ScssPhp\ScssPhp\Visitor\ValueVisitor;
+
+/**
+ * A SassScript calculation.
+ *
+ * Although calculations can in principle have any name or any number of
+ * arguments, this class only exposes the specific calculations that are
+ * supported by the Sass spec. This ensures that all calculations that the user
+ * works with are always fully simplified.
+ */
+final class SassCalculation extends Value
+{
+    /**
+     * The calculation's name, such as `"calc"`.
+     *
+     * @var string
+     */
+    private $name;
+
+    /**
+     * The calculation's arguments.
+     *
+     * Each argument is either a {@see SassNumber}, a {@see SassCalculation}, an unquoted
+     * {@see SassString}, a {@see CalculationOperation}, or a {@see CalculationInterpolation}.
+     *
+     * @var list<object>
+     */
+    private $arguments;
+
+    /**
+     * Creates a `calc()` calculation with the given $argument.
+     *
+     * The $argument must be either a {@see SassNumber}, a {@see SassCalculation}, an
+     * unquoted {@see SassString}, a {@see CalculationOperation}, or a
+     * {@see CalculationInterpolation}.
+     *
+     * This automatically simplifies the calculation, so it may return a
+     * {@see SassNumber} rather than a {@see SassCalculation}. It throws an exception if it
+     * can determine that the calculation will definitely produce invalid CSS.
+     *
+     * @param list<object> $argument
+     *
+     * @return Value
+     *
+     * @throws SassScriptException
+     */
+    public static function calc($argument): Value
+    {
+        $argument = self::simplify($argument);
+
+        if ($argument instanceof SassNumber) {
+            return $argument;
+        }
+
+        if ($argument instanceof SassCalculation) {
+            return $argument;
+        }
+
+        return new SassCalculation('calc', [$argument]);
+    }
+
+    /**
+     * Creates a `min()` calculation with the given $arguments.
+     *
+     * Each argument must be either a {@see SassNumber}, a {@see SassCalculation}, an
+     * unquoted {@see SassString}, a {@see CalculationOperation}, or a
+     * {@see CalculationInterpolation}. It must be passed at least one argument.
+     *
+     * This automatically simplifies the calculation, so it may return a
+     * {@see SassNumber} rather than a {@see SassCalculation}. It throws an exception if it
+     * can determine that the calculation will definitely produce invalid CSS.
+     *
+     * @param list<object> $arguments
+     *
+     * @return Value
+     *
+     * @throws SassScriptException
+     */
+    public static function min(array $arguments): Value
+    {
+        $args = self::simplifyArguments($arguments);
+
+        if (!$args) {
+            throw new \InvalidArgumentException('min() must have at least one argument.');
+        }
+
+        /** @var SassNumber|null $minimum */
+        $minimum = null;
+
+        foreach ($args as $arg) {
+            if (!$arg instanceof SassNumber || $minimum !== null && !$minimum->isComparableTo($arg)) {
+                $minimum = null;
+                break;
+            }
+
+            if ($minimum === null || $minimum->greaterThan($arg)->isTruthy()) {
+                $minimum = $arg;
+            }
+        }
+
+        if ($minimum !== null) {
+            return $minimum;
+        }
+
+        self::verifyCompatibleNumbers($args);
+
+        return new SassCalculation('min', $args);
+    }
+
+    /**
+     * Creates a `max()` calculation with the given $arguments.
+     *
+     * Each argument must be either a {@see SassNumber}, a {@see SassCalculation}, an
+     * unquoted {@see SassString}, a {@see CalculationOperation}, or a
+     * {@see CalculationInterpolation}. It must be passed at least one argument.
+     *
+     * This automatically simplifies the calculation, so it may return a
+     * {@see SassNumber} rather than a {@see SassCalculation}. It throws an exception if it
+     * can determine that the calculation will definitely produce invalid CSS.
+     *
+     * @param list<object> $arguments
+     *
+     * @return Value
+     *
+     * @throws SassScriptException
+     */
+    public static function max(array $arguments): Value
+    {
+        $args = self::simplifyArguments($arguments);
+
+        if (!$args) {
+            throw new \InvalidArgumentException('max() must have at least one argument.');
+        }
+
+        /** @var SassNumber|null $maximum */
+        $maximum = null;
+
+        foreach ($args as $arg) {
+            if (!$arg instanceof SassNumber || $maximum !== null && !$maximum->isComparableTo($arg)) {
+                $maximum = null;
+                break;
+            }
+
+            if ($maximum === null || $maximum->lessThan($arg)->isTruthy()) {
+                $maximum = $arg;
+            }
+        }
+
+        if ($maximum !== null) {
+            return $maximum;
+        }
+
+        self::verifyCompatibleNumbers($args);
+
+        return new SassCalculation('max', $args);
+    }
+
+    /**
+     * Creates a `clamp()` calculation with the given [min], [value], and [max].
+     *
+     * Each argument must be either a {@see SassNumber}, a {@see SassCalculation}, an
+     * unquoted {@see SassString}, a {@see CalculationOperation}, or a
+     * {@see CalculationInterpolation}.
+     *
+     * This automatically simplifies the calculation, so it may return a
+     * {@see SassNumber} rather than a {@see SassCalculation}. It throws an exception if it
+     * can determine that the calculation will definitely produce invalid CSS.
+     *
+     * This may be passed fewer than three arguments, but only if one of the
+     * arguments is an unquoted `var()` string.
+     *
+     * @param object      $min
+     * @param object|null $value
+     * @param object|null $max
+     *
+     * @return Value
+     *
+     * @throws SassScriptException
+     */
+    public static function clamp(object $min, object $value = null, object $max = null): Value
+    {
+        if ($value === null && $max !== null) {
+            throw new \InvalidArgumentException('If value is null, max must also be null.');
+        }
+
+        $min = self::simplify($min);
+
+        if ($value !== null) {
+            $value = self::simplify($value);
+        }
+
+        if ($max !== null) {
+            $max = self::simplify($max);
+        }
+
+        if ($min instanceof SassNumber && $value instanceof SassNumber && $max instanceof SassNumber && $min->hasCompatibleUnits($value) && $min->hasCompatibleUnits($max)) {
+            if ($value->lessThanOrEquals($min)->isTruthy()) {
+                return $min;
+            }
+
+            if ($value->greaterThanOrEquals($max)->isTruthy()) {
+                return $max;
+            }
+
+            return $value;
+        }
+
+        $args = array_filter([$min, $value, $max]);
+        self::verifyCompatibleNumbers($args);
+        self::verifyLength($args, 3);
+
+        return new SassCalculation('clamp', $args);
+    }
+
+    /**
+     * Creates and simplifies a {@see CalculationOperation} with the given $operator,
+     * $left, and $right.
+     *
+     * This automatically simplifies the operation, so it may return a
+     * {@see SassNumber} rather than a {@see CalculationOperation}.
+     *
+     * Each of $left and $right must be either a {@see SassNumber}, a
+     * {@see SassCalculation}, an unquoted {@see SassString}, a {@see CalculationOperation}, or
+     * a {@see CalculationInterpolation}.
+     *
+     * @param string $operator
+     * @param object $left
+     * @param object $right
+     *
+     * @return object
+     *
+     * @phpstan-param CalculationOperator::* $operator
+     *
+     * @throws SassScriptException
+     */
+    public static function operate(string $operator, object $left, object $right): object
+    {
+        return self::operateInternal($operator, $left, $right, false);
+    }
+
+    /**
+     * Like {@see operate}, but with the internal-only $inMinMax parameter.
+     *
+     * If $inMinMax is `true`, this allows unitless numbers to be added and
+     * subtracted with numbers with units, for backwards-compatibility with the
+     * old global `min()` and `max()` functions.
+     *
+     * @param string $operator
+     * @param object $left
+     * @param object $right
+     * @param bool   $inMinMax
+     *
+     * @return object
+     *
+     * @throws SassScriptException
+     *
+     * @phpstan-param CalculationOperator::* $operator
+     *
+     * @internal
+     */
+    public static function operateInternal(string $operator, object $left, object $right, bool $inMinMax): object
+    {
+        $left = self::simplify($left);
+        $right = self::simplify($right);
+
+        if ($operator === CalculationOperator::PLUS || $operator === CalculationOperator::MINUS) {
+            if ($left instanceof SassNumber && $right instanceof SassNumber && ($inMinMax ? $left->isComparableTo($right) : $left->hasCompatibleUnits($right))) {
+                return $operator === CalculationOperator::PLUS ? $left->plus($right) : $left->minus($right);
+            }
+
+            self::verifyCompatibleNumbers([$left, $right]);
+
+            if ($right instanceof SassNumber && NumberUtil::fuzzyLessThan($right->getValue(), 0)) {
+                $right = $right->times(SassNumber::create(-1));
+                $operator = $operator === CalculationOperator::PLUS ? CalculationOperator::MINUS : CalculationOperator::PLUS;
+            }
+
+            return new CalculationOperation($operator, $left, $right);
+        }
+
+        if ($left instanceof SassNumber && $right instanceof SassNumber) {
+            return $operator === CalculationOperator::TIMES ? $left->times($right) : $left->dividedBy($right);
+        }
+
+        return new CalculationOperation($operator, $left, $right);
+    }
+
+    /**
+     * An internal constructor that doesn't perform any validation or
+     * simplification.
+     *
+     * @param string       $name
+     * @param list<object> $arguments
+     */
+    private function __construct(string $name, array $arguments)
+    {
+        $this->name = $name;
+        $this->arguments = $arguments;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function isSpecialNumber(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return list<object>
+     */
+    public function getArguments(): array
+    {
+        return $this->arguments;
+    }
+
+    public function accept(ValueVisitor $visitor)
+    {
+        return $visitor->visitCalculation($this);
+    }
+
+    public function assertCalculation(?string $name = null): SassCalculation
+    {
+        return $this;
+    }
+
+    public function plus(Value $other): Value
+    {
+        if ($other instanceof SassString) {
+            return parent::plus($other);
+        }
+
+        throw new SassScriptException("Undefined operation \"$this + $other\".");
+    }
+
+    public function minus(Value $other): Value
+    {
+        throw new SassScriptException("Undefined operation \"$this - $other\".");
+    }
+
+    public function unaryPlus(): Value
+    {
+        throw new SassScriptException("Undefined operation \"+$this\".");
+    }
+
+    public function unaryMinus(): Value
+    {
+        throw new SassScriptException("Undefined operation \"-$this\".");
+    }
+
+    public function equals(object $other): bool
+    {
+        if (!$other instanceof SassCalculation || $this->name !== $other->name) {
+            return false;
+        }
+
+        if (\count($this->arguments) !== \count($other->arguments)) {
+            return false;
+        }
+
+        foreach ($this->arguments as $i => $argument) {
+            assert($argument instanceof Equatable);
+            $otherArgument = $other->arguments[$i];
+
+            if (!$argument->equals($otherArgument)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param list<mixed> $args
+     *
+     * @return list<object>
+     *
+     * @throws SassScriptException
+     */
+    private static function simplifyArguments(array $args): array
+    {
+        return array_map([self::class, 'simplify'], $args);
+    }
+
+    /**
+     * @param mixed $arg
+     *
+     * @return object
+     *
+     * @throws SassScriptException
+     */
+    private static function simplify($arg): object
+    {
+        if ($arg instanceof SassNumber || $arg instanceof CalculationInterpolation || $arg instanceof CalculationOperation) {
+            return $arg;
+        }
+
+        if ($arg instanceof SassString) {
+            if (!$arg->hasQuotes()) {
+                return $arg;
+            }
+
+            throw new SassScriptException("Quoted string $arg can't be used in a calculation.");
+        }
+
+        if ($arg instanceof SassCalculation) {
+            return $arg->getName() === 'calc' ? $arg->getArguments()[0] : $arg;
+        }
+
+        if ($arg instanceof Value) {
+            throw new SassScriptException("Value $arg can't be used in a calculation.");
+        }
+
+        throw new \InvalidArgumentException(sprintf('Unexpected calculation argument %s.', \is_object($arg) ? get_class($arg) : gettype($arg)));
+    }
+
+    /**
+     * Verifies that all the numbers in $args aren't known to be incompatible
+     * with one another, and that they don't have units that are too complex for
+     * calculations.
+     *
+     * @param list<object> $args
+     *
+     * @throws SassScriptException
+     */
+    private static function verifyCompatibleNumbers(array $args): void
+    {
+        foreach ($args as $arg) {
+            if (!$arg instanceof SassNumber) {
+                continue;
+            }
+
+            if (\count($arg->getNumeratorUnits()) > 1 || \count($arg->getDenominatorUnits())) {
+                throw new SassScriptException("Number $arg isn't compatible with CSS calculations.");
+            }
+        }
+
+        for ($i = 0; $i < \count($args); $i++) {
+            $number1 = $args[$i];
+
+            if (!$number1 instanceof SassNumber) {
+                continue;
+            }
+
+            for ($j = $i + 1; $j < \count($args); $j++) {
+                $number2 = $args[$j];
+
+                if (!$number2 instanceof SassNumber) {
+                    continue;
+                }
+
+                if ($number1->hasPossiblyCompatibleUnits($number2)) {
+                    continue;
+                }
+
+                throw new SassScriptException("$number1 and $number2 are incompatible.");
+            }
+        }
+    }
+
+    /**
+     * Throws a {@see SassScriptException} if $args isn't $expectedLength *and*
+     * doesn't contain either a {@see SassString} or a {@see CalculationInterpolation}.
+     *
+     * @param list<object> $args
+     * @param int          $expectedLength
+     *
+     * @throws SassScriptException
+     */
+    private static function verifyLength(array $args, int $expectedLength): void
+    {
+        if (\count($args) === $expectedLength) {
+            return;
+        }
+
+        foreach ($args as $arg) {
+            if ($arg instanceof SassString || $arg instanceof CalculationInterpolation) {
+                return;
+            }
+        }
+
+        $length = \count($args);
+        $verb = $length === 1 ? 'was' : 'were';
+
+        throw new SassScriptException("$expectedLength arguments required, but only $length $verb passed.");
+    }
+}

--- a/src/Value/SassColor.php
+++ b/src/Value/SassColor.php
@@ -1,0 +1,474 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Value;
+
+use ScssPhp\ScssPhp\Exception\SassScriptException;
+use ScssPhp\ScssPhp\Util\ErrorUtil;
+use ScssPhp\ScssPhp\Util\NumberUtil;
+use ScssPhp\ScssPhp\Visitor\ValueVisitor;
+
+final class SassColor extends Value
+{
+    /**
+     * This color's red channel, between `0` and `255`.
+     *
+     * @var int|null
+     */
+    private $red;
+
+    /**
+     * This color's blue channel, between `0` and `255`.
+     *
+     * @var int|null
+     */
+    private $blue;
+
+    /**
+     * This color's green channel, between `0` and `255`.
+     *
+     * @var int|null
+     */
+    private $green;
+
+    /**
+     * This color's hue, between `0` and `360`.
+     *
+     * @var int|float|null
+     */
+    private $hue;
+
+    /**
+     * This color's saturation, a percentage between `0` and `100`.
+     *
+     * @var int|float|null
+     */
+    private $saturation;
+
+    /**
+     * This color's lightness, a percentage between `0` and `100`.
+     *
+     * @var int|float|null
+     */
+    private $lightness;
+
+    /**
+     * TThis color's alpha channel, between `0` and `1`.
+     *
+     * @var int|float
+     */
+    private $alpha;
+
+    /**
+     * Creates a RGB color
+     *
+     * @param int $red
+     * @param int $blue
+     * @param int $green
+     * @param int|float|null $alpha
+     *
+     * @return SassColor
+     *
+     * @throws \OutOfRangeException if values are outside the expected range.
+     */
+    public static function rgb(int $red, int $green, int $blue, $alpha = null): SassColor
+    {
+        if ($alpha === null) {
+            $alpha = 1;
+        } else {
+            $alpha = NumberUtil::fuzzyAssertRange($alpha, 0, 1, 'alpha');
+        }
+
+        ErrorUtil::checkIntInInterval($red, 0, 255, 'red');
+        ErrorUtil::checkIntInInterval($green, 0, 255, 'green');
+        ErrorUtil::checkIntInInterval($blue, 0, 255, 'blue');
+
+        return new self($red, $green, $blue, null, null, null, $alpha);
+    }
+
+    /**
+     * @param int|float $hue
+     * @param int|float $saturation
+     * @param int|float $lightness
+     * @param int|float|null $alpha
+     *
+     * @return SassColor
+     */
+    public static function hsl($hue, $saturation, $lightness, $alpha = null): SassColor
+    {
+        if ($alpha === null) {
+            $alpha = 1;
+        } else {
+            $alpha = NumberUtil::fuzzyAssertRange($alpha, 0, 1, 'alpha');
+        }
+
+        $hue = fmod($hue , 360);
+        $saturation = NumberUtil::fuzzyAssertRange($saturation, 0, 100, 'saturation');
+        $lightness = NumberUtil::fuzzyAssertRange($lightness, 0, 100, 'lightness');
+
+        return new self(null, null, null, $hue, $saturation, $lightness, $alpha);
+    }
+
+    /**
+     * @param int|float      $hue
+     * @param int|float      $whiteness
+     * @param int|float      $blackness
+     * @param int|float|null $alpha
+     *
+     * @return SassColor
+     */
+    public static function hwb($hue, $whiteness, $blackness, $alpha = null): SassColor
+    {
+        $scaledHue = fmod($hue , 360) / 360;
+        $scaledWhiteness = NumberUtil::fuzzyAssertRange($whiteness, 0, 100, 'whiteness') / 100;
+        $scaledBlackness = NumberUtil::fuzzyAssertRange($blackness, 0, 100, 'blackness') / 100;
+
+        $sum = $scaledWhiteness + $scaledBlackness;
+
+        if ($sum > 1) {
+            $scaledWhiteness /= $sum;
+            $scaledBlackness /= $sum;
+        }
+
+        $factor = 1 - $scaledWhiteness - $scaledBlackness;
+
+        $toRgb = function (float $hue) use ($factor, $scaledWhiteness) {
+            $channel = self::hueToRgb(0, 1, $hue) * $factor + $scaledWhiteness;
+
+            return NumberUtil::fuzzyRound($channel * 255);
+        };
+
+        return self::rgb($toRgb($scaledHue + 1/3), $toRgb($scaledHue), $toRgb($scaledHue - 1/3), $alpha);
+    }
+
+    /**
+     * This must always provide non-null values for either RGB or HSL values.
+     * If they are all provided, they are expected to be in sync and this not
+     * revalidated. This constructor does not revalidate ranges either.
+     * Use named factories when this cannot be guaranteed.
+     *
+     * @param int|null       $red
+     * @param int|null       $green
+     * @param int|null       $blue
+     * @param int|float|null $hue
+     * @param int|float|null $saturation
+     * @param int|float|null $lightness
+     * @param int|float      $alpha
+     */
+    private function __construct(?int $red, ?int $green, ?int $blue, $hue, $saturation, $lightness, $alpha)
+    {
+        $this->red = $red;
+        $this->green = $green;
+        $this->blue = $blue;
+        $this->hue = $hue;
+        $this->saturation = $saturation;
+        $this->lightness = $lightness;
+        $this->alpha = $alpha;
+    }
+
+    public function getRed(): int
+    {
+        if (\is_null($this->red)) {
+            $this->hslToRgb();
+            assert(!\is_null($this->red));
+        }
+
+        return $this->red;
+    }
+
+    public function getGreen(): int
+    {
+        if (\is_null($this->green)) {
+            $this->hslToRgb();
+            assert(!\is_null($this->green));
+        }
+
+        return $this->green;
+    }
+
+    public function getBlue(): int
+    {
+        if (\is_null($this->blue)) {
+            $this->hslToRgb();
+            assert(!\is_null($this->blue));
+        }
+
+        return $this->blue;
+    }
+
+    /**
+     * @return int|float
+     */
+    public function getHue()
+    {
+        if (\is_null($this->hue)) {
+            $this->rgbToHsl();
+            assert(!\is_null($this->hue));
+        }
+
+        return $this->hue;
+    }
+
+    /**
+     * @return int|float
+     */
+    public function getSaturation()
+    {
+        if (\is_null($this->saturation)) {
+            $this->rgbToHsl();
+            assert(!\is_null($this->saturation));
+        }
+
+        return $this->saturation;
+    }
+
+    /**
+     * @return int|float
+     */
+    public function getLightness()
+    {
+        if (\is_null($this->lightness)) {
+            $this->rgbToHsl();
+            assert(!\is_null($this->lightness));
+        }
+
+        return $this->lightness;
+    }
+
+    /**
+     * @return float|int
+     */
+    public function getWhiteness()
+    {
+        return min($this->getRed(), $this->getGreen(), $this->getBlue()) / 255 * 100;
+    }
+
+    /**
+     * @return float|int
+     */
+    public function getBlackness()
+    {
+        return 100 - max($this->getRed(), $this->getGreen(), $this->getBlue()) / 255 * 100;
+    }
+
+    /**
+     * @return int|float
+     */
+    public function getAlpha()
+    {
+        return $this->alpha;
+    }
+
+    public function accept(ValueVisitor $visitor)
+    {
+        return $visitor->visitColor($this);
+    }
+
+    public function assertColor(?string $name = null): SassColor
+    {
+        return $this;
+    }
+
+    /**
+     * @param int|null $red
+     * @param int|null $green
+     * @param int|null $blue
+     * @param int|float|null $alpha
+     *
+     * @return SassColor
+     */
+    public function changeRgb(?int $red = null, ?int $green = null, ?int $blue = null, $alpha = null): SassColor
+    {
+        return self::rgb($red ?? $this->getRed(), $green ?? $this->getGreen(), $blue ?? $this->getBlue(), $alpha ?? $this->alpha);
+    }
+
+    /**
+     * @param int|float|null $hue
+     * @param int|float|null $saturation
+     * @param int|float|null $lightness
+     * @param int|float|null $alpha
+     *
+     * @return SassColor
+     */
+    public function changeHsl($hue = null, $saturation = null, $lightness = null, $alpha = null): SassColor
+    {
+        return self::hsl($hue ?? $this->getHue(), $saturation ?? $this->getSaturation(), $lightness ?? $this->getLightness(), $alpha ?? $this->alpha);
+    }
+
+    /**
+     * @param int|float|null $hue
+     * @param int|float|null $whiteness
+     * @param int|float|null $blackness
+     * @param int|float|null $alpha
+     *
+     * @return SassColor
+     */
+    public function changeHwb($hue = null, $whiteness = null, $blackness = null, $alpha = null): SassColor
+    {
+        return self::hwb($hue ?? $this->getHue(), $whiteness ?? $this->getWhiteness(), $blackness ?? $this->getBlackness(), $alpha ?? $this->alpha);
+    }
+
+    /**
+     * @param int|float $alpha
+     *
+     * @return SassColor
+     */
+    public function changeAlpha($alpha): SassColor
+    {
+        return new self(
+            $this->red,
+            $this->green,
+            $this->blue,
+            $this->hue,
+            $this->saturation,
+            $this->lightness,
+            NumberUtil::fuzzyAssertRange($alpha, 0, 1, 'alpha')
+        );
+    }
+
+    public function plus(Value $other): Value
+    {
+        if (!$other instanceof SassColor && !$other instanceof SassNumber) {
+            return parent::plus($other);
+        }
+
+        throw new SassScriptException("Undefined operation \"$this + $other\".");
+    }
+
+    public function minus(Value $other): Value
+    {
+        if (!$other instanceof SassColor && !$other instanceof SassNumber) {
+            return parent::minus($other);
+        }
+
+        throw new SassScriptException("Undefined operation \"$this - $other\".");
+    }
+
+    public function dividedBy(Value $other): Value
+    {
+        if (!$other instanceof SassColor && !$other instanceof SassNumber) {
+            return parent::dividedBy($other);
+        }
+
+        throw new SassScriptException("Undefined operation \"$this / $other\".");
+    }
+
+    public function modulo(Value $other): Value
+    {
+        if (!$other instanceof SassColor && !$other instanceof SassNumber) {
+            return parent::modulo($other);
+        }
+
+        throw new SassScriptException("Undefined operation \"$this % $other\".");
+    }
+
+    public function equals(object $other): bool
+    {
+        return $other instanceof SassColor && $this->getRed() === $other->getRed() && $this->getGreen() === $other->getGreen() && $this->getBlue() === $other->getBlue() && $this->alpha === $other->alpha;
+    }
+
+    /**
+     * @param int $colorComponent
+     *
+     * @return string
+     */
+    private static function getHexComponent(int $colorComponent): string
+    {
+        return str_pad(dechex($colorComponent), 2, '0', STR_PAD_LEFT);
+    }
+
+    /**
+     * @return void
+     */
+    private function rgbToHsl(): void
+    {
+        $scaledRed = $this->getRed() / 255;
+        $scaledGreen = $this->getGreen() / 255;
+        $scaledBlue = $this->getBlue() / 255;
+
+        $min = min($scaledRed, $scaledGreen, $scaledBlue);
+        $max = max($scaledRed, $scaledGreen, $scaledBlue);
+        $delta = $max - $min;
+
+        if ($delta == 0) {
+            $this->hue = 0;
+        } elseif ($max == $scaledRed) {
+            $this->hue = fmod(60 * ($scaledGreen - $scaledBlue) / $delta, 360);
+        } elseif ($max == $scaledGreen) {
+            $this->hue = fmod(120 + 60 * ($scaledBlue - $scaledRed) / $delta, 360);
+        } else {
+            $this->hue = fmod(240 + 60 * ($scaledRed - $scaledGreen) / $delta, 360);
+        }
+
+        $this->lightness = 50 * ($max + $min);
+
+        if ($max == $min) {
+            $this->saturation = 50;
+        } elseif ($this->lightness < 50) {
+            $this->saturation = 100 * $delta / ($max + $min);
+        } else {
+            $this->saturation = 100 * $delta / (2 - $max - $min);
+        }
+    }
+
+    /**
+     * @return void
+     */
+    private function hslToRgb(): void
+    {
+        $scaledHue = $this->getHue() / 360;
+        $scaledSaturation = $this->getSaturation() / 100;
+        $scaledLightness = $this->getLightness() / 100;
+
+        if ($scaledLightness <= 0.5) {
+            $m2 = $scaledLightness * ($scaledSaturation + 1);
+        } else {
+            $m2 = $scaledLightness + $scaledSaturation - $scaledLightness * $scaledSaturation;
+        }
+
+        $m1 = $scaledLightness * 2 - $m2;
+
+        $this->red = NumberUtil::fuzzyRound(self::hueToRgb($m1, $m2, $scaledHue + 1 / 3) * 255);
+        $this->green = NumberUtil::fuzzyRound(self::hueToRgb($m1, $m2, $scaledHue) * 255);
+        $this->blue = NumberUtil::fuzzyRound(self::hueToRgb($m1, $m2, $scaledHue - 1 / 3) * 255);
+    }
+
+    /**
+     * @param int|float $m1
+     * @param int|float $m2
+     * @param int|float $hue
+     *
+     * @return int|float
+     */
+    private static function hueToRgb($m1, $m2, $hue)
+    {
+        if ($hue < 0) {
+            $hue += 1;
+        } elseif ($hue > 1) {
+            $hue -= 1;
+        }
+
+        if ($hue < 1 / 6) {
+            return $m1 + ($m2 - $m1) * $hue * 6;
+        }
+
+        if ($hue < 1 / 2) {
+            return $m2;
+        }
+
+        if ($hue < 2 / 3) {
+            return $m1 + ($m2 - $m1) * (2 / 3 - $hue) * 6;
+        }
+
+        return $m1;
+    }
+}

--- a/src/Value/SassFunction.php
+++ b/src/Value/SassFunction.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Value;
+
+use ScssPhp\ScssPhp\Visitor\ValueVisitor;
+
+final class SassFunction extends Value
+{
+    // TODO find a better representation of functions, as names won't be unique anymore once modules enter in the equation.
+    private $name;
+
+    /**
+     * @internal
+     */
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @internal
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function accept(ValueVisitor $visitor)
+    {
+        return $visitor->visitFunction($this);
+    }
+
+    public function assertFunction(?string $name = null): SassFunction
+    {
+        return $this;
+    }
+
+    public function equals(object $other): bool
+    {
+        return $other instanceof SassFunction && $this->name === $other->name;
+    }
+}

--- a/src/Value/SassList.php
+++ b/src/Value/SassList.php
@@ -1,0 +1,149 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Value;
+
+use ScssPhp\ScssPhp\Visitor\ValueVisitor;
+
+class SassList extends Value
+{
+    /**
+     * @var list<Value>
+     */
+    private $contents;
+
+    /**
+     * @var string
+     * @phpstan-var ListSeparator::*
+     */
+    private $separator;
+
+    /**
+     * @var bool
+     */
+    private $brackets;
+
+    /**
+     * @param string $separator
+     * @param bool   $brackets
+     *
+     * @return SassList
+     *
+     * @phpstan-param ListSeparator::* $separator
+     */
+    public static function createEmpty(string $separator = ListSeparator::UNDECIDED, bool $brackets = false): SassList
+    {
+        return new self(array(), $separator, $brackets);
+    }
+
+    /**
+     * @param list<Value> $contents
+     * @param string      $separator
+     * @param bool        $brackets
+     *
+     * @phpstan-param ListSeparator::* $separator
+     */
+    public function __construct(array $contents, string $separator, bool $brackets = false)
+    {
+        if ($separator === ListSeparator::UNDECIDED && count($contents) > 1) {
+            throw new \InvalidArgumentException('A list with more than one element must have an explicit separator.');
+        }
+
+        $this->contents = $contents;
+        $this->separator = $separator;
+        $this->brackets = $brackets;
+    }
+
+    public function getSeparator(): string
+    {
+        return $this->separator;
+    }
+
+    public function hasBrackets(): bool
+    {
+        return $this->brackets;
+    }
+
+    public function isBlank(): bool
+    {
+        foreach ($this->contents as $element) {
+            if (!$element->isBlank()) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public function asList(): array
+    {
+        return $this->contents;
+    }
+
+    protected function getLengthAsList(): int
+    {
+        return \count($this->contents);
+    }
+
+    public function accept(ValueVisitor $visitor)
+    {
+        return $visitor->visitList($this);
+    }
+
+    public function assertMap(?string $name = null): SassMap
+    {
+        if (\count($this->contents) === 0) {
+            return SassMap::createEmpty();
+        }
+
+        return parent::assertMap($name);
+    }
+
+    public function tryMap(): ?SassMap
+    {
+        if (\count($this->contents) === 0) {
+            return SassMap::createEmpty();
+        }
+
+        return null;
+    }
+
+    public function equals(object $other): bool
+    {
+        if ($other instanceof SassMap) {
+            return \count($this->contents) === 0 && \count($other->asList()) === 0;
+        }
+
+        if (!$other instanceof SassList) {
+            return false;
+        }
+
+        if ($this->separator !== $other->separator || $this->brackets !== $other->brackets) {
+            return false;
+        }
+
+        $otherContent = $other->contents;
+        $length = \count($this->contents);
+
+        if ($length !== \count($otherContent)) {
+            return false;
+        }
+
+        for ($i = 0; $i < $length; ++$i) {
+            if (!$this->contents[$i]->equals($otherContent[$i])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Value/SassMap.php
+++ b/src/Value/SassMap.php
@@ -1,0 +1,126 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Value;
+
+use ScssPhp\ScssPhp\Collection\Map;
+use ScssPhp\ScssPhp\Visitor\ValueVisitor;
+
+final class SassMap extends Value
+{
+    /**
+     * @var Map<Value>
+     */
+    private $contents;
+
+    /**
+     * @param Map<Value> $contents
+     */
+    private function __construct(Map $contents)
+    {
+        $this->contents = Map::unmodifiable($contents);
+    }
+
+    public static function createEmpty(): SassMap
+    {
+        return new self(new Map());
+    }
+
+    /**
+     * @param Map<Value> $contents
+     *
+     * @return SassMap
+     */
+    public static function create(Map $contents): SassMap
+    {
+        return new self($contents);
+    }
+
+    /**
+     * The returned Map is unmodifiable.
+     *
+     * @return Map<Value>
+     */
+    public function getContents(): Map
+    {
+        return $this->contents;
+    }
+
+    public function getSeparator(): string
+    {
+        return \count($this->contents) === 0 ? ListSeparator::UNDECIDED : ListSeparator::COMMA;
+    }
+
+    public function asList(): array
+    {
+        $result = [];
+
+        foreach ($this->contents as $key => $value) {
+            $result[] = new SassList([$key, $value], ListSeparator::SPACE);
+        }
+
+        return $result;
+    }
+
+    protected function getLengthAsList(): int
+    {
+        return \count($this->contents);
+    }
+
+    public function accept(ValueVisitor $visitor)
+    {
+        return $visitor->visitMap($this);
+    }
+
+    public function assertMap(?string $name = null): SassMap
+    {
+        return $this;
+    }
+
+    public function tryMap(): ?SassMap
+    {
+        return $this;
+    }
+
+    public function equals(object $other): bool
+    {
+        if ($other instanceof SassList) {
+            return \count($this->contents) === 0 && \count($other->asList()) === 0;
+        }
+
+        if (!$other instanceof SassMap) {
+            return false;
+        }
+
+        if ($this->contents === $other->contents) {
+            return true;
+        }
+
+        if (\count($this->contents) !== \count($other->contents)) {
+            return false;
+        }
+
+        foreach ($this->contents as $key => $value) {
+            $otherValue = $other->contents->get($key);
+
+            if ($otherValue === null) {
+                return false;
+            }
+
+            if (!$value->equals($otherValue)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Value/SassNull.php
+++ b/src/Value/SassNull.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Value;
+
+use ScssPhp\ScssPhp\Visitor\ValueVisitor;
+
+final class SassNull extends Value
+{
+    /**
+     * @var SassNull|null
+     */
+    private static $instance;
+
+    public static function create(): SassNull
+    {
+        if (self::$instance === null) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+
+    private function __construct()
+    {
+    }
+
+    public function isTruthy(): bool
+    {
+        return false;
+    }
+
+    public function isBlank(): bool
+    {
+        return true;
+    }
+
+    public function accept(ValueVisitor $visitor)
+    {
+        return $visitor->visitNull();
+    }
+
+    public function equals(object $other): bool
+    {
+        return $other instanceof SassNull;
+    }
+
+    public function unaryNot(): Value
+    {
+        return SassBoolean::create(true);
+    }
+}

--- a/src/Value/SassNumber.php
+++ b/src/Value/SassNumber.php
@@ -1,0 +1,999 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Value;
+
+use ScssPhp\ScssPhp\Exception\SassScriptException;
+use ScssPhp\ScssPhp\Util\NumberUtil;
+use ScssPhp\ScssPhp\Visitor\ValueVisitor;
+
+abstract class SassNumber extends Value
+{
+    const PRECISION = 10;
+
+    /**
+     * @see https://www.w3.org/TR/css-values-3/
+     */
+    private const CONVERSIONS = [
+        'in' => [
+            'in' => 1,
+            'pc' => 6,
+            'pt' => 72,
+            'px' => 96,
+            'cm' => 2.54,
+            'mm' => 25.4,
+            'q'  => 101.6,
+        ],
+        'deg' => [
+            'deg'  => 360,
+            'grad' => 400,
+            'rad'  => 6.28318530717958647692528676, // 2 * M_PI
+            'turn' => 1,
+        ],
+        's' => [
+            's'  => 1,
+            'ms' => 1000,
+        ],
+        'Hz' => [
+            'Hz'  => 1,
+            'kHz' => 0.001,
+        ],
+        'dpi' => [
+            'dpi'  => 1,
+            'dpcm' => 1 / 2.54,
+            'dppx' => 1 / 96,
+        ],
+    ];
+
+    /**
+     * A map from human-readable names of unit types to the convertable units that
+     * fall into those types.
+     */
+    private const UNITS_BY_TYPE = [
+        'length' => ['in', 'cm', 'pc', 'mm', 'q', 'pt', 'px'],
+        'angle' => ['deg', 'grad', 'rad', 'turn'],
+        'time' => ['s', 'ms'],
+        'frequency' => ['Hz', 'kHz'],
+        'pixel density' => ['dpi', 'dpcm', 'dppx']
+    ];
+
+    /**
+     * A map from units to the human-readable names of those unit types.
+     */
+    private const TYPES_BY_UNIT = [
+        'in' => 'length',
+        'cm' => 'length',
+        'pc' => 'length',
+        'mm' => 'length',
+        'q' => 'length',
+        'pt' => 'length',
+        'px' => 'length',
+        'deg' => 'angle',
+        'grad' => 'angle',
+        'rad' => 'angle',
+        'turn' => 'angle',
+        's' => 'time',
+        'ms' => 'time',
+        'Hz' => 'frequency',
+        'kHz' => 'frequency',
+        'dpi' => 'pixel density',
+        'dpcm' => 'pixel density',
+        'dppx' => 'pixel density',
+    ];
+
+    /**
+     * @var int|float
+     */
+    private $value;
+
+    /**
+     * The representation of this number as two slash-separated numbers, if it has one.
+     *
+     * @var array{SassNumber, SassNumber}|null
+     */
+    private $asSlash;
+
+    /**
+     * @param int|float  $value
+     * @param array{SassNumber, SassNumber}|null $asSlash
+     */
+    protected function __construct($value, array $asSlash = null)
+    {
+        $this->value = $value;
+        $this->asSlash = $asSlash;
+    }
+
+    /**
+     * Creates a number, optionally with a single numerator unit.
+     *
+     * This matches the numbers that can be written as literals.
+     * {@see SassNumber::withUnits} can be used to construct more complex units.
+     *
+     * @param int|float   $value
+     * @param string|null $unit
+     *
+     * @return self
+     */
+    final public static function create($value, ?string $unit = null): SassNumber
+    {
+        if ($unit === null) {
+            return new UnitlessSassNumber($value);
+        }
+
+        return new SingleUnitSassNumber($value, $unit);
+    }
+
+    /**
+     * Creates a number with full $numeratorUnits and $denominatorUnits.
+     *
+     * @param int|float    $value
+     * @param list<string> $numeratorUnits
+     * @param list<string> $denominatorUnits
+     *
+     * @return self
+     */
+    final public static function withUnits($value, array $numeratorUnits = [], array $denominatorUnits = []): SassNumber
+    {
+        if (empty($numeratorUnits) && empty($denominatorUnits)) {
+            return new UnitlessSassNumber($value);
+        }
+
+        if (empty($denominatorUnits) && \count($numeratorUnits) === 1) {
+            return new SingleUnitSassNumber($value, $numeratorUnits[0]);
+        }
+
+        return new ComplexSassNumber($value, $numeratorUnits, $denominatorUnits);
+    }
+
+    /**
+     * The value of this number.
+     *
+     * Note that due to details of floating-point arithmetic, this may be a
+     * float even if $this represents an int from Sass's perspective. Use
+     * {@see isInt} to determine whether this is an integer, {@see asInt} to get its
+     * integer value, or {@see assertInt} to do both at once.
+     *
+     * @return float|int
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    /**
+     * @return list<string>
+     */
+    abstract public function getNumeratorUnits(): array;
+
+    /**
+     * @return list<string>
+     */
+    abstract public function getDenominatorUnits(): array;
+
+    /**
+     * @return array{SassNumber, SassNumber}|null
+     *
+     * @internal
+     */
+    final public function getAsSlash(): ?array
+    {
+        return $this->asSlash;
+    }
+
+    public function accept(ValueVisitor $visitor)
+    {
+        return $visitor->visitNumber($this);
+    }
+
+    /**
+     * Returns a SassNumber with this value and the same units.
+     *
+     * @param int|float $value
+     *
+     * @return self
+     */
+    abstract protected function withValue($value): SassNumber;
+
+    /**
+     * @param SassNumber $numerator
+     * @param SassNumber $denominator
+     *
+     * @return SassNumber
+     *
+     * @internal
+     */
+    abstract public function withSlash(SassNumber $numerator, SassNumber $denominator): SassNumber;
+
+    public function withoutSlash(): Value
+    {
+        if ($this->asSlash === null) {
+            return $this;
+        }
+
+        return $this->withValue($this->value);
+    }
+
+    public function assertNumber(?string $name = null): SassNumber
+    {
+        return $this;
+    }
+
+    /**
+     * Returns a human-readable string representation of this number's units.
+     */
+    public function getUnitString(): string
+    {
+        return $this->hasUnits() ? self::buildUnitString($this->getNumeratorUnits(), $this->getDenominatorUnits()): '';
+    }
+
+    /**
+     * Whether $this is an integer, according to {@see NumberUtil::fuzzyEquals}.
+     *
+     * The int value can be accessed using {@see asInt} or {@see assertInt}. Note that
+     * this may return `false` for very large doubles even though they may be
+     * mathematically integers, because not all platforms have a valid
+     * representation for integers that large.
+     */
+    public function isInt(): bool
+    {
+        return NumberUtil::fuzzyIsInt($this->value);
+    }
+
+    /**
+     * If $this is an integer according to {@see isInt}, returns {@see value} as an int.
+     *
+     * Otherwise, returns `null`.
+     */
+    public function asInt(): ?int
+    {
+        return NumberUtil::fuzzyAsInt($this->value);
+    }
+
+    /**
+     * Returns the value as an int, if it's an integer value according to
+     * {@see isInt}.
+     *
+     * @throws SassScriptException if the value isn't an integer. If this came
+     * from a function argument, $name is the argument name (without the `$`).
+     * It's used for error reporting.
+     */
+    public function assertInt(?string $name = null): int
+    {
+        $integer = NumberUtil::fuzzyAsInt($this->value);
+
+        if ($integer !== null) {
+            return $integer;
+        }
+
+        throw SassScriptException::forArgument("$this is not an int.", $name);
+    }
+
+    /**
+     * If {@see value} is between $min and $max, returns it.
+     *
+     * If {@see value} is {@see NumberUtil::fuzzyEquals} to $min or $max, it's clamped to the
+     * appropriate value. Otherwise, this throws a {@see SassScriptException}. If this
+     * came from a function argument, $name is the argument name (without the
+     * `$`). It's used for error reporting.
+     *
+     * @param int|float   $min
+     * @param int|float   $max
+     * @param string|null $name
+     *
+     * @return int|float
+     *
+     * @throws SassScriptException if the value is outside the range
+     */
+    public function valueInRange($min, $max, ?string $name = null)
+    {
+        $result = NumberUtil::fuzzyCheckRange($this->value, $min, $max);
+
+        if ($result !== null) {
+            return $result;
+        }
+
+        $unitString = $this->getUnitString();
+
+        throw SassScriptException::forArgument("Expected $this to be within $min$unitString and $max$unitString.", $name);
+    }
+
+    /**
+     * Returns true if the number has units.
+     *
+     * @return boolean
+     */
+    abstract public function hasUnits(): bool;
+
+    /**
+     * Returns whether $this has $unit as its only unit (and as a numerator).
+     *
+     * @param string $unit
+     *
+     * @return bool
+     */
+    abstract public function hasUnit(string $unit): bool;
+
+    /**
+     * Returns whether $this has units that are compatible with $other.
+     *
+     * Unlike {@see isComparableTo}, unitless numbers are only considered compatible
+     * with other unitless numbers.
+     */
+    public function hasCompatibleUnits(SassNumber $other): bool
+    {
+        if (\count($this->getNumeratorUnits()) !== \count($other->getNumeratorUnits())) {
+            return false;
+        }
+
+        if (\count($this->getDenominatorUnits()) !== \count($other->getDenominatorUnits())) {
+            return false;
+        }
+
+        return $this->isComparableTo($other);
+    }
+
+    /**
+     * Returns whether $this has units that are possibly-compatible with
+     * $other, as defined by the Sass spec.
+     *
+     * @internal
+     */
+    abstract public function hasPossiblyCompatibleUnits(SassNumber $other): bool;
+
+    /**
+     * Returns whether $this can be coerced to the given unit.
+     *
+     * This always returns `true` for a unitless number.
+     *
+     * @param string $unit
+     *
+     * @return bool
+     */
+    abstract public function compatibleWithUnit(string $unit): bool;
+
+    /**
+     * Throws a SassScriptException unless $this has $unit as its only unit
+     * (and as a numerator).
+     *
+     * If this came from a function argument, [name] is the argument name
+     * (without the `$`). It's used for error reporting.
+     *
+     * @throws SassScriptException
+     */
+    public function assertUnit(string $unit, ?string $varName = null): void
+    {
+        if ($this->hasUnit($unit)) {
+            return;
+        }
+
+        throw SassScriptException::forArgument(sprintf('Expected %s to have unit "%s".', $this, $unit), $varName);
+    }
+
+    /**
+     * Throws a SassScriptException unless $this has no units.
+     *
+     * If this came from a function argument, [name] is the argument name
+     * (without the `$`). It's used for error reporting.
+     *
+     * @throws SassScriptException
+     */
+    public function assertNoUnits(?string $varName = null): void
+    {
+        if (!$this->hasUnits()) {
+            return;
+        }
+
+        throw SassScriptException::forArgument(sprintf('Expected %s to have no units.', $this), $varName);
+    }
+
+    /**
+     * Returns a copy of this number, converted to the same units as $other.
+     *
+     * Unlike {@see convertToMatch}, this does not throw an error if this number is
+     * unitless and $other is not, or vice versa. Instead, it treats all unitless
+     * numbers as convertible to and from all units without changing the value.
+     *
+     * Note that {@see coerceValueToMatch} is generally more efficient if the value
+     * is going to be accessed directly.
+     *
+     * @param SassNumber  $other
+     * @param string|null $name      The argument name if this is a function argument
+     * @param string|null $otherName The argument name for $other if this is a function argument
+     *
+     * @return SassNumber
+     *
+     * @throws SassScriptException if the units are not compatible
+     */
+    public function coerceToMatch(SassNumber $other, ?string $name = null, ?string $otherName = null): SassNumber
+    {
+        return self::withUnits($this->coerceValueToMatch($other, $name, $otherName), $other->getNumeratorUnits(), $other->getDenominatorUnits());
+    }
+
+    /**
+     * Returns {@see value}, converted to the same units as $other.
+     *
+     * Unlike {@see convertValueToMatch}, this does not throw an error if this number
+     * is unitless and $other is not, or vice versa. Instead, it treats all unitless
+     * numbers as convertible to and from all units without changing the value.
+     *
+     * @param SassNumber  $other
+     * @param string|null $name      The argument name if this is a function argument
+     * @param string|null $otherName The argument name for $other if this is a function argument
+     *
+     * @return int|float
+     *
+     * @throws SassScriptException if the units are not compatible
+     */
+    public function coerceValueToMatch(SassNumber $other, ?string $name = null, ?string $otherName = null)
+    {
+        return $this->convertOrCoerceValue($other->getNumeratorUnits(), $other->getDenominatorUnits(), true, $name, $other, $otherName);
+    }
+
+    /**
+     * Returns a copy of this number, converted to the same units as $other.
+     *
+     * Note that {@see convertValueToMatch} is generally more efficient if the value
+     * is going to be accessed directly.
+     *
+     * @param SassNumber  $other
+     * @param string|null $name      The argument name if this is a function argument
+     * @param string|null $otherName The argument name for $other if this is a function argument
+     *
+     * @return SassNumber
+     *
+     * @throws SassScriptException if the units are not compatible or if either number is unitless but the other is not.
+     */
+    public function convertToMatch(SassNumber $other, ?string $name = null, ?string $otherName = null): SassNumber
+    {
+        return self::withUnits($this->convertValueToMatch($other, $name, $otherName), $other->getNumeratorUnits(), $other->getDenominatorUnits());
+    }
+
+    /**
+     * Returns {@see value}, converted to the same units as $other.
+     *
+     * @param SassNumber  $other
+     * @param string|null $name      The argument name if this is a function argument
+     * @param string|null $otherName The argument name for $other if this is a function argument
+     *
+     * @return int|float
+     *
+     * @throws SassScriptException if the units are not compatible or if either number is unitless but the other is not.
+     */
+    public function convertValueToMatch(SassNumber $other, ?string $name = null, ?string $otherName = null)
+    {
+        return $this->convertOrCoerceValue($other->getNumeratorUnits(), $other->getDenominatorUnits(), false, $name, $other, $otherName);
+    }
+
+    /**
+     * Returns a copy of this number, converted to the units represented by $newNumeratorUnits and $newDenominatorUnits.
+     *
+     * This does not throw an error if this number is unitless and
+     * $newNumeratorUnits/$newDenominatorUnits are not empty, or vice versa. Instead,
+     * it treats all unitless numbers as convertible to and from all units without
+     * changing the value.
+     *
+     * Note that {@see coerceValue} is generally more efficient if the value
+     * is going to be accessed directly.
+     *
+     * @param list<string> $newNumeratorUnits
+     * @param list<string> $newDenominatorUnits
+     * @param string|null  $name      The argument name if this is a function argument
+     *
+     * @return SassNumber
+     *
+     * @throws SassScriptException if this number's units are not compatible with $newNumeratorUnits and $newDenominatorUnits
+     */
+    public function coerce(array $newNumeratorUnits, array $newDenominatorUnits, ?string $name = null): SassNumber
+    {
+        return self::withUnits($this->coerceValue($newNumeratorUnits, $newDenominatorUnits, $name), $newNumeratorUnits, $newDenominatorUnits);
+    }
+
+    /**
+     * Returns {@see value}, converted to the units represented by $newNumeratorUnits and $newDenominatorUnits.
+     *
+     * This does not throw an error if this number is unitless and
+     * $newNumeratorUnits/$newDenominatorUnits are not empty, or vice versa. Instead,
+     * it treats all unitless numbers as convertible to and from all units without
+     * changing the value.
+     *
+     * @param list<string> $newNumeratorUnits
+     * @param list<string> $newDenominatorUnits
+     * @param string|null  $name                The argument name if this is a function argument
+     *
+     * @return int|float
+     *
+     * @throws SassScriptException if this number's units are not compatible with $newNumeratorUnits and $newDenominatorUnits
+     */
+    public function coerceValue(array $newNumeratorUnits, array $newDenominatorUnits, ?string $name = null)
+    {
+        return $this->convertOrCoerceValue($newNumeratorUnits, $newDenominatorUnits, true, $name);
+    }
+
+    /**
+     * A shorthand for {@see coerceValue} with a single unit
+     *
+     * @param string      $unit
+     * @param string|null $name The argument name if this is a function argument
+     *
+     * @return int|float
+     */
+    public function coerceValueToUnit(string $unit, ?string $name = null)
+    {
+        return $this->coerceValue([$unit], [], $name);
+    }
+
+    /**
+     * Returns whether this number can be compared to $other.
+     *
+     * Two numbers can be compared if they have compatible units, or if either
+     * number has no units.
+     *
+     * @param SassNumber $other
+     *
+     * @return bool
+     *
+     * @internal
+     */
+    public function isComparableTo(SassNumber $other): bool
+    {
+        if (!$this->hasUnits() || !$other->hasUnits()) {
+            return true;
+        }
+
+        try {
+            $this->greaterThan($other);
+            return true;
+        } catch (SassScriptException $e) {
+            return false;
+        }
+    }
+
+    public function greaterThan(Value $other): SassBoolean
+    {
+        if ($other instanceof SassNumber) {
+            return SassBoolean::create($this->coerceUnits($other, [NumberUtil::class, 'fuzzyGreaterThan']));
+        }
+
+        throw new SassScriptException("Undefined operation \"$this > $other\".");
+    }
+
+    public function greaterThanOrEquals(Value $other): SassBoolean
+    {
+        if ($other instanceof SassNumber) {
+            return SassBoolean::create($this->coerceUnits($other, [NumberUtil::class, 'fuzzyGreaterThanOrEquals']));
+        }
+
+        throw new SassScriptException("Undefined operation \"$this >= $other\".");
+    }
+
+    public function lessThan(Value $other): SassBoolean
+    {
+        if ($other instanceof SassNumber) {
+            return SassBoolean::create($this->coerceUnits($other, [NumberUtil::class, 'fuzzyLessThan']));
+        }
+
+        throw new SassScriptException("Undefined operation \"$this < $other\".");
+    }
+
+    public function lessThanOrEquals(Value $other): SassBoolean
+    {
+        if ($other instanceof SassNumber) {
+            return SassBoolean::create($this->coerceUnits($other, [NumberUtil::class, 'fuzzyLessThanOrEquals']));
+        }
+
+        throw new SassScriptException("Undefined operation \"$this > $other\".");
+    }
+
+    public function modulo(Value $other): Value
+    {
+        if ($other instanceof SassNumber) {
+            return $this->withValue($this->coerceUnits($other, [NumberUtil::class, 'moduloLikeSass']));
+        }
+
+        throw new SassScriptException("Undefined operation \"$this % $other\".");
+    }
+
+    public function plus(Value $other): Value
+    {
+        if ($other instanceof SassNumber) {
+            return $this->withValue($this->coerceUnits($other, function ($num1, $num2) {
+                return $num1 + $num2;
+            }));
+        }
+
+        if (!$other instanceof SassColor) {
+            return parent::plus($other);
+        }
+
+        throw new SassScriptException("Undefined operation \"$this + $other\".");
+    }
+
+    public function minus(Value $other): Value
+    {
+        if ($other instanceof SassNumber) {
+            return $this->withValue($this->coerceUnits($other, function ($num1, $num2) {
+                return $num1 - $num2;
+            }));
+        }
+
+        if (!$other instanceof SassColor) {
+            return parent::plus($other);
+        }
+
+        throw new SassScriptException("Undefined operation \"$this - $other\".");
+    }
+
+    public function times(Value $other): Value
+    {
+        if ($other instanceof SassNumber) {
+            if (!$other->hasUnits()) {
+                return $this->withValue($this->value * $other->value);
+            }
+
+            return $this->multiplyUnits($this->value * $other->value, $other->getNumeratorUnits(), $other->getDenominatorUnits());
+        }
+
+        throw new SassScriptException("Undefined operation \"$this * $other\".");
+    }
+
+    public function dividedBy(Value $other): Value
+    {
+        if ($other instanceof SassNumber) {
+            $value = NumberUtil::divideLikeSass($this->value, $other->value);
+
+            if (!$other->hasUnits()) {
+                return $this->withValue($value);
+            }
+
+            return $this->multiplyUnits($value, $other->getDenominatorUnits(), $other->getNumeratorUnits());
+        }
+
+        return parent::dividedBy($other);
+    }
+
+    public function unaryPlus(): Value
+    {
+        return $this;
+    }
+
+    public function equals(object $other): bool
+    {
+        if (!$other instanceof SassNumber) {
+            return false;
+        }
+
+        if (\count($this->getNumeratorUnits()) !== \count($other->getNumeratorUnits()) || \count($this->getDenominatorUnits()) !== \count($other->getDenominatorUnits())) {
+            return false;
+        }
+
+        // In Sass, neither NaN nor Infinity are equal to themselves, while PHP defines INF==INF
+        if (is_nan($this->value) || is_nan($other->value) || !is_finite($this->value) || !is_finite($other->value)) {
+            return false;
+        }
+
+        if (!$this->hasUnits()) {
+            return NumberUtil::fuzzyEquals($this->value, $other->value);
+        }
+
+        if (self::canonicalizeUnitList($this->getNumeratorUnits()) !== self::canonicalizeUnitList($other->getNumeratorUnits()) ||
+            self::canonicalizeUnitList($this->getDenominatorUnits()) !== self::canonicalizeUnitList($other->getDenominatorUnits())
+        ) {
+            return false;
+        }
+
+        return NumberUtil::fuzzyEquals(
+            $this->value * self::getCanonicalMultiplier($this->getNumeratorUnits()) / self::getCanonicalMultiplier($this->getDenominatorUnits()),
+            $other->value * self::getCanonicalMultiplier($other->getNumeratorUnits()) / self::getCanonicalMultiplier($other->getDenominatorUnits())
+        );
+    }
+
+    /**
+     * @param list<string> $units
+     *
+     * @return float|int
+     */
+    private static function getCanonicalMultiplier(array $units)
+    {
+        return array_reduce($units, function ($multiplier, $unit) {
+            return $multiplier * self::getCanonicalMultiplierForUnit($unit);
+        }, 1);
+    }
+
+    /**
+     * @param string $unit
+     *
+     * @return float|int
+     */
+    private static function getCanonicalMultiplierForUnit(string $unit)
+    {
+        foreach (self::CONVERSIONS as $canonicalUnit => $conversions) {
+            if (isset($conversions[$unit])) {
+                return $conversions[$canonicalUnit] / $conversions[$unit];
+            }
+        }
+
+        return 1;
+    }
+
+    /**
+     * @param list<string> $units
+     *
+     * @return list<string>
+     */
+    private static function canonicalizeUnitList(array $units): array
+    {
+        if (\count($units) === 0) {
+            return $units;
+        }
+
+        if (\count($units) === 1) {
+            if (isset(self::TYPES_BY_UNIT[$units[0]])) {
+                $type = self::TYPES_BY_UNIT[$units[0]];
+
+                return [self::UNITS_BY_TYPE[$type][0]];
+            }
+
+            return $units;
+        }
+
+        $canonicalUnits = [];
+
+        foreach ($units as $unit) {
+            if (isset(self::TYPES_BY_UNIT[$unit])) {
+                $type = self::TYPES_BY_UNIT[$unit];
+
+                $canonicalUnits[] = self::UNITS_BY_TYPE[$type][0];
+            } else {
+                $canonicalUnits[] = $unit;
+            }
+        }
+
+        sort($canonicalUnits);
+
+        return $canonicalUnits;
+    }
+
+    /**
+     * @template T
+     *
+     * @param SassNumber                        $other
+     * @param callable(int|float, int|float): T $operation
+     *
+     * @return T
+     */
+    private function coerceUnits(SassNumber $other, callable $operation)
+    {
+        try {
+            return \call_user_func($operation, $this->value, $other->coerceValueToMatch($this));
+        } catch (SassScriptException $e) {
+            // If the conversion fails, re-run it in the other direction. This will
+            // generate an error message that prints [this] before [other], which is
+            // more readable.
+            $this->coerceValueToMatch($other);
+
+            throw $e; // Should be unreadable as the coercion should throw.
+        }
+    }
+
+    /**
+     * @param list<string>    $newNumeratorUnits
+     * @param list<string>    $newDenominatorUnits
+     * @param bool            $coerceUnitless
+     * @param string|null     $name      The argument name if this is a function argument
+     * @param SassNumber|null $other
+     * @param string|null     $otherName The argument name for $other if this is a function argument
+     *
+     * @return int|float
+     *
+     * @throws SassScriptException if this number's units are not compatible with $newNumeratorUnits and $newDenominatorUnits
+     */
+    private function convertOrCoerceValue(array $newNumeratorUnits, array $newDenominatorUnits, bool $coerceUnitless, ?string $name = null, SassNumber $other = null, ?string $otherName = null)
+    {
+        assert($other === null || ($other->getNumeratorUnits() === $newNumeratorUnits && $other->getDenominatorUnits() === $newDenominatorUnits), sprintf("Expected %s to have units %s.", $other, self::buildUnitString($newNumeratorUnits, $newDenominatorUnits)));
+
+        if ($this->getNumeratorUnits() === $newNumeratorUnits && $this->getDenominatorUnits() === $newDenominatorUnits) {
+            return $this->value;
+        }
+
+        $otherHasUnits = !empty($newNumeratorUnits) || !empty($newDenominatorUnits);
+
+        if ($coerceUnitless && (!$otherHasUnits || !$this->hasUnits())) {
+            return $this->value;
+        }
+
+        $value = $this->value;
+        $oldNumerators = $this->getNumeratorUnits();
+
+        foreach ($newNumeratorUnits as $newNumerator) {
+            foreach ($oldNumerators as $key => $oldNumerator) {
+                $conversionFactor = self::getConversionFactor($newNumerator, $oldNumerator);
+
+                if (\is_null($conversionFactor)) {
+                    continue;
+                }
+
+                $value *= $conversionFactor;
+                unset($oldNumerators[$key]);
+                continue 2;
+            }
+
+            throw $this->compatibilityException($otherHasUnits, $newNumeratorUnits, $newDenominatorUnits, $name, $other, $otherName);
+        }
+
+        $oldDenominators = $this->getDenominatorUnits();
+
+        foreach ($newDenominatorUnits as $newDenominator) {
+            foreach ($oldDenominators as $key => $oldDenominator) {
+                $conversionFactor = self::getConversionFactor($newDenominator, $oldDenominator);
+
+                if (\is_null($conversionFactor)) {
+                    continue;
+                }
+
+                $value /= $conversionFactor;
+                unset($oldDenominators[$key]);
+                continue 2;
+            }
+
+            throw $this->compatibilityException($otherHasUnits, $newNumeratorUnits, $newDenominatorUnits, $name, $other, $otherName);
+        }
+
+        if (\count($oldNumerators) || \count($oldDenominators)) {
+            throw $this->compatibilityException($otherHasUnits, $newNumeratorUnits, $newDenominatorUnits, $name, $other, $otherName);
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param bool            $otherHasUnits
+     * @param list<string>    $newNumeratorUnits
+     * @param list<string>    $newDenominatorUnits
+     * @param string|null     $name
+     * @param SassNumber|null $other
+     * @param string|null     $otherName
+     *
+     * @return SassScriptException
+     */
+    private function compatibilityException(bool $otherHasUnits, array $newNumeratorUnits, array $newDenominatorUnits, ?string $name, SassNumber $other = null, ?string $otherName = null): SassScriptException
+    {
+        if ($other !== null) {
+            $message = "$this and";
+
+            if ($otherName !== null) {
+                $message .= " \$$otherName:";
+            }
+
+            $message .= "$other have incompatible units";
+
+            if (!$this->hasUnits() || !$otherHasUnits) {
+                $message .= " (one has units and the other doesn't)";
+            }
+
+            return SassScriptException::forArgument("$message.", $name);
+        }
+
+        if (!$otherHasUnits) {
+            return SassScriptException::forArgument("Expected $this to have no units.", $name);
+        }
+
+        if (\count($newNumeratorUnits) === 1 && \count($newDenominatorUnits) === 0 && isset(self::TYPES_BY_UNIT[$newNumeratorUnits[0]])) {
+            $type = self::TYPES_BY_UNIT[$newNumeratorUnits[0]];
+            $article = \in_array($type[0], ['a', 'e', 'i', 'o', 'u'], true) ? 'an' : 'a';
+            $supportedUnits = implode(', ', self::UNITS_BY_TYPE[$type]);
+
+            return SassScriptException::forArgument("Expected $this to have $article $type unit ($supportedUnits).", $name);
+        }
+
+        return SassScriptException::forArgument(sprintf('Expected %s to have unit%s %s.', $this, \count($newNumeratorUnits) + \count($newDenominatorUnits) !== 1 ? 's' : '', self::buildUnitString($newNumeratorUnits, $newDenominatorUnits)), $name);
+    }
+
+    /**
+     * @param int|float    $value
+     * @param list<string> $otherNumerators
+     * @param list<string> $otherDenominators
+     *
+     * @return SassNumber
+     */
+    protected function multiplyUnits($value, array $otherNumerators, array $otherDenominators): SassNumber
+    {
+        $newNumerators = array();
+
+        foreach ($this->getNumeratorUnits() as $numerator) {
+            foreach ($otherDenominators as $key => $denominator) {
+                $conversionFactor = self::getConversionFactor($numerator, $denominator);
+
+                if (\is_null($conversionFactor)) {
+                    continue;
+                }
+
+                $value /= $conversionFactor;
+                unset($otherDenominators[$key]);
+                continue 2;
+            }
+
+            $newNumerators[] = $numerator;
+        }
+
+        $denominators = $this->getDenominatorUnits();
+
+        foreach ($otherNumerators as $numerator) {
+            foreach ($denominators as $key => $denominator) {
+                $conversionFactor = self::getConversionFactor($numerator, $denominator);
+
+                if (\is_null($conversionFactor)) {
+                    continue;
+                }
+
+                $value /= $conversionFactor;
+                unset($denominators[$key]);
+                continue 2;
+            }
+
+            $newNumerators[] = $numerator;
+        }
+
+        $newDenominators = array_values(array_merge($denominators, $otherDenominators));
+
+        return self::withUnits($value, $newNumerators, $newDenominators);
+    }
+
+    /**
+     * Returns the number of [unit1]s per [unit2].
+     *
+     * Equivalently, `1unit2 * conversionFactor(unit1, unit2) = 1unit1`.
+     *
+     * @param string $unit1
+     * @param string $unit2
+     *
+     * @return float|int|null
+     */
+    protected static function getConversionFactor(string $unit1, string $unit2)
+    {
+        if ($unit1 === $unit2) {
+            return 1;
+        }
+
+        foreach (self::CONVERSIONS as $unitVariants) {
+            if (isset($unitVariants[$unit1]) && isset($unitVariants[$unit2])) {
+                return $unitVariants[$unit1] / $unitVariants[$unit2];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns unit(s) as the product of numerator units divided by the product of denominator units
+     *
+     * @param list<string> $numerators
+     * @param list<string> $denominators
+     *
+     * @return string
+     */
+    private static function buildUnitString(array $numerators, array $denominators): string
+    {
+        if (!\count($numerators)) {
+            if (\count($denominators) === 0) {
+                return 'no units';
+            }
+
+            if (\count($denominators) === 1) {
+                return $denominators[0] . '^-1';
+            }
+
+            return '(' . implode('*', $denominators) . ')^-1';
+        }
+
+        return implode('*', $numerators) . (\count($denominators) ? '/' . implode('*', $denominators) : '');
+    }
+}

--- a/src/Value/SassString.php
+++ b/src/Value/SassString.php
@@ -1,0 +1,235 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Value;
+
+use ScssPhp\ScssPhp\Exception\SassScriptException;
+use ScssPhp\ScssPhp\Util;
+use ScssPhp\ScssPhp\Visitor\ValueVisitor;
+
+final class SassString extends Value
+{
+    /**
+     * The contents of the string.
+     *
+     * For quoted strings, this is the semantic content—any escape sequences that
+     * were been written in the source text are resolved to their Unicode values.
+     * For unquoted strings, though, escape sequences are preserved as literal
+     * backslashes.
+     *
+     * This difference allows us to distinguish between identifiers with escapes,
+     * such as `url\u28 http://example.com\u29`, and unquoted strings that
+     * contain characters that aren't valid in identifiers, such as
+     * `url(http://example.com)`. Unfortunately, it also means that we don't
+     * consider `foo` and `f\6F\6F` the same string.
+     *
+     * @var string
+     */
+    private $text;
+
+    /**
+     * Whether this string has quotes.
+     *
+     * @var bool
+     */
+    private $quotes;
+
+    public function __construct(string $text, bool $quotes = true)
+    {
+        $this->text = $text;
+        $this->quotes = $quotes;
+    }
+
+    public function getText(): string
+    {
+        return $this->text;
+    }
+
+    public function hasQuotes(): bool
+    {
+        return $this->quotes;
+    }
+
+    public function getSassLength(): int
+    {
+        return Util::mbStrlen($this->text);
+    }
+
+    public function isSpecialNumber(): bool
+    {
+        if ($this->quotes) {
+            return false;
+        }
+
+        if (\strlen($this->text) < \strlen('min(_)')) {
+            return false;
+        }
+
+        $first = $this->text[0];
+
+        if ($first === 'c' || $first === 'C') {
+            $second = $this->text[1];
+
+            if ($second === 'l' || $second === 'L') {
+                return ($this->text[2] === 'a' || $this->text[2] === 'A')
+                    && ($this->text[3] === 'm' || $this->text[3] === 'M')
+                    && ($this->text[4] === 'p' || $this->text[4] === 'P')
+                    && $this->text[5] === '(';
+            }
+
+            if ($second === 'a' || $second === 'A') {
+                return ($this->text[2] === 'l' || $this->text[2] === 'L')
+                    && ($this->text[3] === 'c' || $this->text[3] === 'C')
+                    && $this->text[4] === '(';
+            }
+
+            return false;
+        }
+
+        if ($first === 'v' || $first === 'V') {
+            return ($this->text[1] === 'a' || $this->text[1] === 'A')
+                && ($this->text[2] === 'r' || $this->text[2] === 'R')
+                && $this->text[3] === '(';
+        }
+
+        if ($first === 'e' || $first === 'E') {
+            return ($this->text[1] === 'n' || $this->text[1] === 'N')
+                && ($this->text[2] === 'v' || $this->text[2] === 'V')
+                && $this->text[3] === '(';
+        }
+
+        if ($first === 'm' || $first === 'M') {
+            $second = $this->text[1];
+
+            if ($second === 'a' || $second === 'A') {
+                return ($this->text[2] === 'x' || $this->text[2] === 'X')
+                    && $this->text[3] === '(';
+            }
+
+            if ($second === 'i' || $second === 'I') {
+                return ($this->text[2] === 'n' || $this->text[2] === 'N')
+                    && $this->text[3] === '(';
+            }
+
+            return false;
+        }
+
+        return false;
+    }
+
+    public function isVar(): bool
+    {
+        if ($this->quotes) {
+            return false;
+        }
+
+        if (\strlen($this->text) < \strlen('var(--_)')) {
+            return false;
+        }
+
+        return ($this->text[0] === 'v' || $this->text[0] === 'V')
+            && ($this->text[1] === 'a' || $this->text[1] === 'A')
+            && ($this->text[2] === 'r' || $this->text[2] === 'R')
+            && $this->text[3] === '(';
+    }
+
+    public function isBlank(): bool
+    {
+        return !$this->quotes && $this->text === '';
+    }
+
+    /**
+     * Converts $sassIndex into a PHP-style index into {@see text}.
+     *
+     * Sass indexes are one-based, while PHP indexes are zero-based. Sass
+     * indexes may also be negative in order to index from the end of the string.
+     *
+     * In addition, Sass indices refer to Unicode code points while PHP string
+     * indices refer to bytes. For example, the character U+1F60A,
+     * Smiling Face With Smiling Eyes, is a single Unicode code point but is
+     * represented in UTF-8 as several bytes (`0xF0`, `0x9F`, `0x98` and `0x8A`). So in
+     * PHP, `substr("a😊b", 1, 1)` returns `"\xF0"`, whereas in Sass
+     * `str-slice("a😊b", 1, 1)` returns `"😊"`.
+     *
+     * @throws SassScriptException if $sassIndex isn't a number, if that
+     * number isn't an integer, or if that integer isn't a valid index for this
+     * string. If $sassIndex came from a function argument, $name is the
+     * argument name (without the `$`). It's used for error reporting.
+     */
+    public function sassIndexToStringIndex(Value $sassIndex, ?string $name = null): int
+    {
+        $codepointIndex = $this->sassIndexToCodePointIndex($sassIndex, $name);
+
+        if ($codepointIndex === 0) {
+            return 0;
+        }
+
+        return \strlen(Util::mbSubstr($this->text, 0, $codepointIndex));
+    }
+
+    /**
+     * Converts $sassIndex into a PHP-style index into codepoints.
+     *
+     * This index is suitable to use with functions dealing with codepoints
+     * (i.e. the mbstring functions).
+     *
+     * Sass indexes are one-based, while PHP indexes are zero-based. Sass
+     * indexes may also be negative in order to index from the end of the string.
+     *
+     * See also {@see sassIndexToStringIndex}, which is an index into {@see getText} directly.
+     *
+     * @throws SassScriptException if $sassIndex isn't a number, if that
+     * number isn't an integer, or if that integer isn't a valid index for this
+     * string. If $sassIndex came from a function argument, $name is the
+     * argument name (without the `$`). It's used for error reporting.
+     */
+    public function sassIndexToCodePointIndex(Value $sassIndex, ?string $name = null): int
+    {
+        $index = $sassIndex->assertNumber($name)->assertInt($name);
+
+        if ($index === 0) {
+            throw SassScriptException::forArgument('String index may not be 0.', $name);
+        }
+
+        $sassLength = $this->getSassLength();
+
+        if (abs($index) > $sassLength) {
+            throw SassScriptException::forArgument("Invalid index $sassIndex for a string with $sassLength characters.", $name);
+        }
+
+        return $index < 0 ? $sassLength + $index : $index - 1;
+    }
+
+    public function accept(ValueVisitor $visitor)
+    {
+        return $visitor->visitString($this);
+    }
+
+    public function assertString(?string $name = null): SassString
+    {
+        return $this;
+    }
+
+    public function plus(Value $other): Value
+    {
+        if ($other instanceof SassString) {
+            return new SassString($this->text . $other->getText(), $this->quotes);
+        }
+
+        return new SassString($this->text . $other->toCssString(), $this->quotes);
+    }
+
+    public function equals(object $other): bool
+    {
+        return $other instanceof SassString && $this->text === $other->text;
+    }
+}

--- a/src/Value/SingleUnitSassNumber.php
+++ b/src/Value/SingleUnitSassNumber.php
@@ -1,0 +1,294 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Value;
+
+use ScssPhp\ScssPhp\Util\NumberUtil;
+
+/**
+ * A specialized subclass of {@see SassNumber} for numbers that have exactly one numerator unit.
+ *
+ * @internal
+ */
+final class SingleUnitSassNumber extends SassNumber
+{
+    private const KNOWN_COMPATIBILITIES_BY_UNIT = [
+        // length
+        'em' => ['em', 'ex', 'ch', 'rem', 'vw', 'vh', 'vmin', 'vmax', 'cm', 'mm', 'q', 'in', 'pc', 'pt', 'px'],
+        'ex' => ['em', 'ex', 'ch', 'rem', 'vw', 'vh', 'vmin', 'vmax', 'cm', 'mm', 'q', 'in', 'pc', 'pt', 'px'],
+        'ch' => ['em', 'ex', 'ch', 'rem', 'vw', 'vh', 'vmin', 'vmax', 'cm', 'mm', 'q', 'in', 'pc', 'pt', 'px'],
+        'rem' => ['em', 'ex', 'ch', 'rem', 'vw', 'vh', 'vmin', 'vmax', 'cm', 'mm', 'q', 'in', 'pc', 'pt', 'px'],
+        'vw' => ['em', 'ex', 'ch', 'rem', 'vw', 'vh', 'vmin', 'vmax', 'cm', 'mm', 'q', 'in', 'pc', 'pt', 'px'],
+        'vh' => ['em', 'ex', 'ch', 'rem', 'vw', 'vh', 'vmin', 'vmax', 'cm', 'mm', 'q', 'in', 'pc', 'pt', 'px'],
+        'vmin' => ['em', 'ex', 'ch', 'rem', 'vw', 'vh', 'vmin', 'vmax', 'cm', 'mm', 'q', 'in', 'pc', 'pt', 'px'],
+        'vmax' => ['em', 'ex', 'ch', 'rem', 'vw', 'vh', 'vmin', 'vmax', 'cm', 'mm', 'q', 'in', 'pc', 'pt', 'px'],
+        'cm' => ['em', 'ex', 'ch', 'rem', 'vw', 'vh', 'vmin', 'vmax', 'cm', 'mm', 'q', 'in', 'pc', 'pt', 'px'],
+        'mm' => ['em', 'ex', 'ch', 'rem', 'vw', 'vh', 'vmin', 'vmax', 'cm', 'mm', 'q', 'in', 'pc', 'pt', 'px'],
+        'q' => ['em', 'ex', 'ch', 'rem', 'vw', 'vh', 'vmin', 'vmax', 'cm', 'mm', 'q', 'in', 'pc', 'pt', 'px'],
+        'in' => ['em', 'ex', 'ch', 'rem', 'vw', 'vh', 'vmin', 'vmax', 'cm', 'mm', 'q', 'in', 'pc', 'pt', 'px'],
+        'pc' => ['em', 'ex', 'ch', 'rem', 'vw', 'vh', 'vmin', 'vmax', 'cm', 'mm', 'q', 'in', 'pc', 'pt', 'px'],
+        'pt' => ['em', 'ex', 'ch', 'rem', 'vw', 'vh', 'vmin', 'vmax', 'cm', 'mm', 'q', 'in', 'pc', 'pt', 'px'],
+        'px' => ['em', 'ex', 'ch', 'rem', 'vw', 'vh', 'vmin', 'vmax', 'cm', 'mm', 'q', 'in', 'pc', 'pt', 'px'],
+        // angle
+        'deg' => ['deg', 'grad', 'rad', 'turn'],
+        'grad' => ['deg', 'grad', 'rad', 'turn'],
+        'rad' => ['deg', 'grad', 'rad', 'turn'],
+        'turn' => ['deg', 'grad', 'rad', 'turn'],
+        // time
+        's' => ['s', 'ms'],
+        'ms' => ['s', 'ms'],
+        // frequency
+        'hz' => ['hz', 'khz'],
+        'khz' => ['hz', 'khz'],
+        // pixel density
+        'dpi' => ['dpi', 'dpcm', 'dppx'],
+        'dpcm' => ['dpi', 'dpcm', 'dppx'],
+        'dppx' => ['dpi', 'dpcm', 'dppx'],
+    ];
+
+    /**
+     * @var string
+     */
+    private $unit;
+
+    /**
+     * @param int|float                          $value
+     * @param string                             $unit
+     * @param array{SassNumber, SassNumber}|null $asSlash
+     */
+    public function __construct($value, string $unit, array $asSlash = null)
+    {
+        parent::__construct($value, $asSlash);
+        $this->unit = $unit;
+    }
+
+    public function getNumeratorUnits(): array
+    {
+        return [$this->unit];
+    }
+
+    public function getDenominatorUnits(): array
+    {
+        return [];
+    }
+
+    public function hasUnits(): bool
+    {
+        return true;
+    }
+
+    protected function withValue($value): SassNumber
+    {
+        return new self($value, $this->unit);
+    }
+
+    public function withSlash(SassNumber $numerator, SassNumber $denominator): SassNumber
+    {
+        return new self($this->getValue(), $this->unit, array($numerator, $denominator));
+    }
+
+    public function hasUnit(string $unit): bool
+    {
+        return $unit === $this->unit;
+    }
+
+    public function hasCompatibleUnits(SassNumber $other): bool
+    {
+        return $other instanceof SingleUnitSassNumber && $this->compatibleWithUnit($other->unit);
+    }
+
+    public function hasPossiblyCompatibleUnits(SassNumber $other): bool
+    {
+        if (!$other instanceof SingleUnitSassNumber) {
+            return false;
+        }
+
+        $knownCompatibilities = self::KNOWN_COMPATIBILITIES_BY_UNIT[strtolower($this->unit)] ?? null;
+
+        if ($knownCompatibilities === null) {
+            return true;
+        }
+
+        $otherUnit = strtolower($other->unit);
+
+        return !isset(self::KNOWN_COMPATIBILITIES_BY_UNIT[$otherUnit]) || \in_array($otherUnit, $knownCompatibilities, true);
+    }
+
+    public function compatibleWithUnit(string $unit): bool
+    {
+        return self::getConversionFactor($this->unit, $unit) !== null;
+    }
+
+    public function coerceToMatch(SassNumber $other, ?string $name = null, ?string $otherName = null): SassNumber
+    {
+        return $this->convertToMatch($other, $name, $otherName);
+    }
+
+    public function coerceValueToMatch(SassNumber $other, ?string $name = null, ?string $otherName = null)
+    {
+        return $this->convertValueToMatch($other, $name, $otherName);
+    }
+
+    public function convertToMatch(SassNumber $other, ?string $name = null, ?string $otherName = null): SassNumber
+    {
+        if ($other instanceof SingleUnitSassNumber) {
+            $coerced = $this->tryCoerceToUnit($other->unit);
+
+            if ($coerced !== null) {
+                return $coerced;
+            }
+        }
+
+        // Call the parent to generate a consistent error message.
+        return parent::convertToMatch($other, $name, $otherName);
+    }
+
+    public function convertValueToMatch(SassNumber $other, ?string $name = null, ?string $otherName = null)
+    {
+        if ($other instanceof SingleUnitSassNumber) {
+            $coerced = $this->tryCoerceValueToUnit($other->unit);
+
+            if ($coerced !== null) {
+                return $coerced;
+            }
+        }
+
+        // Call the parent to generate a consistent error message.
+        return parent::convertValueToMatch($other, $name, $otherName);
+    }
+
+    public function coerce(array $newNumeratorUnits, array $newDenominatorUnits, ?string $name = null): SassNumber
+    {
+        if (\count($newNumeratorUnits) === 1 && \count($newDenominatorUnits) === 0) {
+            $coerced = $this->tryCoerceToUnit($newNumeratorUnits[0]);
+
+            if ($coerced !== null) {
+                return $coerced;
+            }
+        }
+
+        // Call the parent to generate a consistent error message.
+        return parent::coerce($newNumeratorUnits, $newDenominatorUnits, $name);
+    }
+
+    public function coerceValue(array $newNumeratorUnits, array $newDenominatorUnits, ?string $name = null)
+    {
+        if (\count($newNumeratorUnits) === 1 && \count($newDenominatorUnits) === 0) {
+            $coerced = $this->tryCoerceValueToUnit($newNumeratorUnits[0]);
+
+            if ($coerced !== null) {
+                return $coerced;
+            }
+        }
+
+        // Call the parent to generate a consistent error message.
+        return parent::coerceValue($newNumeratorUnits, $newDenominatorUnits, $name);
+    }
+
+    public function coerceValueToUnit(string $unit, ?string $name = null)
+    {
+        $coerced = $this->tryCoerceValueToUnit($unit);
+
+        if ($coerced !== null) {
+            return $coerced;
+        }
+
+        // Call the parent to generate a consistent error message.
+        return parent::coerceValueToUnit($unit, $name);
+    }
+
+    public function unaryMinus(): Value
+    {
+        return new self(-$this->getValue(), $this->unit);
+    }
+
+    public function equals(object $other): bool
+    {
+        if ($other instanceof SingleUnitSassNumber) {
+            $factor = self::getConversionFactor($other->unit, $this->unit);
+
+            return $factor !== null && NumberUtil::fuzzyEquals($this->getValue() * $factor, $other->getValue());
+        }
+
+        return false;
+    }
+
+    /**
+     * @param int|float    $value
+     * @param list<string> $otherNumerators
+     * @param list<string> $otherDenominators
+     *
+     * @return SassNumber
+     */
+    protected function multiplyUnits($value, array $otherNumerators, array $otherDenominators): SassNumber
+    {
+        $newNumerators = $otherDenominators;
+        $removed = false;
+
+        foreach ($otherDenominators as $key => $denominator) {
+            $conversionFactor = self::getConversionFactor($denominator, $this->unit);
+
+            if (\is_null($conversionFactor)) {
+                continue;
+            }
+
+            $value *= $conversionFactor;
+            unset($otherDenominators[$key]);
+            $removed = true;
+            break;
+        }
+
+        if ($removed) {
+            $otherDenominators = array_values($otherDenominators);
+        } else {
+            array_unshift($newNumerators, $this->unit);
+        }
+
+        return SassNumber::withUnits($value, $newNumerators, $otherDenominators);
+    }
+
+    /**
+     * @param string $unit
+     *
+     * @return SassNumber|null
+     */
+    private function tryCoerceToUnit(string $unit): ?SassNumber
+    {
+        if ($unit === $this->unit) {
+            return $this;
+        }
+
+        $factor = self::getConversionFactor($unit, $this->unit);
+
+        if ($factor === null) {
+            return null;
+        }
+
+        return new SingleUnitSassNumber($this->getValue() * $factor, $unit);
+    }
+
+    /**
+     * @param string $unit
+     *
+     * @return float|int|null
+     */
+    private function tryCoerceValueToUnit(string $unit)
+    {
+        $factor = self::getConversionFactor($unit, $this->unit);
+
+        if ($factor === null) {
+            return null;
+        }
+
+        return $this->getValue() * $factor;
+    }
+}

--- a/src/Value/UnitlessSassNumber.php
+++ b/src/Value/UnitlessSassNumber.php
@@ -1,0 +1,219 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Value;
+
+use ScssPhp\ScssPhp\Util\NumberUtil;
+
+/**
+ * A specialized subclass of {@see SassNumber} for numbers that have no units.
+ *
+ * @internal
+ */
+final class UnitlessSassNumber extends SassNumber
+{
+    /**
+     * @param int|float  $value
+     * @param array{SassNumber, SassNumber}|null $asSlash
+     */
+    public function __construct($value, array $asSlash = null)
+    {
+        parent::__construct($value, $asSlash);
+    }
+
+    public function getNumeratorUnits(): array
+    {
+        return [];
+    }
+
+    public function getDenominatorUnits(): array
+    {
+        return [];
+    }
+
+    public function hasUnits(): bool
+    {
+        return false;
+    }
+
+    protected function withValue($value): SassNumber
+    {
+        return new self($value);
+    }
+
+    public function withSlash(SassNumber $numerator, SassNumber $denominator): SassNumber
+    {
+        return new self($this->getValue(), array($numerator, $denominator));
+    }
+
+    public function hasUnit(string $unit): bool
+    {
+        return false;
+    }
+
+    public function hasCompatibleUnits(SassNumber $other): bool
+    {
+        return $other instanceof UnitlessSassNumber;
+    }
+
+    public function hasPossiblyCompatibleUnits(SassNumber $other): bool
+    {
+        return $other instanceof UnitlessSassNumber;
+    }
+
+    public function compatibleWithUnit(string $unit): bool
+    {
+        return true;
+    }
+
+    public function coerceToMatch(SassNumber $other, ?string $name = null, ?string $otherName = null): SassNumber
+    {
+        return $other->withValue($this->getValue());
+    }
+
+    public function coerceValueToMatch(SassNumber $other, ?string $name = null, ?string $otherName = null)
+    {
+        return $this->getValue();
+    }
+
+    public function convertToMatch(SassNumber $other, ?string $name = null, ?string $otherName = null): SassNumber
+    {
+        if (!$other->hasUnits()) {
+            return $this;
+        }
+
+        // Call the parent to generate a consistent error message.
+        return parent::convertToMatch($other, $name, $otherName);
+    }
+
+    public function convertValueToMatch(SassNumber $other, ?string $name = null, ?string $otherName = null)
+    {
+        if (!$other->hasUnits()) {
+            return $this->getValue();
+        }
+
+        // Call the parent to generate a consistent error message.
+        return parent::convertValueToMatch($other, $name, $otherName);
+    }
+
+    public function coerce(array $newNumeratorUnits, array $newDenominatorUnits, ?string $name = null): SassNumber
+    {
+        return SassNumber::withUnits($this->getValue(), $newNumeratorUnits, $newDenominatorUnits);
+    }
+
+    public function coerceValue(array $newNumeratorUnits, array $newDenominatorUnits, ?string $name = null)
+    {
+        return $this->getValue();
+    }
+
+    public function coerceValueToUnit(string $unit, ?string $name = null)
+    {
+        return $this->getValue();
+    }
+
+    public function greaterThan(Value $other): SassBoolean
+    {
+        if ($other instanceof SassNumber) {
+            return SassBoolean::create(NumberUtil::fuzzyGreaterThan($this->getValue(), $other->getValue()));
+        }
+
+        return parent::greaterThan($other);
+    }
+
+    public function greaterThanOrEquals(Value $other): SassBoolean
+    {
+        if ($other instanceof SassNumber) {
+            return SassBoolean::create(NumberUtil::fuzzyGreaterThanOrEquals($this->getValue(), $other->getValue()));
+        }
+
+        return parent::greaterThanOrEquals($other);
+    }
+
+    public function lessThan(Value $other): SassBoolean
+    {
+        if ($other instanceof SassNumber) {
+            return SassBoolean::create(NumberUtil::fuzzyLessThan($this->getValue(), $other->getValue()));
+        }
+
+        return parent::lessThan($other);
+    }
+
+    public function lessThanOrEquals(Value $other): SassBoolean
+    {
+        if ($other instanceof SassNumber) {
+            return SassBoolean::create(NumberUtil::fuzzyLessThanOrEquals($this->getValue(), $other->getValue()));
+        }
+
+        return parent::lessThanOrEquals($other);
+    }
+
+    public function modulo(Value $other): Value
+    {
+        if ($other instanceof SassNumber) {
+            return $other->withValue(NumberUtil::moduloLikeSass($this->getValue(), $other->getValue()));
+        }
+
+        return parent::modulo($other);
+    }
+
+    public function plus(Value $other): Value
+    {
+        if ($other instanceof SassNumber) {
+            return $other->withValue($this->getValue() + $other->getValue());
+        }
+
+        return parent::plus($other);
+    }
+
+    public function minus(Value $other): Value
+    {
+        if ($other instanceof SassNumber) {
+            return $other->withValue($this->getValue() - $other->getValue());
+        }
+
+        return parent::minus($other);
+    }
+
+    public function times(Value $other): Value
+    {
+        if ($other instanceof SassNumber) {
+            return $other->withValue($this->getValue() * $other->getValue());
+        }
+
+        return parent::times($other);
+    }
+
+    public function dividedBy(Value $other): Value
+    {
+        if ($other instanceof SassNumber) {
+            $value = NumberUtil::divideLikeSass($this->getValue(), $other->getValue());
+
+            if ($other->hasUnits()) {
+                return SassNumber::withUnits($value, $other->getDenominatorUnits(), $other->getNumeratorUnits());
+            }
+
+            return new self($value);
+        }
+
+        return parent::dividedBy($other);
+    }
+
+    public function unaryMinus(): Value
+    {
+        return new self(-$this->getValue());
+    }
+
+    public function equals(object $other): bool
+    {
+        return $other instanceof UnitlessSassNumber && NumberUtil::fuzzyEquals($this->getValue(), $other->getValue());
+    }
+}

--- a/src/Value/Value.php
+++ b/src/Value/Value.php
@@ -1,0 +1,560 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Value;
+
+use ScssPhp\ScssPhp\Exception\SassScriptException;
+use ScssPhp\ScssPhp\Serializer\Serializer;
+use ScssPhp\ScssPhp\Util\Equatable;
+use ScssPhp\ScssPhp\Visitor\ValueVisitor;
+
+abstract class Value implements Equatable
+{
+    /**
+     * Whether the value counts as `true` in an `@if` statement and other contexts
+     *
+     * @return bool
+     */
+    public function isTruthy(): bool
+    {
+        return true;
+    }
+
+    /**
+     * The separator for this value as a list.
+     *
+     * All SassScript values can be used as lists. Maps count as lists of pairs,
+     * and all other values count as single-value lists.
+     *
+     * @return string
+     *
+     * @phpstan-return ListSeparator::*
+     */
+    public function getSeparator(): string
+    {
+        return ListSeparator::UNDECIDED;
+    }
+
+    /**
+     * Whether this value as a list has brackets.
+     *
+     * All SassScript values can be used as lists. Maps count as lists of pairs,
+     * and all other values count as single-value lists.
+     *
+     * @return bool
+     */
+    public function hasBrackets(): bool
+    {
+        return false;
+    }
+
+    /**
+     * This value as a list.
+     *
+     * All SassScript values can be used as lists. Maps count as lists of pairs,
+     * and all other values count as single-value lists.
+     *
+     * @return list<Value>
+     */
+    public function asList(): array
+    {
+        return [$this];
+    }
+
+    /**
+     * The length of {@see asList}.
+     *
+     * This is used to compute {@see sassIndexToListIndex} without allocating a new
+     * list.
+     */
+    protected function getLengthAsList(): int
+    {
+        return 1;
+    }
+
+    /**
+     * Calls the appropriate visit method on $visitor.
+     *
+     * @template T
+     *
+     * @param ValueVisitor<T> $visitor
+     *
+     * @return T
+     *
+     * @internal
+     */
+    abstract public function accept(ValueVisitor $visitor);
+
+    /**
+     * Converts $sassIndex into a PHP-style index into the list returned by
+     * {@see asList}.
+     *
+     * Sass indexes are one-based, while PHP indexes are zero-based. Sass
+     * indexes may also be negative in order to index from the end of the list.
+     *
+     * @throws SassScriptException if $sassIndex isn't a number, if that
+     * number isn't an integer, or if that integer isn't a valid index for
+     * {@see asList}. If $sassIndex came from a function argument, $name is the
+     * argument name (without the `$`). It's used for error reporting.
+     */
+    public function sassIndexToListIndex(Value $sassIndex, ?string $name = null): int
+    {
+        $index = $sassIndex->assertNumber($name)->assertInt($name);
+
+        if ($index === 0) {
+            throw SassScriptException::forArgument('List index may not be 0.', $name);
+        }
+
+        $lengthAsList = $this->getLengthAsList();
+
+        if (abs($index) > $lengthAsList) {
+            throw SassScriptException::forArgument("Invalid index $sassIndex for a list with $lengthAsList elements.", $name);
+        }
+
+        return $index < 0 ? $lengthAsList + $index : $index - 1;
+    }
+
+    /**
+     * Throws a {@see SassScriptException} if $this isn't a boolean.
+     *
+     * Note that generally, functions should use {@see isTruthy} rather than requiring
+     * a literal boolean.
+     *
+     * If this came from a function argument, $name is the argument name
+     * (without the `$`). It's used for error reporting.
+     *
+     * @param string|null $name
+     *
+     * @return SassBoolean
+     *
+     * @throws SassScriptException
+     */
+    public function assertBoolean(?string $name = null): SassBoolean
+    {
+        throw SassScriptException::forArgument("$this is not a boolean.", $name);
+    }
+
+    /**
+     * Throws a {@see SassScriptException} if $this isn't a calculation.
+     *
+     * If this came from a function argument, $name is the argument name
+     * (without the `$`). It's used for error reporting.
+     *
+     * @param string|null $name
+     *
+     * @return SassCalculation
+     *
+     * @throws SassScriptException
+     */
+    public function assertCalculation(?string $name = null): SassCalculation
+    {
+        throw SassScriptException::forArgument("$this is not a calculation.", $name);
+    }
+
+    /**
+     * Throws a {@see SassScriptException} if $this isn't a color.
+     *
+     * If this came from a function argument, $name is the argument name
+     * (without the `$`). It's used for error reporting.
+     *
+     * @param string|null $name
+     *
+     * @return SassColor
+     *
+     * @throws SassScriptException
+     */
+    public function assertColor(?string $name = null): SassColor
+    {
+        throw SassScriptException::forArgument("$this is not a color.", $name);
+    }
+
+    /**
+     * Throws a {@see SassScriptException} if $this isn't a string.
+     *
+     * If this came from a function argument, $name is the argument name
+     * (without the `$`). It's used for error reporting.
+     *
+     * @param string|null $name
+     *
+     * @return SassFunction
+     *
+     * @throws SassScriptException
+     */
+    public function assertFunction(?string $name = null): SassFunction
+    {
+        throw SassScriptException::forArgument("$this is not a function.", $name);
+    }
+
+    /**
+     * Throws a {@see SassScriptException} if $this isn't a map.
+     *
+     * If this came from a function argument, $name is the argument name
+     * (without the `$`). It's used for error reporting.
+     *
+     * @param string|null $name
+     *
+     * @return SassMap
+     *
+     * @throws SassScriptException
+     */
+    public function assertMap(?string $name = null): SassMap
+    {
+        throw SassScriptException::forArgument("$this is not a map.", $name);
+    }
+
+    /**
+     * Return $this as a SassMap if it is one (including empty lists) or null otherwise.
+     *
+     * @return SassMap|null
+     */
+    public function tryMap(): ?SassMap
+    {
+        return null;
+    }
+
+    /**
+     * Throws a {@see SassScriptException} if $this isn't a number.
+     *
+     * If this came from a function argument, $name is the argument name
+     * (without the `$`). It's used for error reporting.
+     *
+     * @param string|null $name
+     *
+     * @return SassNumber
+     *
+     * @throws SassScriptException
+     */
+    public function assertNumber(?string $name = null): SassNumber
+    {
+        throw SassScriptException::forArgument("$this is not a number.", $name);
+    }
+
+    /**
+     * Throws a {@see SassScriptException} if $this isn't a string.
+     *
+     * If this came from a function argument, $name is the argument name
+     * (without the `$`). It's used for error reporting.
+     *
+     * @param string|null $name
+     *
+     * @return SassString
+     *
+     * @throws SassScriptException
+     */
+    public function assertString(?string $name = null): SassString
+    {
+        throw SassScriptException::forArgument("$this is not a string.", $name);
+    }
+
+    /**
+     * Whether the value will be represented in CSS as the empty string.
+     *
+     * @return bool
+     *
+     * @internal
+     */
+    public function isBlank(): bool
+    {
+        return false;
+    }
+
+    /**
+     * Whether this is a value that CSS may treat as a number, such as `calc()` or `var()`.
+     *
+     * Functions that shadow plain CSS functions need to gracefully handle when
+     * these arguments are passed in.
+     *
+     * @return bool
+     *
+     * @internal
+     */
+    public function isSpecialNumber(): bool
+    {
+        return false;
+    }
+
+    /**
+     * Whether this is a call to `var()`, which may be substituted in CSS for a custom property value.
+     *
+     * Functions that shadow plain CSS functions need to gracefully handle when
+     * these arguments are passed in.
+     *
+     * @return bool
+     *
+     * @internal
+     */
+    public function isVar(): bool
+    {
+        return false;
+    }
+
+    /**
+     * Returns a new list containing $contents that defaults to this value's
+     * separator and brackets.
+     *
+     * @param list<Value> $contents
+     * @param string|null $separator
+     * @param bool|null   $brackets
+     *
+     * @return SassList
+     *
+     * @phpstan-param ListSeparator::*|null $separator
+     */
+    public function withListContents(array $contents, ?string $separator = null, ?bool $brackets = null): SassList
+    {
+        return new SassList($contents, $separator ?? $this->getSeparator(), $brackets ?? $this->hasBrackets());
+    }
+
+    /**
+     * The SassScript = operation
+     *
+     * @param Value $other
+     *
+     * @return Value
+     *
+     * @internal
+     */
+    public function singleEquals(Value $other): Value
+    {
+        return new SassString(sprintf('%s=%s', $this->toCssString(), $other->toCssString()), false);
+    }
+
+    /**
+     * The SassScript `>` operation.
+     *
+     * @param Value $other
+     *
+     * @return SassBoolean
+     *
+     * @internal
+     */
+    public function greaterThan(Value $other): SassBoolean
+    {
+        throw new SassScriptException("Undefined operation \"$this > $other\".");
+    }
+
+    /**
+     * The SassScript `>=` operation.
+     *
+     * @param Value $other
+     *
+     * @return SassBoolean
+     *
+     * @internal
+     */
+    public function greaterThanOrEquals(Value $other): SassBoolean
+    {
+        throw new SassScriptException("Undefined operation \"$this >= $other\".");
+    }
+
+    /**
+     * The SassScript `<` operation.
+     *
+     * @param Value $other
+     *
+     * @return SassBoolean
+     *
+     * @internal
+     */
+    public function lessThan(Value $other): SassBoolean
+    {
+        throw new SassScriptException("Undefined operation \"$this < $other\".");
+    }
+
+    /**
+     * The SassScript `<=` operation.
+     *
+     * @param Value $other
+     *
+     * @return SassBoolean
+     *
+     * @internal
+     */
+    public function lessThanOrEquals(Value $other): SassBoolean
+    {
+        throw new SassScriptException("Undefined operation \"$this <= $other\".");
+    }
+
+    /**
+     * The SassScript `*` operation.
+     *
+     * @param Value $other
+     *
+     * @return Value
+     *
+     * @internal
+     */
+    public function times(Value $other): Value
+    {
+        throw new SassScriptException("Undefined operation \"$this * $other\".");
+    }
+
+    /**
+     * The SassScript `%` operation.
+     *
+     * @param Value $other
+     *
+     * @return Value
+     *
+     * @internal
+     */
+    public function modulo(Value $other): Value
+    {
+        throw new SassScriptException("Undefined operation \"$this % $other\".");
+    }
+
+    /**
+     * The SassScript `+` operation.
+     *
+     * @param Value $other
+     *
+     * @return Value
+     *
+     * @internal
+     */
+    public function plus(Value $other): Value
+    {
+        if ($other instanceof SassString) {
+            return new SassString($this->toCssString() . $other->getText(), $other->hasQuotes());
+        }
+
+        if ($other instanceof SassCalculation) {
+            throw new SassScriptException("Undefined operation \"$this + $other\".");
+        }
+
+        return new SassString($this->toCssString() . $other->toCssString(), false);
+    }
+
+    /**
+     * The SassScript `-` operation.
+     *
+     * @param Value $other
+     *
+     * @return Value
+     *
+     * @internal
+     */
+    public function minus(Value $other): Value
+    {
+        if ($other instanceof SassCalculation) {
+            throw new SassScriptException("Undefined operation \"$this - $other\".");
+        }
+
+        return new SassString(sprintf('%s-%s', $this->toCssString(), $other->toCssString()), false);
+    }
+
+    /**
+     * The SassScript `/` operation.
+     *
+     * @param Value $other
+     *
+     * @return Value
+     *
+     * @internal
+     */
+    public function dividedBy(Value $other): Value
+    {
+        return new SassString(sprintf('%s/%s', $this->toCssString(), $other->toCssString()), false);
+    }
+
+    /**
+     * The SassScript unary `+` operation.
+     *
+     * @return Value
+     *
+     * @internal
+     */
+    public function unaryPlus(): Value
+    {
+        return new SassString(sprintf('+%s', $this->toCssString()), false);
+    }
+
+    /**
+     * The SassScript unary `-` operation.
+     *
+     * @return Value
+     *
+     * @internal
+     */
+    public function unaryMinus(): Value
+    {
+        return new SassString(sprintf('-%s', $this->toCssString()), false);
+    }
+
+    /**
+     * The SassScript unary `/` operation.
+     *
+     * @return Value
+     *
+     * @internal
+     */
+    public function unaryDivide(): Value
+    {
+        return new SassString(sprintf('/%s', $this->toCssString()), false);
+    }
+
+    /**
+     * The SassScript unary `not` operation.
+     *
+     * @return Value
+     *
+     * @internal
+     */
+    public function unaryNot(): Value
+    {
+        return SassBoolean::create(false);
+    }
+
+    /**
+     * Returns a copy of $this without {@see SassNumber::$asSlash} set.
+     *
+     * If this isn't a SassNumber, return it as-is.
+     *
+     * @return Value
+     *
+     * @internal
+     */
+    public function withoutSlash(): Value
+    {
+        return $this;
+    }
+
+    /**
+     * Returns a valid CSS representation of $this.
+     *
+     * Use {@see toString} instead to get a string representation even if this
+     * isn't valid CSS.
+     *
+     * Internal-only: If $quote is `false`, quoted strings are emitted without
+     * quotes.
+     *
+     * @throws SassScriptException if $this cannot be represented in plain CSS.
+     */
+    final public function toCssString(bool $quote = true): string
+    {
+        return Serializer::serializeValue($this, false, $quote);
+    }
+
+    /**
+     * Returns a Sass representation of $this.
+     *
+     * Note that this is equivalent to calling `inspect()` on the value, and thus
+     * won't reflect the user's output settings. {@see toCssString} should be used
+     * instead to convert $this to CSS.
+     *
+     * @return string
+     */
+    final public function __toString(): string
+    {
+        return Serializer::serializeValue($this, true);
+    }
+}

--- a/src/Visitor/ValueVisitor.php
+++ b/src/Visitor/ValueVisitor.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Visitor;
+
+use ScssPhp\ScssPhp\Value\SassBoolean;
+use ScssPhp\ScssPhp\Value\SassCalculation;
+use ScssPhp\ScssPhp\Value\SassColor;
+use ScssPhp\ScssPhp\Value\SassFunction;
+use ScssPhp\ScssPhp\Value\SassList;
+use ScssPhp\ScssPhp\Value\SassMap;
+use ScssPhp\ScssPhp\Value\SassNumber;
+use ScssPhp\ScssPhp\Value\SassString;
+
+/**
+ * An interface for visitors that traverse SassScript $values.
+ *
+ * @internal
+ *
+ * @template T
+ */
+interface ValueVisitor
+{
+    /**
+     * @return T
+     */
+    public function visitBoolean(SassBoolean $value);
+
+    /**
+     * @return T
+     */
+    public function visitCalculation(SassCalculation $value);
+
+    /**
+     * @return T
+     */
+    public function visitColor(SassColor $value);
+
+    /**
+     * @return T
+     */
+    public function visitFunction(SassFunction $value);
+
+    /**
+     * @return T
+     */
+    public function visitList(SassList $value);
+
+    /**
+     * @return T
+     */
+    public function visitMap(SassMap $value);
+
+    /**
+     * @return T
+     */
+    public function visitNull();
+
+    /**
+     * @return T
+     */
+    public function visitNumber(SassNumber $value);
+
+    /**
+     * @return T
+     */
+    public function visitString(SassString $value);
+}

--- a/tests/Serializer/SerializerTest.php
+++ b/tests/Serializer/SerializerTest.php
@@ -1,0 +1,140 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2018-2020 Anthon Pang
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Tests\Serializer;
+
+use ScssPhp\ScssPhp\Serializer\Serializer;
+use PHPUnit\Framework\TestCase;
+use ScssPhp\ScssPhp\Value\SassString;
+
+class SerializerTest extends TestCase
+{
+    /**
+     * @dataProvider provideQuotedStrings
+     */
+    public function testSerializeQuotedString($expected, $input)
+    {
+        $this->assertSame($expected, Serializer::serializeValue(new SassString($input)));
+    }
+
+    public static function provideQuotedStrings(): iterable
+    {
+        yield [
+            '"foo"',
+            'foo',
+        ];
+        yield [
+            '"fo\'o"',
+            'fo\'o',
+        ];
+        yield [
+            '\'fo"o\'',
+            'fo"o',
+        ];
+        yield [
+            '"f\\"o\'o"',
+            'f"o\'o',
+        ];
+        yield [
+            '"fo\\\\o"',
+            'fo\\o',
+        ];
+        yield [
+            "\"fo\to\"",
+            "fo\to",
+        ];
+        yield [
+            '"fo\ao"',
+            "fo\no",
+        ];
+        yield [
+            '"fo\a 1o"',
+            "fo\n1o",
+        ];
+        yield [
+            '"fo\a Ao"',
+            "fo\nAo",
+        ];
+        yield [
+            '"fo\a  o"',
+            "fo\n o",
+        ];
+        yield [
+            "\"fo\\a \to\"",
+            "fo\n\to",
+        ];
+        yield [
+            '"fo\a co"',
+            "fo\nco",
+        ];
+        yield [
+            '"foo\a"',
+            "foo\n",
+        ];
+    }
+
+    /**
+     * @dataProvider provideUnquotedStrings
+     */
+    public function testSerializeUnquotedString($expected, $input)
+    {
+        $this->assertSame($expected, Serializer::serializeValue(new SassString($input, false)));
+    }
+
+    public static function provideUnquotedStrings(): iterable
+    {
+        yield [
+            'foo',
+            'foo',
+        ];
+        yield [
+            'fo\'o',
+            'fo\'o',
+        ];
+        yield [
+            'fo"o',
+            'fo"o',
+        ];
+        yield [
+            'f"o\'o',
+            'f"o\'o',
+        ];
+        yield [
+            'fo\\o',
+            'fo\\o',
+        ];
+        yield [
+            "fo\to",
+            "fo\to",
+        ];
+        yield [
+            'fo o',
+            "fo\no",
+        ];
+        yield [
+            'fo 1o',
+            "fo\n1o",
+        ];
+        yield [
+            'fo A o',
+            "fo\nA o",
+        ];
+        yield [
+            'fo o',
+            "fo\n   o",
+        ];
+        yield [
+            "fo \to",
+            "fo\n\to",
+        ];
+    }
+}

--- a/tests/Value/SassBooleanTest.php
+++ b/tests/Value/SassBooleanTest.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2018-2020 Anthon Pang
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Tests\Value;
+
+use ScssPhp\ScssPhp\Exception\SassScriptException;
+use ScssPhp\ScssPhp\Value\SassBoolean;
+use PHPUnit\Framework\TestCase;
+use ScssPhp\ScssPhp\Value\Value;
+
+class SassBooleanTest extends TestCase
+{
+    public function testTrueTruthy()
+    {
+        $this->assertTrue(SassBoolean::create(true)->isTruthy());
+    }
+
+    public function testFalseIsFalsy()
+    {
+        $this->assertFalse(SassBoolean::create(false)->isTruthy());
+    }
+
+    public static function provideValues(): iterable
+    {
+        yield [SassBoolean::create(true)];
+        yield [SassBoolean::create(false)];
+    }
+
+    /**
+     * @dataProvider provideValues
+     */
+    public function testIsABoolean(Value $value)
+    {
+        $this->assertSame($value, $value->assertBoolean());
+    }
+
+    /**
+     * @dataProvider provideValues
+     */
+    public function testIsNotAColor(Value $value)
+    {
+        $this->expectException(SassScriptException::class);
+
+        $value->assertColor();
+    }
+
+    /**
+     * @dataProvider provideValues
+     */
+    public function testIsNotAFunction(Value $value)
+    {
+        $this->expectException(SassScriptException::class);
+
+        $value->assertFunction();
+    }
+
+    /**
+     * @dataProvider provideValues
+     */
+    public function testIsNotAMap(Value $value)
+    {
+        $this->assertNull($value->tryMap());
+
+        $this->expectException(SassScriptException::class);
+
+        $value->assertMap();
+    }
+
+    /**
+     * @dataProvider provideValues
+     */
+    public function testIsNotANumber(Value $value)
+    {
+        $this->expectException(SassScriptException::class);
+
+        $value->assertNumber();
+    }
+
+    /**
+     * @dataProvider provideValues
+     */
+    public function testIsNotAString(Value $value)
+    {
+        $this->expectException(SassScriptException::class);
+
+        $value->assertString();
+    }
+}

--- a/tests/Value/SassColor/HslTest.php
+++ b/tests/Value/SassColor/HslTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2018-2020 Anthon Pang
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Tests\Value\SassColor;
+
+use ScssPhp\ScssPhp\Tests\Value\ValueTestCase;
+use ScssPhp\ScssPhp\Value\SassColor;
+
+/**
+ * @testdox An HSL color
+ */
+class HslTest extends ValueTestCase
+{
+    /**
+     * @var SassColor
+     */
+    private $value;
+
+    protected function setUp(): void
+    {
+        $this->value = self::parseValue('hsl(120, 42%, 42%)');
+    }
+
+    public function testHasRgbChannels()
+    {
+        $this->assertSame(0x3E, $this->value->getRed());
+        $this->assertSame(0x98, $this->value->getGreen());
+        $this->assertSame(0x3E, $this->value->getBlue());
+    }
+
+    public function testHasHslChannels()
+    {
+        $this->assertEquals(120, $this->value->getHue());
+        $this->assertEquals(42, $this->value->getSaturation());
+        $this->assertEquals(42, $this->value->getLightness());
+    }
+
+    public function testHasHwbChannels()
+    {
+        $this->assertEquals(120, $this->value->getHue());
+        $this->assertEquals(24.313725490196077, $this->value->getWhiteness());
+        $this->assertEquals(40.3921568627451, $this->value->getBlackness());
+    }
+
+    public function testHasAnAlphaChannel()
+    {
+        $this->assertEquals(1, $this->value->getAlpha());
+    }
+
+    public function testEqualsTheSameColor()
+    {
+        $rgbValue = SassColor::rgb(0x3E, 0x98, 0x3E);
+        $hslValue = SassColor::hsl(120, 42, 42);
+        $hwbValue = SassColor::hwb(120, 24.313725490196077, 40.3921568627451);
+
+        $this->assertSassEquals($this->value, $rgbValue);
+        $this->assertSassEquals($this->value, $hslValue);;
+        $this->assertSassEquals($this->value, $hwbValue);;
+    }
+
+}

--- a/tests/Value/SassColor/HwbTest.php
+++ b/tests/Value/SassColor/HwbTest.php
@@ -1,0 +1,110 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2018-2020 Anthon Pang
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Tests\Value\SassColor;
+
+use ScssPhp\ScssPhp\Tests\Value\ValueTestCase;
+use ScssPhp\ScssPhp\Value\SassColor;
+
+/**
+ * @testdox new SassColor.hwb()
+ */
+class HwbTest extends ValueTestCase
+{
+    /**
+     * @var SassColor
+     */
+    private $value;
+
+    protected function setUp(): void
+    {
+        $this->value = SassColor::hwb(120, 42, 42);
+    }
+
+    public function testHasRgbChannels()
+    {
+        $this->assertSame(0x6B, $this->value->getRed());
+        $this->assertSame(0x94, $this->value->getGreen());
+        $this->assertSame(0x6B, $this->value->getBlue());
+    }
+
+    public function testHasHslChannels()
+    {
+        $this->assertEquals(120, $this->value->getHue());
+        $this->assertEquals(16.078431372549026, $this->value->getSaturation());
+        $this->assertEquals(50, $this->value->getLightness());
+    }
+
+    public function testHasHwbChannels()
+    {
+        $this->assertEquals(120, $this->value->getHue());
+        $this->assertEquals(41.96078431372549, $this->value->getWhiteness());
+        $this->assertEquals(41.96078431372548, $this->value->getBlackness());
+    }
+
+    public function testHasAnAlphaChannel()
+    {
+        $this->assertEquals(1, $this->value->getAlpha());
+    }
+
+    public function testEqualsTheSameColor()
+    {
+        $this->assertSassEquals($this->value, SassColor::rgb(0x6B, 0x94, 0x6B));;
+        $this->assertSassEquals($this->value, SassColor::hsl(120, 16, 50));;
+        $this->assertSassEquals($this->value, SassColor::hwb(120, 42, 42));;
+    }
+
+    public function testAllowsValidValues()
+    {
+        $this->assertSassEquals(SassColor::hwb(0, 0, 0, 0), self::parseValue('rgba(255, 0, 0, 0)'));
+        $this->assertSassEquals(SassColor::hwb(4320, 100, 100, 1), self::parseValue('grey'));
+    }
+
+    /**
+     * @dataProvider provideInvalidPercentageValues
+     */
+    public function testHwbConstructorDisallowsInvalidValuesForWhiteness($invalidValue)
+    {
+        $this->expectException(\OutOfRangeException::class);
+        SassColor::hwb(0, $invalidValue, 0, 0);
+    }
+
+    /**
+     * @dataProvider provideInvalidPercentageValues
+     */
+    public function testHwbConstructorDisallowsInvalidValuesForBlackness($invalidValue)
+    {
+        $this->expectException(\OutOfRangeException::class);
+        SassColor::hwb(0, 0, $invalidValue, 0);
+    }
+
+    /**
+     * @dataProvider provideInvalidAlphaValues
+     */
+    public function testHwbConstructorDisallowsInvalidValuesForAlpha($invalidValue)
+    {
+        $this->expectException(\OutOfRangeException::class);
+        SassColor::hwb(0, 0, 0, $invalidValue);
+    }
+
+    public static function provideInvalidPercentageValues(): iterable
+    {
+        yield [-0.1];
+        yield [100.1];
+    }
+
+    public static function provideInvalidAlphaValues(): iterable
+    {
+        yield [-0.1];
+        yield [1.1];
+    }
+}

--- a/tests/Value/SassColor/RgbTest.php
+++ b/tests/Value/SassColor/RgbTest.php
@@ -1,0 +1,303 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2018-2020 Anthon Pang
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Tests\Value\SassColor;
+
+use ScssPhp\ScssPhp\Exception\SassScriptException;
+use ScssPhp\ScssPhp\Tests\Value\ValueTestCase;
+use ScssPhp\ScssPhp\Value\SassColor;
+
+/**
+ * @testdox An RGB Color
+ */
+class RgbTest extends ValueTestCase
+{
+    /**
+     * @var SassColor
+     */
+    private $value;
+
+    protected function setUp(): void
+    {
+        $this->value = self::parseValue('#123456');
+    }
+
+    public function testHasRgbChannels()
+    {
+        $this->assertSame(0x12, $this->value->getRed());
+        $this->assertSame(0x34, $this->value->getGreen());
+        $this->assertSame(0x56, $this->value->getBlue());
+    }
+
+    public function testHasHslChannels()
+    {
+        $this->assertEquals(210, $this->value->getHue());
+        $this->assertEquals(65.3846153846154, $this->value->getSaturation());
+        $this->assertEquals(20.392156862745097, $this->value->getLightness());
+    }
+
+    public function testHasHwbChannels()
+    {
+        $this->assertEquals(210, $this->value->getHue());
+        $this->assertEquals(7.0588235294117645, $this->value->getWhiteness());
+        $this->assertEquals(66.27450980392157, $this->value->getBlackness());
+    }
+
+    public function testHasAnAlphaChannel()
+    {
+        $this->assertEquals(1, $this->value->getAlpha());
+    }
+
+    public function testEqualsTheSameValue()
+    {
+        $rgbValue = SassColor::rgb(0x12, 0x34, 0x56);
+        $hslValue = SassColor::hsl(210, 65.3846153846154, 20.392156862745097);
+
+        $this->assertSassEquals($this->value, $rgbValue);;
+        $this->assertSassEquals($this->value, $hslValue);;
+    }
+
+    public function testChangeRgbChangesRGBValues()
+    {
+        $this->assertSassEquals($this->value->changeRgb(0xAA), SassColor::rgb(0xAA, 0x34, 0x56));
+        $this->assertSassEquals($this->value->changeRgb(null, 0xAA), SassColor::rgb(0x12, 0xAA, 0x56));
+        $this->assertSassEquals($this->value->changeRgb(null, null, 0xAA), SassColor::rgb(0x12, 0x34, 0xAA));
+        $this->assertSassEquals($this->value->changeRgb(null, null, null, 0.5), SassColor::rgb(0x12, 0x34, 0x56, 0.5));
+        $this->assertSassEquals($this->value->changeRgb(0xAA, 0xAA, 0xAA, 0.5), SassColor::rgb(0xAA, 0xAA, 0xAA, 0.5));
+    }
+
+    public function testChangeRgbAllowsValidValues()
+    {
+        $this->assertEquals(0, $this->value->changeRgb(0)->getRed());
+        $this->assertEquals(0xFF, $this->value->changeRgb(0xFF)->getRed());
+        $this->assertEquals(0, $this->value->changeRgb(null, 0)->getGreen());
+        $this->assertEquals(0xFF, $this->value->changeRgb(null, 0xFF)->getGreen());
+        $this->assertEquals(0, $this->value->changeRgb(null, null, 0)->getBlue());
+        $this->assertEquals(0xFF, $this->value->changeRgb(null, null, 0xFF)->getBlue());
+        $this->assertEquals(0, $this->value->changeRgb(null, null, null, 0)->getAlpha());
+        $this->assertEquals(1, $this->value->changeRgb(null, null, null, 1)->getAlpha());
+    }
+
+    /**
+     * @dataProvider provideInvalidRgbValues
+     */
+    public function testChangeRgbDisallowsInvalidValuesForRed($invalidValue)
+    {
+        $this->expectException(\OutOfRangeException::class);
+        $this->value->changeRgb($invalidValue);
+    }
+
+    /**
+     * @dataProvider provideInvalidRgbValues
+     */
+    public function testChangeRgbDisallowsInvalidValuesForGreen($invalidValue)
+    {
+        $this->expectException(\OutOfRangeException::class);
+        $this->value->changeRgb(null, $invalidValue);
+    }
+
+    /**
+     * @dataProvider provideInvalidRgbValues
+     */
+    public function testChangeRgbDisallowsInvalidValuesForBlue($invalidValue)
+    {
+        $this->expectException(\OutOfRangeException::class);
+        $this->value->changeRgb(null, null, $invalidValue);
+    }
+
+    public static function provideInvalidRgbValues(): iterable
+    {
+        yield [-1];
+        yield [256];
+    }
+
+    /**
+     * @dataProvider provideInvalidAlphaValues
+     */
+    public function testChangeRgbDisallowsInvalidValuesForAlpha($invalidValue)
+    {
+        $this->expectException(\OutOfRangeException::class);
+        $this->value->changeRgb(null, null, null, $invalidValue);
+    }
+
+    public static function provideInvalidAlphaValues(): iterable
+    {
+        yield [-0.1];
+        yield [1.1];
+    }
+
+    public function testChangeHslChangesHSLValues()
+    {
+        $this->assertSassEquals($this->value->changeHsl(120), SassColor::hsl(120, 65.3846153846154, 20.392156862745097));
+        $this->assertSassEquals($this->value->changeHsl(null, 42), SassColor::hsl(210, 42, 20.392156862745097));
+        $this->assertSassEquals($this->value->changeHsl(null, null, 42), SassColor::hsl(210, 65.3846153846154, 42));
+        $this->assertSassEquals($this->value->changeHsl(null, null, null, 0.5), SassColor::hsl(210, 65.3846153846154, 20.392156862745097, 0.5));
+        $this->assertSassEquals($this->value->changeHsl(120, 42, 42, 0.5), SassColor::hsl(120, 42, 42, 0.5));
+    }
+
+    public function testChangeHslAllowsValidValues()
+    {
+        $this->assertEquals(0, $this->value->changeHsl(null,0)->getSaturation());
+        $this->assertEquals(100, $this->value->changeHsl(null, 100)->getSaturation());
+        $this->assertEquals(0, $this->value->changeHsl(null, null, 0)->getLightness());
+        $this->assertEquals(100, $this->value->changeHsl(null, null, 100)->getLightness());
+        $this->assertEquals(0, $this->value->changeHsl(null, null, null, 0)->getAlpha());
+        $this->assertEquals(1, $this->value->changeHsl(null, null, null, 1)->getAlpha());
+    }
+
+    /**
+     * @dataProvider provideInvalidPercentageValues
+     */
+    public function testChangeHslDisallowsInvalidValuesForSaturation($invalidValue)
+    {
+        $this->expectException(\OutOfRangeException::class);
+        $this->value->changeHsl(null, $invalidValue);
+    }
+
+    /**
+     * @dataProvider provideInvalidPercentageValues
+     */
+    public function testChangeHslDisallowsInvalidValuesForLightness($invalidValue)
+    {
+        $this->expectException(\OutOfRangeException::class);
+        $this->value->changeHsl(null, null, $invalidValue);
+    }
+
+    public static function provideInvalidPercentageValues(): iterable
+    {
+        yield [-0.1];
+        yield [100.1];
+    }
+
+    /**
+     * @dataProvider provideInvalidAlphaValues
+     */
+    public function testChangeHslDisallowsInvalidValuesForAlpha($invalidValue)
+    {
+        $this->expectException(\OutOfRangeException::class);
+        $this->value->changeHsl(null, null, null, $invalidValue);
+    }
+
+    public function testChangeHwbChangesHWBValues()
+    {
+        $this->assertSassEquals($this->value->changeHwb(120), SassColor::hwb(120, 7.0588235294117645, 66.27450980392157));
+        $this->assertSassEquals($this->value->changeHwb(null, 20), SassColor::hwb(210, 20, 66.27450980392157));
+        $this->assertSassEquals($this->value->changeHwb(null, null, 42), SassColor::hwb(210, 7.0588235294117645, 42));
+        $this->assertSassEquals($this->value->changeHwb(null, null, null, 0.5), SassColor::hwb(210, 7.0588235294117645, 66.27450980392157, 0.5));
+        $this->assertSassEquals($this->value->changeHwb(120, 42, 42, 0.5), SassColor::hwb(120, 42, 42, 0.5));
+        $this->assertSassEquals($this->value->changeHwb(null, 50), SassColor::hwb(210, 43, 57));
+    }
+
+    public function testChangeHwbAllowsValidValues()
+    {
+        $this->assertEquals(0, $this->value->changeHwb(null,0)->getWhiteness());
+        $this->assertEquals(60.0, $this->value->changeHwb(null, 100)->getWhiteness());
+        $this->assertEquals(0, $this->value->changeHwb(null, null, 0)->getBlackness());
+        $this->assertEquals(93.33333333333333, $this->value->changeHwb(null, null, 100)->getBlackness());
+        $this->assertEquals(0, $this->value->changeHwb(null, null, null, 0)->getAlpha());
+        $this->assertEquals(1, $this->value->changeHwb(null, null, null, 1)->getAlpha());
+    }
+
+    /**
+     * @dataProvider provideInvalidPercentageValues
+     */
+    public function testChangeHwbDisallowsInvalidValuesForWhiteness($invalidValue)
+    {
+        $this->expectException(\OutOfRangeException::class);
+        $this->value->changeHwb(null, $invalidValue);
+    }
+
+    /**
+     * @dataProvider provideInvalidPercentageValues
+     */
+    public function testChangeHwbDisallowsInvalidValuesForBlackness($invalidValue)
+    {
+        $this->expectException(\OutOfRangeException::class);
+        $this->value->changeHwb(null, null, $invalidValue);
+    }
+
+    /**
+     * @dataProvider provideInvalidAlphaValues
+     */
+    public function testChangeHwbDisallowsInvalidValuesForAlpha($invalidValue)
+    {
+        $this->expectException(\OutOfRangeException::class);
+        $this->value->changeHwb(null, null, null, $invalidValue);
+    }
+
+    public function testChangeAlphaChangesTheAlphaValue()
+    {
+        $this->assertSassEquals($this->value->changeAlpha(0.5), SassColor::rgb(0x12, 0x34, 0x56, 0.5));
+    }
+
+    public function testChangeAlphaAcceptsValidAlpha()
+    {
+        $this->assertEquals(0, $this->value->changeAlpha(0)->getAlpha());
+        $this->assertEquals(1, $this->value->changeAlpha(1)->getAlpha());
+    }
+
+    /**
+     * @dataProvider provideInvalidAlphaValues
+     */
+    public function testChangeAlphaRejectsInvalidAlpha($invalidValue)
+    {
+        $this->expectException(\OutOfRangeException::class);
+        $this->value->changeAlpha($invalidValue);
+    }
+
+    public function testIsTruthy()
+    {
+        $this->assertTrue(SassColor::rgb(0x12, 0x34, 0x56)->isTruthy());
+    }
+
+    public function testIsNotABoolean()
+    {
+        $this->expectException(SassScriptException::class);
+
+        $this->value->assertBoolean();
+    }
+
+    public function testIsAColor()
+    {
+        $this->assertSame($this->value, $this->value->assertColor());
+    }
+
+    public function testIsNotAFunction()
+    {
+        $this->expectException(SassScriptException::class);
+
+        $this->value->assertFunction();
+    }
+
+    public function testIsNotAMap()
+    {
+        $this->assertNull($this->value->tryMap());
+
+        $this->expectException(SassScriptException::class);
+
+        $this->value->assertMap();
+    }
+
+    public function testIsNotANumber()
+    {
+        $this->expectException(SassScriptException::class);
+
+        $this->value->assertNumber();
+    }
+
+    public function testIsNotAString()
+    {
+        $this->expectException(SassScriptException::class);
+
+        $this->value->assertString();
+    }
+}

--- a/tests/Value/SassColor/SassColorTest.php
+++ b/tests/Value/SassColor/SassColorTest.php
@@ -1,0 +1,108 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2018-2020 Anthon Pang
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Tests\Value\SassColor;
+
+use ScssPhp\ScssPhp\Tests\Value\ValueTestCase;
+use ScssPhp\ScssPhp\Util\NumberUtil;
+use ScssPhp\ScssPhp\Value\SassColor;
+
+class SassColorTest extends ValueTestCase
+{
+    public function testAnRgbaColorHasAnAlphaChannel()
+    {
+        /** @var SassColor $color */
+        $color = self::parseValue('rgba(10, 20, 30, 0.7)');
+        $this->assertEqualsWithDelta(0.7, $color->getAlpha(), NumberUtil::EPSILON);
+    }
+
+    /**
+     * @dataProvider provideInvalidRgbValues
+     */
+    public function testRgbConstructorDisallowsInvalidValuesForRed($invalidValue)
+    {
+        $this->expectException(\OutOfRangeException::class);
+        SassColor::rgb($invalidValue, 0, 0, 0);
+    }
+
+    /**
+     * @dataProvider provideInvalidRgbValues
+     */
+    public function testRgbConstructorDisallowsInvalidValuesForGreen($invalidValue)
+    {
+        $this->expectException(\OutOfRangeException::class);
+        SassColor::rgb(0, $invalidValue, 0, 0);
+    }
+
+    /**
+     * @dataProvider provideInvalidRgbValues
+     */
+    public function testRgbConstructorDisallowsInvalidValuesForBlue($invalidValue)
+    {
+        $this->expectException(\OutOfRangeException::class);
+        SassColor::rgb(0, 0, $invalidValue, 0);
+    }
+
+    /**
+     * @dataProvider provideInvalidAlphaValues
+     */
+    public function testRgbConstructorDisallowsInvalidValuesForAlpha($invalidValue)
+    {
+        $this->expectException(\OutOfRangeException::class);
+        SassColor::rgb(0, 0, 0, $invalidValue);
+    }
+
+    /**
+     * @dataProvider provideInvalidPercentageValues
+     */
+    public function testHslConstructorDisallowsInvalidValuesForSaturation($invalidValue)
+    {
+        $this->expectException(\OutOfRangeException::class);
+        SassColor::hsl(0, $invalidValue, 0, 0);
+    }
+
+    /**
+     * @dataProvider provideInvalidPercentageValues
+     */
+    public function testHslConstructorDisallowsInvalidValuesForLightness($invalidValue)
+    {
+        $this->expectException(\OutOfRangeException::class);
+        SassColor::hsl(0, 0, $invalidValue, 0);
+    }
+
+    /**
+     * @dataProvider provideInvalidAlphaValues
+     */
+    public function testHslConstructorDisallowsInvalidValuesForAlpha($invalidValue)
+    {
+        $this->expectException(\OutOfRangeException::class);
+        SassColor::hsl(0, 0, 0, $invalidValue);
+    }
+
+    public static function provideInvalidRgbValues(): iterable
+    {
+        yield [-1];
+        yield [256];
+    }
+
+    public static function provideInvalidAlphaValues(): iterable
+    {
+        yield [-0.1];
+        yield [1.1];
+    }
+
+    public static function provideInvalidPercentageValues(): iterable
+    {
+        yield [-0.1];
+        yield [100.1];
+    }
+}

--- a/tests/Value/SassFunctionTest.php
+++ b/tests/Value/SassFunctionTest.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2018-2020 Anthon Pang
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Tests\Value;
+
+use ScssPhp\ScssPhp\Exception\SassScriptException;
+use ScssPhp\ScssPhp\Value\SassFunction;
+
+class SassFunctionTest extends ValueTestCase
+{
+    /**
+     * @var SassFunction
+     */
+    private $value;
+
+    protected function setUp(): void
+    {
+        $this->value = self::parseValue("get-function('red')");
+    }
+
+    public function testEqualsTheSameFunction()
+    {
+        $this->assertSassEquals($this->value, self::parseValue("get-function('red')"));
+    }
+
+    public function testIsTruthy()
+    {
+        $this->assertTrue($this->value->isTruthy());
+    }
+
+    public function testIsNotABoolean()
+    {
+        $this->expectException(SassScriptException::class);
+
+        $this->value->assertBoolean();
+    }
+
+    public function testIsNotAColor()
+    {
+        $this->expectException(SassScriptException::class);
+
+        $this->value->assertColor();
+    }
+
+    public function testIsAFunction()
+    {
+        $this->assertSame($this->value, $this->value->assertFunction());
+    }
+
+    public function testIsNotAMap()
+    {
+        $this->assertNull($this->value->tryMap());
+
+        $this->expectException(SassScriptException::class);
+
+        $this->value->assertMap();
+    }
+
+    public function testIsNotANumber()
+    {
+        $this->expectException(SassScriptException::class);
+
+        $this->value->assertNumber();
+    }
+
+    public function testIsNotAString()
+    {
+        $this->expectException(SassScriptException::class);
+
+        $this->value->assertString();
+    }
+}

--- a/tests/Value/SassList/CommaSeparatedTest.php
+++ b/tests/Value/SassList/CommaSeparatedTest.php
@@ -1,0 +1,188 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2018-2020 Anthon Pang
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Tests\Value\SassList;
+
+use ScssPhp\ScssPhp\Exception\SassScriptException;
+use ScssPhp\ScssPhp\Tests\Value\ValueTestCase;
+use ScssPhp\ScssPhp\Value\ListSeparator;
+use ScssPhp\ScssPhp\Value\SassList;
+use ScssPhp\ScssPhp\Value\SassNumber;
+use ScssPhp\ScssPhp\Value\SassString;
+use ScssPhp\ScssPhp\Value\Value;
+
+/**
+ * @testdox A comma-separated list
+ */
+class CommaSeparatedTest extends ValueTestCase
+{
+    /**
+     * @var Value
+     */
+    private $value;
+
+    protected function setUp(): void
+    {
+        $this->value = self::parseValue('a, b, c');
+    }
+
+    public function testIsCommaSeparated()
+    {
+        $this->assertEquals(ListSeparator::COMMA, $this->value->getSeparator());
+    }
+
+    public function testHasNoBrackets()
+    {
+        $this->assertFalse($this->value->hasBrackets());
+    }
+
+    public function testReturnsItsContentsAsAList()
+    {
+        $this->assertEquals([
+            new SassString('a', false),
+            new SassString('b', false),
+            new SassString('c', false),
+        ], $this->value->asList());
+    }
+
+    public function testEqualsTheSameList()
+    {
+        $this->assertSassEquals($this->value, new SassList([
+            new SassString('a', false),
+            new SassString('b', false),
+            new SassString('c', false),
+        ], ListSeparator::COMMA));
+    }
+
+    public function testDoesntEqualAValueWithDifferentMetadata()
+    {
+        $this->assertNotSassEquals($this->value, new SassList([
+            new SassString('a', false),
+            new SassString('b', false),
+            new SassString('c', false),
+        ], ListSeparator::SPACE));
+
+        $this->assertNotSassEquals($this->value, new SassList([
+            new SassString('a', false),
+            new SassString('b', false),
+            new SassString('c', false),
+        ], ListSeparator::COMMA, true));
+    }
+
+    /**
+     * @testdox sassIndexToListIndex() converts a positive index to a PHP index
+     */
+    public function testSassIndexToListIndexConvertsAPositiveIndexToAPHPIndex()
+    {
+        $this->assertEquals(0, $this->value->sassIndexToListIndex(SassNumber::create(1)));
+        $this->assertEquals(1, $this->value->sassIndexToListIndex(SassNumber::create(2)));
+        $this->assertEquals(2, $this->value->sassIndexToListIndex(SassNumber::create(3)));
+    }
+
+    /**
+     * @testdox sassIndexToListIndex() converts a negative index to a PHP index
+     */
+    public function testSassIndexToListIndexConvertsANegativeIndexToAPHPIndex()
+    {
+        $this->assertEquals(2, $this->value->sassIndexToListIndex(SassNumber::create(-1)));
+        $this->assertEquals(1, $this->value->sassIndexToListIndex(SassNumber::create(-2)));
+        $this->assertEquals(0, $this->value->sassIndexToListIndex(SassNumber::create(-3)));
+    }
+
+    /**
+     * @testdox sassIndexToListIndex() rejects a non-number
+     */
+    public function testSassIndexToListIndexRejectsANonNumber()
+    {
+        $this->expectException(SassScriptException::class);
+        $this->value->sassIndexToListIndex(new SassString('foo'));
+    }
+
+    /**
+     * @testdox sassIndexToListIndex() rejects a non-integer
+     */
+    public function testSassIndexToListIndexRejectsANonInteger()
+    {
+        $this->expectException(SassScriptException::class);
+        $this->value->sassIndexToListIndex(SassNumber::create(1.1));
+    }
+
+    /**
+     * @testdox sassIndexToListIndex() rejects invalid indices
+     * @dataProvider provideInvalidIndices
+     */
+    public function testSassIndexToListIndexRejectsInvalidIndices($index)
+    {
+        $this->expectException(SassScriptException::class);
+        $this->value->sassIndexToListIndex(SassNumber::create($index));
+    }
+
+    public static function provideInvalidIndices(): iterable
+    {
+        yield [0];
+        yield [4];
+        yield [-4];
+    }
+
+    public function testDoesntEqualAValueWithDifferentContents()
+    {
+        $this->assertNotSassEquals($this->value, new SassList([
+            new SassString('a', false),
+            new SassString('x', false),
+            new SassString('c', false),
+        ], ListSeparator::COMMA));
+    }
+
+    public function testIsNotABoolean()
+    {
+        $this->expectException(SassScriptException::class);
+
+        $this->value->assertBoolean();
+    }
+
+    public function testIsNotAColor()
+    {
+        $this->expectException(SassScriptException::class);
+
+        $this->value->assertColor();
+    }
+
+    public function testIsNotAFunction()
+    {
+        $this->expectException(SassScriptException::class);
+
+        $this->value->assertFunction();
+    }
+
+    public function testIsNotAMap()
+    {
+        $this->assertNull($this->value->tryMap());
+
+        $this->expectException(SassScriptException::class);
+
+        $this->value->assertMap();
+    }
+
+    public function testIsNotANumber()
+    {
+        $this->expectException(SassScriptException::class);
+
+        $this->value->assertNumber();
+    }
+
+    public function testIsNotAString()
+    {
+        $this->expectException(SassScriptException::class);
+
+        $this->value->assertString();
+    }
+}

--- a/tests/Value/SassList/ConstructorTest.php
+++ b/tests/Value/SassList/ConstructorTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2018-2020 Anthon Pang
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Tests\Value\SassList;
+
+use PHPUnit\Framework\TestCase;
+use ScssPhp\ScssPhp\Value\ListSeparator;
+use ScssPhp\ScssPhp\Value\SassList;
+use ScssPhp\ScssPhp\Value\SassString;
+
+/**
+ * @testdox new SassList()
+ */
+class ConstructorTest extends TestCase
+{
+    public function testCreatesAListWithTheGivenContentsAndMetadata()
+    {
+        $list = new SassList([new SassString('a', false)], ListSeparator::SPACE);
+
+        $this->assertEquals([new SassString('a', false)], $list->asList());
+        $this->assertEquals(ListSeparator::SPACE, $list->getSeparator());
+        $this->assertFalse($list->hasBrackets());
+    }
+
+    public function testCanCreateABracketedList()
+    {
+        $list = new SassList([new SassString('a', false)], ListSeparator::SPACE, true);
+
+        $this->assertTrue($list->hasBrackets());
+    }
+
+    public function testCanCreateAShortListWithAnUndecidedSeparator()
+    {
+        $list = new SassList([new SassString('a', false)], ListSeparator::UNDECIDED);
+        $this->assertEquals(ListSeparator::UNDECIDED, $list->getSeparator());
+
+        $this->assertEquals(ListSeparator::UNDECIDED, (new SassList([], ListSeparator::UNDECIDED))->getSeparator());
+    }
+
+    public function testCantCreateALongListWithAnUndecidedSeparator()
+    {
+        $contents = [new SassString('a', false), new SassString('b', false)];
+
+        $this->expectException(\InvalidArgumentException::class);
+        new SassList($contents, ListSeparator::UNDECIDED);
+    }
+}

--- a/tests/Value/SassList/EmptyListTest.php
+++ b/tests/Value/SassList/EmptyListTest.php
@@ -1,0 +1,109 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2018-2020 Anthon Pang
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Tests\Value\SassList;
+
+use ScssPhp\ScssPhp\Exception\SassScriptException;
+use ScssPhp\ScssPhp\Tests\Value\ValueTestCase;
+use ScssPhp\ScssPhp\Value\ListSeparator;
+use ScssPhp\ScssPhp\Value\SassMap;
+use ScssPhp\ScssPhp\Value\SassNumber;
+use ScssPhp\ScssPhp\Value\Value;
+
+/**
+ * @testdox An empty list
+ */
+class EmptyListTest extends ValueTestCase
+{
+    /**
+     * @var Value
+     */
+    private $value;
+
+    protected function setUp(): void
+    {
+        $this->value = self::parseValue('()');
+    }
+
+    public function testHasAnUndecidedSeparator()
+    {
+        $this->assertEquals(ListSeparator::UNDECIDED, $this->value->getSeparator());
+    }
+
+    public function testReturnsItsContentsAsAList()
+    {
+        $this->assertEmpty($this->value->asList());
+    }
+
+    public function testEqualsAnEmptyMap()
+    {
+        $this->assertSassEquals($this->value, SassMap::createEmpty());
+    }
+
+    public function testCountsAsAnEmptyMap()
+    {
+        $this->assertEmpty($this->value->assertMap()->getContents());
+        $this->assertNotNull($this->value->tryMap());
+    }
+
+    public function testIsNotABoolean()
+    {
+        $this->expectException(SassScriptException::class);
+
+        $this->value->assertBoolean();
+    }
+
+    public function testIsNotAColor()
+    {
+        $this->expectException(SassScriptException::class);
+
+        $this->value->assertColor();
+    }
+
+    public function testIsNotAFunction()
+    {
+        $this->expectException(SassScriptException::class);
+
+        $this->value->assertFunction();
+    }
+
+    public function testIsNotANumber()
+    {
+        $this->expectException(SassScriptException::class);
+
+        $this->value->assertNumber();
+    }
+
+    public function testIsNotAString()
+    {
+        $this->expectException(SassScriptException::class);
+
+        $this->value->assertString();
+    }
+
+    /**
+     * @testdox sassIndexToListIndex() rejects invalid indices
+     * @dataProvider provideInvalidIndices
+     */
+    public function testSassIndexToListIndexRejectsInvalidIndices($index)
+    {
+        $this->expectException(SassScriptException::class);
+        $this->value->sassIndexToListIndex(SassNumber::create($index));
+    }
+
+    public static function provideInvalidIndices(): iterable
+    {
+        yield [0];
+        yield [1];
+        yield [-1];
+    }
+}

--- a/tests/Value/SassList/SassListTest.php
+++ b/tests/Value/SassList/SassListTest.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2018-2020 Anthon Pang
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Tests\Value\SassList;
+
+use ScssPhp\ScssPhp\Tests\Value\ValueTestCase;
+use ScssPhp\ScssPhp\Value\ListSeparator;
+
+class SassListTest extends ValueTestCase
+{
+    public function testASlashSeparatedListIsSlashSeparated()
+    {
+        $this->assertEquals(ListSeparator::SLASH, self::parseValue('list.slash(a, b, c)')->getSeparator());
+    }
+
+    public function testASpaceSeparatedListIsSpaceSeparated()
+    {
+        $this->assertEquals(ListSeparator::SPACE, self::parseValue('a b c')->getSeparator());
+    }
+
+    public function testABracketedListHasBrackets()
+    {
+        $this->assertTrue(self::parseValue('[a, b, c]')->hasBrackets());
+    }
+
+    public function testACommaSeparatedSingleElementListIsCommaSeparated()
+    {
+        $this->assertEquals(ListSeparator::COMMA, self::parseValue('(1,)')->getSeparator());
+    }
+}

--- a/tests/Value/SassList/ScalarValueTest.php
+++ b/tests/Value/SassList/ScalarValueTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2018-2020 Anthon Pang
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Tests\Value\SassList;
+
+use ScssPhp\ScssPhp\Exception\SassScriptException;
+use ScssPhp\ScssPhp\Tests\Value\ValueTestCase;
+use ScssPhp\ScssPhp\Value\ListSeparator;
+use ScssPhp\ScssPhp\Value\SassNumber;
+use ScssPhp\ScssPhp\Value\Value;
+
+/**
+ * @testdox A scalar value
+ */
+class ScalarValueTest extends ValueTestCase
+{
+    /**
+     * @var Value
+     */
+    private $value;
+
+    protected function setUp(): void
+    {
+        $this->value = self::parseValue('blue');
+    }
+
+    public function testHasAnUndecidedSeparator()
+    {
+        $this->assertEquals(ListSeparator::UNDECIDED, $this->value->getSeparator());
+    }
+
+    public function testHasNoBrackets()
+    {
+        $this->assertFalse($this->value->hasBrackets());
+    }
+
+    public function testReturnsItselfAsAList()
+    {
+        $list = $this->value->asList();
+
+        $this->assertCount(1, $list);
+        $this->assertSame($this->value, $list[0]);
+    }
+
+    /**
+     * @testdox sassIndexToListIndex() converts a positive index to a PHP index
+     */
+    public function testSassIndexToListIndexConvertsAPositiveIndexToAPHPIndex()
+    {
+        $this->assertEquals(0, $this->value->sassIndexToListIndex(SassNumber::create(1)));
+    }
+
+    /**
+     * @testdox sassIndexToListIndex() converts a negative index to a PHP index
+     */
+    public function testSassIndexToListIndexConvertsANegativeIndexToAPHPIndex()
+    {
+        $this->assertEquals(0, $this->value->sassIndexToListIndex(SassNumber::create(-1)));
+    }
+
+    /**
+     * @testdox sassIndexToListIndex() rejects invalid indices
+     * @dataProvider provideInvalidIndices
+     */
+    public function testSassIndexToListIndexRejectsInvalidIndices($index)
+    {
+        $this->expectException(SassScriptException::class);
+        $this->value->sassIndexToListIndex(SassNumber::create($index));
+    }
+
+    public static function provideInvalidIndices(): iterable
+    {
+        yield [0];
+        yield [2];
+        yield [-2];
+    }
+}

--- a/tests/Value/SassList/SingleElementTest.php
+++ b/tests/Value/SassList/SingleElementTest.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2018-2020 Anthon Pang
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Tests\Value\SassList;
+
+use ScssPhp\ScssPhp\Exception\SassScriptException;
+use ScssPhp\ScssPhp\Tests\Value\ValueTestCase;
+use ScssPhp\ScssPhp\Value\ListSeparator;
+use ScssPhp\ScssPhp\Value\SassNumber;
+use ScssPhp\ScssPhp\Value\Value;
+
+/**
+ * @testdox A single-element list
+ */
+class SingleElementTest extends ValueTestCase
+{
+    /**
+     * @var Value
+     */
+    private $value;
+
+    protected function setUp(): void
+    {
+        $this->value = self::parseValue('[1]');
+    }
+
+    public function testHasAnUndecidedSeparator()
+    {
+        $this->assertEquals(ListSeparator::UNDECIDED, $this->value->getSeparator());
+    }
+
+    public function testReturnsItsContentsAsAList()
+    {
+        $this->assertEquals([SassNumber::create(1)], $this->value->asList());
+    }
+
+    public function testIsNotABoolean()
+    {
+        $this->expectException(SassScriptException::class);
+
+        $this->value->assertBoolean();
+    }
+
+    public function testIsNotAColor()
+    {
+        $this->expectException(SassScriptException::class);
+
+        $this->value->assertColor();
+    }
+
+    public function testIsNotAFunction()
+    {
+        $this->expectException(SassScriptException::class);
+
+        $this->value->assertFunction();
+    }
+
+    public function testIsNotAMap()
+    {
+        $this->assertNull($this->value->tryMap());
+
+        $this->expectException(SassScriptException::class);
+
+        $this->value->assertMap();
+    }
+
+    public function testIsNotANumber()
+    {
+        $this->expectException(SassScriptException::class);
+
+        $this->value->assertNumber();
+    }
+
+    public function testIsNotAString()
+    {
+        $this->expectException(SassScriptException::class);
+
+        $this->value->assertString();
+    }
+}

--- a/tests/Value/SassMap/ContentsTest.php
+++ b/tests/Value/SassMap/ContentsTest.php
@@ -1,0 +1,189 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2018-2020 Anthon Pang
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Tests\Value\SassMap;
+
+use ScssPhp\ScssPhp\Collection\Map;
+use ScssPhp\ScssPhp\Exception\SassScriptException;
+use ScssPhp\ScssPhp\Tests\Value\ValueTestCase;
+use ScssPhp\ScssPhp\Value\ListSeparator;
+use ScssPhp\ScssPhp\Value\SassList;
+use ScssPhp\ScssPhp\Value\SassMap;
+use ScssPhp\ScssPhp\Value\SassNumber;
+use ScssPhp\ScssPhp\Value\SassString;
+
+class ContentsTest extends ValueTestCase
+{
+    /**
+     * @var SassMap
+     */
+    private $value;
+
+    protected function setUp(): void
+    {
+        $this->value = self::parseValue('(a: b, c: d)');
+    }
+
+    public function testHasACommaSeparator()
+    {
+        $this->assertEquals(ListSeparator::COMMA, $this->value->getSeparator());
+    }
+
+    public function testReturnsItsContentAsAMap()
+    {
+        $map = new Map();
+        $map->put(new SassString('a', false), new SassString('b', false));
+        $map->put(new SassString('c', false), new SassString('d', false));
+
+        $this->assertEquals(Map::unmodifiable($map), $this->value->getContents());
+    }
+
+    public function testReturnsItsContentAsAList()
+    {
+        $list = [
+            new SassList([new SassString('a', false), new SassString('b', false)], ListSeparator::SPACE),
+            new SassList([new SassString('c', false), new SassString('d', false)], ListSeparator::SPACE),
+        ];
+        $this->assertEquals($list, $this->value->asList());
+    }
+
+    /**
+     * @testdox sassIndexToListIndex() converts a positive index to a PHP index
+     */
+    public function testSassIndexToListIndexConvertsAPositiveIndexToAPHPIndex()
+    {
+        $this->assertEquals(0, $this->value->sassIndexToListIndex(SassNumber::create(1)));
+        $this->assertEquals(1, $this->value->sassIndexToListIndex(SassNumber::create(2)));
+    }
+
+    /**
+     * @testdox sassIndexToListIndex() converts a negative index to a PHP index
+     */
+    public function testSassIndexToListIndexConvertsANegativeIndexToAPHPIndex()
+    {
+        $this->assertEquals(1, $this->value->sassIndexToListIndex(SassNumber::create(-1)));
+        $this->assertEquals(0, $this->value->sassIndexToListIndex(SassNumber::create(-2)));
+    }
+
+    /**
+     * @testdox sassIndexToListIndex() rejects invalid indices
+     * @dataProvider provideInvalidIndices
+     */
+    public function testSassIndexToListIndexRejectsInvalidIndices($index)
+    {
+        $this->expectException(SassScriptException::class);
+        $this->value->sassIndexToListIndex(SassNumber::create($index));
+    }
+
+    public static function provideInvalidIndices(): iterable
+    {
+        yield [0];
+        yield [3];
+        yield [-3];
+    }
+
+    public function testEqualsTheSameMap()
+    {
+        $map = new Map();
+        $map->put(new SassString('a', false), new SassString('b', false));
+        $map->put(new SassString('c', false), new SassString('d', false));
+
+        $this->assertSassEquals($this->value, SassMap::create($map));
+    }
+
+    public function testDoesntEqualTheEquivalentList()
+    {
+        $list = new SassList([
+            new SassList([new SassString('a', false), new SassString('b', false)], ListSeparator::SPACE),
+            new SassList([new SassString('c', false), new SassString('d', false)], ListSeparator::SPACE),
+        ], ListSeparator::COMMA);
+
+        $this->assertNotSassEquals($this->value, $list);
+    }
+
+    public function testDoesntEqualAMapWithADifferentValue()
+    {
+        $map = new Map();
+        $map->put(new SassString('a', false), new SassString('x', false));
+        $map->put(new SassString('c', false), new SassString('d', false));
+
+        $this->assertNotSassEquals($this->value, SassMap::create($map));
+    }
+
+    public function testDoesntEqualAMapWithADifferentKey()
+    {
+        $map = new Map();
+        $map->put(new SassString('a', false), new SassString('b', false));
+        $map->put(new SassString('x', false), new SassString('d', false));
+
+        $this->assertNotSassEquals($this->value, SassMap::create($map));
+    }
+
+    public function testDoesntEqualAMapWithAMissingPair()
+    {
+        $map = new Map();
+        $map->put(new SassString('a', false), new SassString('b', false));
+
+        $this->assertNotSassEquals($this->value, SassMap::create($map));
+    }
+
+    public function testDoesntEqualAMapWithAnAdditionalPair()
+    {
+        $map = new Map();
+        $map->put(new SassString('a', false), new SassString('b', false));
+        $map->put(new SassString('c', false), new SassString('d', false));
+        $map->put(new SassString('e', false), new SassString('f', false));
+
+        $this->assertNotSassEquals($this->value, SassMap::create($map));
+    }
+
+    public function testIsAMap()
+    {
+        $this->assertSame($this->value, $this->value->assertMap());
+        $this->assertSame($this->value, $this->value->tryMap());
+    }
+
+    public function testIsNotABoolean()
+    {
+        $this->expectException(SassScriptException::class);
+
+        $this->value->assertBoolean();
+    }
+
+    public function testIsNotAColor()
+    {
+        $this->expectException(SassScriptException::class);
+
+        $this->value->assertColor();
+    }
+
+    public function testIsNotAFunction()
+    {
+        $this->expectException(SassScriptException::class);
+
+        $this->value->assertFunction();
+    }
+
+    public function testIsNotANumber()
+    {
+        $this->expectException(SassScriptException::class);
+
+        $this->value->assertNumber();
+    }
+
+    public function testIsNotAString()
+    {
+        $this->expectException(SassScriptException::class);
+
+        $this->value->assertString();
+    }
+}

--- a/tests/Value/SassMap/EmptyTest.php
+++ b/tests/Value/SassMap/EmptyTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2018-2020 Anthon Pang
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Tests\Value\SassMap;
+
+use ScssPhp\ScssPhp\Exception\SassScriptException;
+use ScssPhp\ScssPhp\Tests\Value\ValueTestCase;
+use ScssPhp\ScssPhp\Value\ListSeparator;
+use ScssPhp\ScssPhp\Value\SassList;
+use ScssPhp\ScssPhp\Value\SassMap;
+use ScssPhp\ScssPhp\Value\SassNumber;
+
+/**
+ * @testdox An empty map
+ */
+class EmptyTest extends ValueTestCase
+{
+    /**
+     * @var SassMap
+     */
+    private $value;
+
+    protected function setUp(): void
+    {
+        $this->value = self::parseValue('map-remove((a: b), a)');
+    }
+
+    public function testHasAnUndecidedSeparator()
+    {
+        $this->assertEquals(ListSeparator::UNDECIDED, $this->value->getSeparator());
+    }
+
+    public function testReturnsItsContentAsAMap()
+    {
+        $this->assertEmpty($this->value->getContents());
+    }
+
+    public function testReturnsItsContentAsAList()
+    {
+        $this->assertEmpty($this->value->asList());
+    }
+
+    public function testEqualsAnEmptyList()
+    {
+        $this->assertSassEquals($this->value, SassList::createEmpty());
+    }
+
+    /**
+     * @testdox sassIndexToListIndex() rejects invalid indices
+     * @dataProvider provideInvalidIndices
+     */
+    public function testSassIndexToListIndexRejectsInvalidIndices($index)
+    {
+        $this->expectException(SassScriptException::class);
+        $this->value->sassIndexToListIndex(SassNumber::create($index));
+    }
+
+    public static function provideInvalidIndices(): iterable
+    {
+        yield [0];
+        yield [1];
+        yield [-1];
+    }
+}

--- a/tests/Value/SassNullTest.php
+++ b/tests/Value/SassNullTest.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2018-2020 Anthon Pang
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Tests\Value;
+
+use ScssPhp\ScssPhp\Exception\SassScriptException;
+use ScssPhp\ScssPhp\Value\Value;
+
+class SassNullTest extends ValueTestCase
+{
+    /**
+     * @var Value
+     */
+    private $value;
+
+    protected function setUp(): void
+    {
+        $this->value = self::parseValue('null');
+    }
+
+    public function testIsFalsy()
+    {
+        $this->assertFalse($this->value->isTruthy());
+    }
+
+    public function testIsNotABoolean()
+    {
+        $this->expectException(SassScriptException::class);
+
+        $this->value->assertBoolean();
+    }
+
+    public function testIsNotAColor()
+    {
+        $this->expectException(SassScriptException::class);
+
+        $this->value->assertColor();
+    }
+
+    public function testIsNotAFunction()
+    {
+        $this->expectException(SassScriptException::class);
+
+        $this->value->assertFunction();
+    }
+
+    public function testIsNotAMap()
+    {
+        $this->assertNull($this->value->tryMap());
+
+        $this->expectException(SassScriptException::class);
+
+        $this->value->assertMap();
+    }
+
+    public function testIsNotANumber()
+    {
+        $this->expectException(SassScriptException::class);
+
+        $this->value->assertNumber();
+    }
+
+    public function testIsNotAString()
+    {
+        $this->expectException(SassScriptException::class);
+
+        $this->value->assertString();
+    }
+}

--- a/tests/Value/SassNumber/ComplexUnitNumberTest.php
+++ b/tests/Value/SassNumber/ComplexUnitNumberTest.php
@@ -1,0 +1,165 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2018-2020 Anthon Pang
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Tests\Value\SassNumber;
+
+use ScssPhp\ScssPhp\Exception\SassScriptException;
+use ScssPhp\ScssPhp\Tests\Value\ValueTestCase;
+use ScssPhp\ScssPhp\Value\SassNumber;
+
+/**
+ * @testdox A number with numerator and denominator units
+ */
+class ComplexUnitNumberTest extends ValueTestCase
+{
+    /**
+     * @var SassNumber
+     */
+    private $value;
+
+    protected function setUp(): void
+    {
+        $this->value = self::parseValue('123px / 5ms');
+    }
+
+    public function testHasThoseUnits()
+    {
+        $this->assertEquals(['px'], $this->value->getNumeratorUnits());
+        $this->assertEquals(['ms'], $this->value->getDenominatorUnits());
+        $this->assertTrue($this->value->hasUnits());
+    }
+
+    public function testHasNoUnitsAssertion()
+    {
+        $this->expectException(SassScriptException::class);
+        $this->value->assertNoUnits();
+    }
+
+    /**
+     * @testdox reports false for hasUnit()
+     */
+    public function testReportsFalseForHasUnit()
+    {
+        $this->assertFalse($this->value->hasUnit('px'));
+
+        $this->expectException(SassScriptException::class);
+        $this->value->assertUnit('px');
+    }
+
+    public function testCanBeCoercedToUnitless()
+    {
+        $this->assertSassEquals($this->value->coerce([], []), SassNumber::withUnits(24.6));
+    }
+
+    public function testCanBeCoercedToCompatibleUnits()
+    {
+        $this->assertEquals($this->value->coerce(['px'], ['ms']), $this->value);
+        $this->assertEquals($this->value->coerce(['in'], ['s']), SassNumber::withUnits(256.25, ['in'], ['s']));
+    }
+
+    public function testCanCoerceToMatchAnotherNumber()
+    {
+        $this->assertEquals($this->value->coerceToMatch(SassNumber::withUnits(456, ['in'], ['s'])), SassNumber::withUnits(256.25, ['in'], ['s']));
+    }
+
+    public function testCantBeCoercedToIncompatibleUnits()
+    {
+        $this->expectException(SassScriptException::class);
+        $this->value->coerce(['abc'], []);
+    }
+
+    public function testCantBeConvertedToUnitless()
+    {
+        $this->expectException(SassScriptException::class);
+        $this->value->convertToMatch(SassNumber::create(456));
+    }
+
+    public function testCanBeConvertedToCompatibleUnits()
+    {
+        $this->assertEquals($this->value->convertToMatch(SassNumber::withUnits(456, ['px'], ['ms'])), $this->value);
+        $this->assertEquals($this->value->convertToMatch(SassNumber::withUnits(456, ['in'], ['s'])), SassNumber::withUnits(256.25, ['in'], ['s']));
+    }
+
+    public function testCantBeConvertedToIncompatibleUnit()
+    {
+        $this->expectException(SassScriptException::class);
+        $this->value->convertToMatch(SassNumber::create(456, 'abc'));
+    }
+
+    public function testCanCoerceItsValueToUnitless()
+    {
+        $this->assertEquals(24.6, $this->value->coerceValue([], []));
+    }
+
+    public function testCanCoerceItsValueToCompatibleUnits()
+    {
+        $this->assertEquals(24.6, $this->value->coerceValue(['px'], ['ms']));
+        $this->assertEquals(256.25, $this->value->coerceValue(['in'], ['s']));
+    }
+
+    public function testCantCoerceItsValueToIncompatibleUnits()
+    {
+        $this->expectException(SassScriptException::class);
+        $this->value->coerceValue(['abc'], []);
+    }
+
+    public function testCantConvertItsValueToUnitless()
+    {
+        $this->expectException(SassScriptException::class);
+        $this->value->convertValueToMatch(SassNumber::create(456));
+    }
+
+    public function testCanConvertItsValueToCompatibleUnits()
+    {
+        $this->assertEquals(24.6, $this->value->convertValueToMatch(SassNumber::withUnits(456, ['px'], ['ms'])));
+        $this->assertEquals(256.25, $this->value->convertValueToMatch(SassNumber::withUnits(456, ['in'], ['s'])));
+    }
+
+    public function testCantConvertItsValueToIncompatibleUnit()
+    {
+        $this->expectException(SassScriptException::class);
+        $this->value->convertValueToMatch(SassNumber::create(456, 'abc'));
+    }
+
+    public function testIsIncompatibleWithTheNumeratorUnit()
+    {
+        $this->assertFalse($this->value->compatibleWithUnit('px'));
+    }
+
+    public function testIsIncompatibleWithTheDenominatorUnit()
+    {
+        $this->assertFalse($this->value->compatibleWithUnit('ms'));
+    }
+
+    public function testEqualsTheSameNumber()
+    {
+        $this->assertSassEquals($this->value, SassNumber::withUnits(24.6, ['px'], ['ms']));
+    }
+
+    public function testEqualsAnEquivalentNumber()
+    {
+        $this->assertSassEquals($this->value, SassNumber::withUnits(256.25, ['in'], ['s']));
+    }
+
+    public function testDoesntEqualAUnitlessNumber()
+    {
+        $this->assertNotSassEquals($this->value, SassNumber::create(24.6));
+    }
+
+    public function testDoesntEqualANumberWithDifferentUnits()
+    {
+        $this->assertNotSassEquals($this->value, SassNumber::create(24.6, 'px'));
+        $this->assertNotSassEquals($this->value, SassNumber::withUnits(24.6, ['ms'], ['px']));
+        $this->assertNotSassEquals($this->value, SassNumber::withUnits(24.6, [], ['ms']));
+        $this->assertNotSassEquals($this->value, SassNumber::withUnits(24.6, ['in'], ['s']));
+    }
+}

--- a/tests/Value/SassNumber/SassNumberTest.php
+++ b/tests/Value/SassNumber/SassNumberTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2018-2020 Anthon Pang
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Tests\Value\SassNumber;
+
+use ScssPhp\ScssPhp\Value\SassNumber;
+use PHPUnit\Framework\TestCase;
+
+class SassNumberTest extends TestCase
+{
+    public function testCreateCanCreateAUnitlessNumber()
+    {
+        $number = SassNumber::create(123.456);
+        $this->assertEquals(123.456, $number->getValue());
+        $this->assertFalse($number->hasUnits());
+    }
+
+    public function testCreateCanCreateANumberWithANumerator()
+    {
+        $number = SassNumber::create(123.456, 'px');
+        $this->assertEquals(123.456, $number->getValue());
+        $this->assertTrue($number->hasUnit('px'));
+    }
+
+    public function testWithUnitsCanCreateAUnitlessNumber()
+    {
+        $number = SassNumber::withUnits(123.456);
+        $this->assertEquals(123.456, $number->getValue());
+        $this->assertFalse($number->hasUnits());
+    }
+
+    public function testWithUnitsCanCreateANumberWithUnits()
+    {
+        $number = SassNumber::withUnits(123.456, ['px', 'em'], ['ms', 'kHz']);
+        $this->assertEquals(123.456, $number->getValue());
+        $this->assertEquals(['px', 'em'], $number->getNumeratorUnits());
+        $this->assertEquals(['ms', 'kHz'], $number->getDenominatorUnits());
+    }
+}

--- a/tests/Value/SassNumber/SingleUnitIntegerTest.php
+++ b/tests/Value/SassNumber/SingleUnitIntegerTest.php
@@ -1,0 +1,164 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2018-2020 Anthon Pang
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Tests\Value\SassNumber;
+
+use ScssPhp\ScssPhp\Exception\SassScriptException;
+use ScssPhp\ScssPhp\Tests\Value\ValueTestCase;
+use ScssPhp\ScssPhp\Value\SassNumber;
+
+/**
+ * @testdox An integer with a single numerator unit
+ */
+class SingleUnitIntegerTest extends ValueTestCase
+{
+    /**
+     * @var SassNumber
+     */
+    private $value;
+
+    protected function setUp(): void
+    {
+        $this->value = self::parseValue('123px');
+    }
+
+    public function testHasThatUnits()
+    {
+        $this->assertEquals(['px'], $this->value->getNumeratorUnits());
+        $this->assertTrue($this->value->hasUnits());
+        $this->assertTrue($this->value->hasUnit('px'));
+        $this->value->assertUnit('px'); // should not throw
+    }
+
+    public function testHasNoUnitsAssertion()
+    {
+        $this->expectException(SassScriptException::class);
+        $this->value->assertNoUnits();
+    }
+
+    public function testHasNoOtherUnits()
+    {
+        $this->assertEmpty($this->value->getDenominatorUnits());
+        $this->assertFalse($this->value->hasUnit('in'));
+
+        $this->expectException(SassScriptException::class);
+        $this->value->assertUnit('in');
+    }
+
+    public function testCanBeCoercedToUnitless()
+    {
+        $this->assertSassEquals($this->value->coerce([], []), SassNumber::withUnits(123));
+    }
+
+    public function testCanBeCoercedToCompatibleUnits()
+    {
+        $this->assertEquals($this->value->coerce(['px'], []), $this->value);
+        $this->assertEquals($this->value->coerce(['in'], []), SassNumber::create(1.28125, 'in'));
+    }
+
+    public function testCantBeCoercedToIncompatibleUnits()
+    {
+        $this->expectException(SassScriptException::class);
+        $this->value->coerce(['abc'], []);
+    }
+
+    public function testCantBeConvertedToUnitless()
+    {
+        $this->expectException(SassScriptException::class);
+        $this->value->convertToMatch(SassNumber::create(456));
+    }
+
+    public function testCanBeConvertedToCompatibleUnits()
+    {
+        $this->assertEquals($this->value->convertToMatch(SassNumber::create(456, 'px')), $this->value);
+        $this->assertEquals($this->value->convertToMatch(SassNumber::create(456, 'in')), SassNumber::create(1.28125, 'in'));
+    }
+
+    public function testCantBeConvertedToIncompatibleUnit()
+    {
+        $this->expectException(SassScriptException::class);
+        $this->value->convertToMatch(SassNumber::create(456, 'abc'));
+    }
+
+    public function testCanCoerceItsValueToUnitless()
+    {
+        $this->assertEquals(123, $this->value->coerceValue([], []));
+    }
+
+    public function testCanCoerceItsValueToCompatibleUnits()
+    {
+        $this->assertEquals(123, $this->value->coerceValue(['px'], []));
+        $this->assertEquals(1.28125, $this->value->coerceValue(['in'], []));
+    }
+
+    public function testCantCoerceItsValueToIncompatibleUnits()
+    {
+        $this->expectException(SassScriptException::class);
+        $this->value->coerceValue(['abc'], []);
+    }
+
+    public function testCantConvertItsValueToUnitless()
+    {
+        $this->expectException(SassScriptException::class);
+        $this->value->convertValueToMatch(SassNumber::create(456));
+    }
+
+    public function testCanConvertItsValueToCompatibleUnits()
+    {
+        $this->assertEquals(123, $this->value->convertValueToMatch(SassNumber::create(456, 'px')));
+        $this->assertEquals(1.28125, $this->value->convertValueToMatch(SassNumber::create(456, 'in')));
+    }
+
+    public function testCantConvertItsValueToIncompatibleUnit()
+    {
+        $this->expectException(SassScriptException::class);
+        $this->value->convertValueToMatch(SassNumber::create(456, 'abc'));
+    }
+
+    public function testIsCompatibleWithTheSameUnit()
+    {
+        $this->assertTrue($this->value->compatibleWithUnit('px'));
+    }
+
+    public function testIsCompatibleWithACompatibleUnit()
+    {
+        $this->assertTrue($this->value->compatibleWithUnit('in'));
+    }
+
+    public function testIsIncompatibleWithAnIncompatibleUnit()
+    {
+        $this->assertFalse($this->value->compatibleWithUnit('abc'));
+    }
+
+    public function testEqualsTheSameNumber()
+    {
+        $this->assertSassEquals($this->value, SassNumber::create(123, 'px'));
+    }
+
+    public function testEqualsAnEquivalentNumber()
+    {
+        $this->assertSassEquals($this->value, SassNumber::create(1.28125, 'in'));
+    }
+
+    public function testDoesntEqualAUnitlessNumber()
+    {
+        $this->assertNotSassEquals($this->value, SassNumber::create(123));
+    }
+
+    public function testDoesntEqualANumberWithDifferentUnits()
+    {
+        $this->assertNotSassEquals($this->value, SassNumber::create(123, 'abc'));
+        $this->assertNotSassEquals($this->value, SassNumber::withUnits(123, ['px', 'px']));
+        $this->assertNotSassEquals($this->value, SassNumber::withUnits(123, ['px'], ['abc']));
+        $this->assertNotSassEquals($this->value, SassNumber::withUnits(123, [], ['px']));
+    }
+}

--- a/tests/Value/SassNumber/UnitlessDoubleTest.php
+++ b/tests/Value/SassNumber/UnitlessDoubleTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2018-2020 Anthon Pang
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Tests\Value\SassNumber;
+
+use ScssPhp\ScssPhp\Exception\SassScriptException;
+use ScssPhp\ScssPhp\Tests\Value\ValueTestCase;
+use ScssPhp\ScssPhp\Value\SassNumber;
+
+/**
+ * @testdox A unitless double
+ */
+class UnitlessDoubleTest extends ValueTestCase
+{
+    /**
+     * @var SassNumber
+     */
+    private $value;
+
+    protected function setUp(): void
+    {
+        $this->value = self::parseValue('123.456');
+    }
+
+    public function testHasTheCorrectValue()
+    {
+        $this->assertEquals(123.456, $this->value->getValue());
+    }
+
+    public function testIsNotAnInt()
+    {
+        $this->assertFalse($this->value->isInt());
+        $this->assertNull($this->value->asInt());
+
+        $this->expectException(SassScriptException::class);
+        $this->value->assertInt();
+    }
+}

--- a/tests/Value/SassNumber/UnitlessFuzzyIntegerTest.php
+++ b/tests/Value/SassNumber/UnitlessFuzzyIntegerTest.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2018-2020 Anthon Pang
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Tests\Value\SassNumber;
+
+use ScssPhp\ScssPhp\Exception\SassScriptException;
+use ScssPhp\ScssPhp\Tests\Value\ValueTestCase;
+use ScssPhp\ScssPhp\Value\SassNumber;
+
+/**
+ * @testdox A unitless fuzzy integer
+ */
+class UnitlessFuzzyIntegerTest extends ValueTestCase
+{
+    /**
+     * @var SassNumber
+     */
+    private $value;
+
+    protected function setUp(): void
+    {
+        $this->value = self::parseValue('123.000000000001');
+    }
+
+    public function testHasTheCorrectValue()
+    {
+        $this->assertEquals(123.000000000001, $this->value->getValue());
+    }
+
+    public function testIsAnInt()
+    {
+        $this->assertTrue($this->value->isInt());
+        $this->assertEquals(123, $this->value->asInt());
+        $this->assertEquals(123, $this->value->assertInt());
+    }
+
+    public function testEqualsTheSameNumber()
+    {
+        $this->assertSassEquals($this->value, SassNumber::create(123 + pow(10, -SassNumber::PRECISION - 2)));
+    }
+
+    public function testEqualsTheSameNumberWithinPrecisionTolerance()
+    {
+        $this->assertSassEquals($this->value, SassNumber::create(123));
+        $this->assertSassEquals($this->value, SassNumber::create(123 - pow(10, -SassNumber::PRECISION - 2)));
+    }
+
+    public function testValueInRangeClampsWithinAGivenRange()
+    {
+        $this->assertEquals(123, $this->value->valueInRange(0, 123));
+        $this->assertEquals(123, $this->value->valueInRange(123, 123));
+        $this->assertEquals(123, $this->value->valueInRange(123, 1000));
+    }
+
+    /**
+     * @dataProvider provideRanges
+     */
+    public function testValueInRangeRejectsAValueOutsideTheRange($min, $max)
+    {
+        $this->expectException(SassScriptException::class);
+        $this->value->valueInRange($min, $max);
+    }
+
+    public static function provideRanges(): iterable
+    {
+        yield [0, 122];
+        yield [124, 1000];
+    }
+}

--- a/tests/Value/SassNumber/UnitlessIntegerTest.php
+++ b/tests/Value/SassNumber/UnitlessIntegerTest.php
@@ -1,0 +1,196 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2018-2020 Anthon Pang
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Tests\Value\SassNumber;
+
+use ScssPhp\ScssPhp\Exception\SassScriptException;
+use ScssPhp\ScssPhp\Tests\Value\ValueTestCase;
+use ScssPhp\ScssPhp\Value\SassNumber;
+
+/**
+ * @testdox A unitless integer
+ */
+class UnitlessIntegerTest extends ValueTestCase
+{
+    /**
+     * @var SassNumber
+     */
+    private $value;
+
+    protected function setUp(): void
+    {
+        $this->value = self::parseValue('123');
+    }
+
+    public function testHasTheCorrectValue()
+    {
+        $this->assertEquals(123, $this->value->getValue());
+        $this->assertIsInt($this->value->getValue());
+    }
+
+    public function testHasNoUnits()
+    {
+        $this->assertEmpty($this->value->getNumeratorUnits());
+        $this->assertEmpty($this->value->getDenominatorUnits());
+        $this->assertFalse($this->value->hasUnits());
+        $this->assertFalse($this->value->hasUnit('px'));
+        $this->value->assertNoUnits(); // should not throw
+    }
+
+    public function testHasNoUnitsAssertion()
+    {
+        $this->expectException(SassScriptException::class);
+        $this->value->assertUnit('px');
+    }
+
+    public function testIsAnInt()
+    {
+        $this->assertTrue($this->value->isInt());
+        $this->assertEquals(123, $this->value->asInt());
+        $this->assertEquals(123, $this->value->assertInt());
+    }
+
+    public function testCanBeCoercedToUnitless()
+    {
+        $this->assertSassEquals($this->value->coerce([], []), SassNumber::withUnits(123));
+    }
+
+    public function testCanBeCoercedToAnyUnits()
+    {
+        $this->assertSassEquals($this->value->coerce(['abc'], ['def']), SassNumber::withUnits(123, ['abc'], ['def']));
+    }
+
+    public function testCanBeConvertedToUnitless()
+    {
+        $this->assertSassEquals($this->value->convertToMatch(SassNumber::create(456)), SassNumber::withUnits(123));
+    }
+
+    public function testCantBeConvertedToAUnit()
+    {
+        $this->expectException(SassScriptException::class);
+        $this->value->convertToMatch(SassNumber::create(456, 'px'));
+    }
+
+    public function testCanCoerceItsValueToUnitless()
+    {
+        $this->assertEquals(123, $this->value->coerceValue([], []));
+    }
+
+    public function testCanCoerceItsValueToAnyUnits()
+    {
+        $this->assertEquals(123, $this->value->coerceValue(['abc'], ['def']));
+    }
+
+    public function testCanConvertItsValueToUnitless()
+    {
+        $this->assertEquals(123, $this->value->convertValueToMatch(SassNumber::create(456)));
+    }
+
+    public function testCantConvertItsValueToAnyUnit()
+    {
+        $this->expectException(SassScriptException::class);
+        $this->value->convertValueToMatch(SassNumber::create(456, 'px'));
+    }
+
+    public function testIsCompatibleWithAnyUnit()
+    {
+        $this->assertTrue($this->value->compatibleWithUnit('px'));
+    }
+
+    public function testValueInRangeReturnsItsValueWithinAGivenRange()
+    {
+        $this->assertEquals(123, $this->value->valueInRange(0, 123));
+        $this->assertEquals(123, $this->value->valueInRange(123, 123));
+        $this->assertEquals(123, $this->value->valueInRange(123, 1000));
+    }
+
+    /**
+     * @dataProvider provideRanges
+     */
+    public function testValueInRangeRejectsAValueOutsideTheRange($min, $max)
+    {
+        $this->expectException(SassScriptException::class);
+        $this->value->valueInRange($min, $max);
+    }
+
+    public static function provideRanges(): iterable
+    {
+        yield [0, 122];
+        yield [124, 1000];
+    }
+
+    public function testEqualsTheSameNumber()
+    {
+        $this->assertSassEquals($this->value, SassNumber::create(123));
+    }
+
+    public function testEqualsTheSameNumberWithinPrecisionTolerance()
+    {
+        $this->assertSassEquals($this->value, SassNumber::create(123 + pow(10, -SassNumber::PRECISION - 2)));
+        $this->assertSassEquals($this->value, SassNumber::create(123 - pow(10, -SassNumber::PRECISION - 2)));
+    }
+
+    public function testDoesntEqualADifferentNumber()
+    {
+        $this->assertNotSassEquals($this->value, SassNumber::create(124));
+        $this->assertNotSassEquals($this->value, SassNumber::create(122));
+        $this->assertNotSassEquals($this->value, SassNumber::create(123 + pow(10, -SassNumber::PRECISION - 1)));
+        $this->assertNotSassEquals($this->value, SassNumber::create(123 - pow(10, -SassNumber::PRECISION - 1)));
+    }
+
+    public function testDoesntEqualANumberWithUnit()
+    {
+        $this->assertNotSassEquals($this->value, SassNumber::create(123, 'px'));
+    }
+
+    public function testIsANumber()
+    {
+        $this->assertSame($this->value, $this->value->assertNumber());
+    }
+
+    public function testIsNotABoolean()
+    {
+        $this->expectException(SassScriptException::class);
+
+        $this->value->assertBoolean();
+    }
+
+    public function testIsNotAColor()
+    {
+        $this->expectException(SassScriptException::class);
+
+        $this->value->assertColor();
+    }
+
+    public function testIsNotAFunction()
+    {
+        $this->expectException(SassScriptException::class);
+
+        $this->value->assertFunction();
+    }
+
+    public function testIsNotAMap()
+    {
+        $this->assertNull($this->value->tryMap());
+
+        $this->expectException(SassScriptException::class);
+
+        $this->value->assertMap();
+    }
+
+    public function testIsNotAString()
+    {
+        $this->expectException(SassScriptException::class);
+
+        $this->value->assertString();
+    }
+}

--- a/tests/Value/SassString/QuotedAsciiTest.php
+++ b/tests/Value/SassString/QuotedAsciiTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2018-2020 Anthon Pang
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Tests\Value\SassString;
+
+use ScssPhp\ScssPhp\Tests\Value\ValueTestCase;
+use ScssPhp\ScssPhp\Value\SassString;
+
+/**
+ * @testdox A quoted ASCII string
+ */
+class QuotedAsciiTest extends ValueTestCase
+{
+    /**
+     * @var SassString
+     */
+    private $value;
+
+    protected function setUp(): void
+    {
+        $this->value = self::parseValue('"foobar"');
+    }
+
+    public function testHasTheCorrectText()
+    {
+        $this->assertEquals('foobar', $this->value->getText());
+    }
+
+    public function testHasNoQuotes()
+    {
+        $this->assertTrue($this->value->hasQuotes());
+    }
+
+    public function testEqualsTheSameString()
+    {
+        $this->assertSassEquals($this->value, new SassString('foobar', false));
+        $this->assertSassEquals($this->value, new SassString('foobar', true));
+    }
+}

--- a/tests/Value/SassString/UnquotedAsciiTest.php
+++ b/tests/Value/SassString/UnquotedAsciiTest.php
@@ -1,0 +1,212 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2018-2020 Anthon Pang
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Tests\Value\SassString;
+
+use ScssPhp\ScssPhp\Exception\SassScriptException;
+use ScssPhp\ScssPhp\Tests\Value\ValueTestCase;
+use ScssPhp\ScssPhp\Value\SassNumber;
+use ScssPhp\ScssPhp\Value\SassString;
+
+/**
+ * @testdox An unquoted ASCII string
+ */
+class UnquotedAsciiTest extends ValueTestCase
+{
+    /**
+     * @var SassString
+     */
+    private $value;
+
+    protected function setUp(): void
+    {
+        $this->value = self::parseValue('foobar');
+    }
+
+    public function testHasTheCorrectText()
+    {
+        $this->assertEquals('foobar', $this->value->getText());
+    }
+
+    public function testHasNoQuotes()
+    {
+        $this->assertFalse($this->value->hasQuotes());
+    }
+
+    public function testEqualsTheSameString()
+    {
+        $this->assertSassEquals($this->value, new SassString('foobar', false));
+        $this->assertSassEquals($this->value, new SassString('foobar', true));
+    }
+
+    public function testIsAString()
+    {
+        $this->assertSame($this->value, $this->value->assertString());
+    }
+
+    public function testIsNotABoolean()
+    {
+        $this->expectException(SassScriptException::class);
+
+        $this->value->assertBoolean();
+    }
+
+    public function testIsNotAColor()
+    {
+        $this->expectException(SassScriptException::class);
+
+        $this->value->assertColor();
+    }
+
+    public function testIsNotAFunction()
+    {
+        $this->expectException(SassScriptException::class);
+
+        $this->value->assertFunction();
+    }
+
+    public function testIsNotAMap()
+    {
+        $this->assertNull($this->value->tryMap());
+
+        $this->expectException(SassScriptException::class);
+
+        $this->value->assertMap();
+    }
+
+    public function testIsNotANumber()
+    {
+        $this->expectException(SassScriptException::class);
+
+        $this->value->assertNumber();
+    }
+
+    public function testSassLengthReturnsTheLength()
+    {
+        $this->assertEquals(6, $this->value->getSassLength());
+    }
+
+    /**
+     * @testdox sassIndexToStringIndex() converts a positive index to a PHP index
+     */
+    public function testSassIndexToStringIndexConvertsAPositiveIndexToAPHPIndex()
+    {
+        $this->assertEquals(0, $this->value->sassIndexToStringIndex(SassNumber::create(1)));
+        $this->assertEquals(1, $this->value->sassIndexToStringIndex(SassNumber::create(2)));
+        $this->assertEquals(2, $this->value->sassIndexToStringIndex(SassNumber::create(3)));
+        $this->assertEquals(3, $this->value->sassIndexToStringIndex(SassNumber::create(4)));
+        $this->assertEquals(4, $this->value->sassIndexToStringIndex(SassNumber::create(5)));
+        $this->assertEquals(5, $this->value->sassIndexToStringIndex(SassNumber::create(6)));
+    }
+
+    /**
+     * @testdox sassIndexToStringIndex() converts a negative index to a PHP index
+     */
+    public function testSassIndexToStringIndexConvertsANegativeIndexToAPHPIndex()
+    {
+        $this->assertEquals(5, $this->value->sassIndexToStringIndex(SassNumber::create(-1)));
+        $this->assertEquals(4, $this->value->sassIndexToStringIndex(SassNumber::create(-2)));
+        $this->assertEquals(3, $this->value->sassIndexToStringIndex(SassNumber::create(-3)));
+        $this->assertEquals(2, $this->value->sassIndexToStringIndex(SassNumber::create(-4)));
+        $this->assertEquals(1, $this->value->sassIndexToStringIndex(SassNumber::create(-5)));
+        $this->assertEquals(0, $this->value->sassIndexToStringIndex(SassNumber::create(-6)));
+    }
+
+    /**
+     * @testdox sassIndexToStringIndex() rejects a non-number
+     */
+    public function testSassIndexToStringIndexRejectsANonNumber()
+    {
+        $this->expectException(SassScriptException::class);
+        $this->value->sassIndexToStringIndex(new SassString('foo'));
+    }
+
+    /**
+     * @testdox sassIndexToStringIndex() rejects a non-integer
+     */
+    public function testSassIndexToStringIndexRejectsANonInteger()
+    {
+        $this->expectException(SassScriptException::class);
+        $this->value->sassIndexToStringIndex(SassNumber::create(1.1));
+    }
+
+    /**
+     * @testdox sassIndexToStringIndex() rejects invalid indices
+     * @dataProvider provideInvalidIndices
+     */
+    public function testSassIndexToStringIndexRejectsInvalidIndices($index)
+    {
+        $this->expectException(SassScriptException::class);
+        $this->value->sassIndexToStringIndex(SassNumber::create($index));
+    }
+
+    /**
+     * @testdox sassIndexToCodePointIndex() converts a positive index to a PHP index
+     */
+    public function testSassIndexToCodePointIndexConvertsAPositiveIndexToAPHPIndex()
+    {
+        $this->assertEquals(0, $this->value->sassIndexToCodePointIndex(SassNumber::create(1)));
+        $this->assertEquals(1, $this->value->sassIndexToCodePointIndex(SassNumber::create(2)));
+        $this->assertEquals(2, $this->value->sassIndexToCodePointIndex(SassNumber::create(3)));
+        $this->assertEquals(3, $this->value->sassIndexToCodePointIndex(SassNumber::create(4)));
+        $this->assertEquals(4, $this->value->sassIndexToCodePointIndex(SassNumber::create(5)));
+        $this->assertEquals(5, $this->value->sassIndexToCodePointIndex(SassNumber::create(6)));
+    }
+
+    /**
+     * @testdox sassIndexToCodePointIndex() converts a negative index to a PHP index
+     */
+    public function testSassIndexToCodePointIndexConvertsANegativeIndexToAPHPIndex()
+    {
+        $this->assertEquals(5, $this->value->sassIndexToCodePointIndex(SassNumber::create(-1)));
+        $this->assertEquals(4, $this->value->sassIndexToCodePointIndex(SassNumber::create(-2)));
+        $this->assertEquals(3, $this->value->sassIndexToCodePointIndex(SassNumber::create(-3)));
+        $this->assertEquals(2, $this->value->sassIndexToCodePointIndex(SassNumber::create(-4)));
+        $this->assertEquals(1, $this->value->sassIndexToCodePointIndex(SassNumber::create(-5)));
+        $this->assertEquals(0, $this->value->sassIndexToCodePointIndex(SassNumber::create(-6)));
+    }
+
+    /**
+     * @testdox sassIndexToCodePointIndex() rejects a non-number
+     */
+    public function testSassIndexToCodePointIndexRejectsANonNumber()
+    {
+        $this->expectException(SassScriptException::class);
+        $this->value->sassIndexToCodePointIndex(new SassString('foo'));
+    }
+
+    /**
+     * @testdox sassIndexToCodePointIndex() rejects a non-integer
+     */
+    public function testSassIndexToCodePointIndexRejectsANonInteger()
+    {
+        $this->expectException(SassScriptException::class);
+        $this->value->sassIndexToCodePointIndex(SassNumber::create(1.1));
+    }
+
+    /**
+     * @testdox sassIndexToCodePointIndex() rejects invalid indices
+     * @dataProvider provideInvalidIndices
+     */
+    public function testSassIndexToCodePointIndexRejectsInvalidIndices($index)
+    {
+        $this->expectException(SassScriptException::class);
+        $this->value->sassIndexToCodePointIndex(SassNumber::create($index));
+    }
+
+    public static function provideInvalidIndices(): iterable
+    {
+        yield [0];
+        yield [7];
+        yield [-7];
+    }
+}

--- a/tests/Value/SassString/UnquotedUnicodeTest.php
+++ b/tests/Value/SassString/UnquotedUnicodeTest.php
@@ -1,0 +1,114 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2018-2020 Anthon Pang
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Tests\Value\SassString;
+
+use ScssPhp\ScssPhp\Exception\SassScriptException;
+use ScssPhp\ScssPhp\Tests\Value\ValueTestCase;
+use ScssPhp\ScssPhp\Value\SassNumber;
+use ScssPhp\ScssPhp\Value\SassString;
+
+/**
+ * @testdox An unquoted unicode string
+ */
+class UnquotedUnicodeTest extends ValueTestCase
+{
+    /**
+     * @var SassString
+     */
+    private $value;
+
+    protected function setUp(): void
+    {
+        $this->value = self::parseValue('a👭b👬c');
+    }
+
+    public function testSassLengthReturnsTheLength()
+    {
+        $this->assertEquals(5, $this->value->getSassLength());
+    }
+
+    /**
+     * @testdox sassIndexToStringIndex() converts a positive index to a PHP index
+     */
+    public function testSassIndexToStringIndexConvertsAPositiveIndexToAPHPIndex()
+    {
+        $this->assertEquals(0, $this->value->sassIndexToStringIndex(SassNumber::create(1)));
+        $this->assertEquals(1, $this->value->sassIndexToStringIndex(SassNumber::create(2)));
+        $this->assertEquals(5, $this->value->sassIndexToStringIndex(SassNumber::create(3)));
+        $this->assertEquals(6, $this->value->sassIndexToStringIndex(SassNumber::create(4)));
+        $this->assertEquals(10, $this->value->sassIndexToStringIndex(SassNumber::create(5)));
+    }
+
+    /**
+     * @testdox sassIndexToStringIndex() converts a negative index to a PHP index
+     */
+    public function testSassIndexToStringIndexConvertsANegativeIndexToAPHPIndex()
+    {
+        $this->assertEquals(10, $this->value->sassIndexToStringIndex(SassNumber::create(-1)));
+        $this->assertEquals(6, $this->value->sassIndexToStringIndex(SassNumber::create(-2)));
+        $this->assertEquals(5, $this->value->sassIndexToStringIndex(SassNumber::create(-3)));
+        $this->assertEquals(1, $this->value->sassIndexToStringIndex(SassNumber::create(-4)));
+        $this->assertEquals(0, $this->value->sassIndexToStringIndex(SassNumber::create(-5)));
+    }
+
+    /**
+     * @testdox sassIndexToStringIndex() rejects invalid indices
+     * @dataProvider provideInvalidIndices
+     */
+    public function testSassIndexToStringIndexRejectsInvalidIndices($index)
+    {
+        $this->expectException(SassScriptException::class);
+        $this->value->sassIndexToStringIndex(SassNumber::create($index));
+    }
+
+    /**
+     * @testdox sassIndexToCodePointIndex() converts a positive index to a PHP index
+     */
+    public function testSassIndexToCodePointIndexConvertsAPositiveIndexToAPHPIndex()
+    {
+        $this->assertEquals(0, $this->value->sassIndexToCodePointIndex(SassNumber::create(1)));
+        $this->assertEquals(1, $this->value->sassIndexToCodePointIndex(SassNumber::create(2)));
+        $this->assertEquals(2, $this->value->sassIndexToCodePointIndex(SassNumber::create(3)));
+        $this->assertEquals(3, $this->value->sassIndexToCodePointIndex(SassNumber::create(4)));
+        $this->assertEquals(4, $this->value->sassIndexToCodePointIndex(SassNumber::create(5)));
+    }
+
+    /**
+     * @testdox sassIndexToCodePointIndex() converts a negative index to a PHP index
+     */
+    public function testSassIndexToCodePointIndexConvertsANegativeIndexToAPHPIndex()
+    {
+        $this->assertEquals(4, $this->value->sassIndexToCodePointIndex(SassNumber::create(-1)));
+        $this->assertEquals(3, $this->value->sassIndexToCodePointIndex(SassNumber::create(-2)));
+        $this->assertEquals(2, $this->value->sassIndexToCodePointIndex(SassNumber::create(-3)));
+        $this->assertEquals(1, $this->value->sassIndexToCodePointIndex(SassNumber::create(-4)));
+        $this->assertEquals(0, $this->value->sassIndexToCodePointIndex(SassNumber::create(-5)));
+    }
+
+    /**
+     * @testdox sassIndexToCodePointIndex() rejects invalid indices
+     * @dataProvider provideInvalidIndices
+     */
+    public function testSassIndexToCodePointIndexRejectsInvalidIndices($index)
+    {
+        $this->expectException(SassScriptException::class);
+        $this->value->sassIndexToCodePointIndex(SassNumber::create($index));
+    }
+
+    public static function provideInvalidIndices(): iterable
+    {
+        yield [0];
+        yield [6];
+        yield [-6];
+    }
+}

--- a/tests/Value/ValueTestCase.php
+++ b/tests/Value/ValueTestCase.php
@@ -1,0 +1,123 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2018-2020 Anthon Pang
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Tests\Value;
+
+use PHPUnit\Framework\TestCase;
+use ScssPhp\ScssPhp\Collection\Map;
+use ScssPhp\ScssPhp\Value\ListSeparator;
+use ScssPhp\ScssPhp\Value\SassBoolean;
+use ScssPhp\ScssPhp\Value\SassColor;
+use ScssPhp\ScssPhp\Value\SassFunction;
+use ScssPhp\ScssPhp\Value\SassList;
+use ScssPhp\ScssPhp\Value\SassMap;
+use ScssPhp\ScssPhp\Value\SassNull;
+use ScssPhp\ScssPhp\Value\SassNumber;
+use ScssPhp\ScssPhp\Value\SassString;
+use ScssPhp\ScssPhp\Value\Value;
+
+abstract class ValueTestCase extends TestCase
+{
+    protected static function parseValue(string $source): Value
+    {
+        // TODO switch to an actual equivalent of dart-sass's parseValue test utility once the compiler uses value objects
+        switch ($source) {
+            case 'null':
+                return SassNull::create();
+            case 'true':
+                return SassBoolean::create(true);
+            case 'false':
+                return SassBoolean::create(false);
+            case '123':
+                return SassNumber::create(123);
+            case '123.456':
+                return SassNumber::create(123.456);
+            case '123.000000000001':
+                return SassNumber::create(123.000000000001);
+            case '123px':
+                return SassNumber::create(123, 'px');
+            case '123px / 5ms':
+                return SassNumber::withUnits(123 / 5, ['px'], ['ms']);
+            case 'blue':
+                return SassColor::rgb(0, 0, 255);
+            case '#123456':
+                return SassColor::rgb(0x12, 0x34, 0x56);
+            case 'hsl(120, 42%, 42%)':
+                return SassColor::hsl(120, 42, 42);
+            case 'rgba(255, 0, 0, 0)':
+                return SassColor::rgb(255, 0, 0, 0);
+            case 'rgba(10, 20, 30, 0.7)':
+                return SassColor::rgb(10, 20, 30, 0.7);
+            case 'grey':
+                return SassColor::rgb(0x80, 0x80, 0x80);
+            case "get-function('red')":
+                return new SassFunction('red');
+            case 'foobar':
+                return new SassString('foobar', false);
+            case 'a👭b👬c':
+                return new SassString('a👭b👬c', false);
+            case '"foobar"':
+                return new SassString('foobar', true);
+            case '()':
+                return new SassList([], ListSeparator::UNDECIDED);
+            case 'a, b, c':
+                return new SassList([
+                    new SassString('a', false),
+                    new SassString('b', false),
+                    new SassString('c', false),
+                ], ListSeparator::COMMA);
+            case 'a b c':
+                return new SassList([
+                    new SassString('a', false),
+                    new SassString('b', false),
+                    new SassString('c', false),
+                ], ListSeparator::SPACE);
+            case '[a, b, c]':
+                return new SassList([
+                    new SassString('a', false),
+                    new SassString('b', false),
+                    new SassString('c', false),
+                ], ListSeparator::COMMA, true);
+            case 'list.slash(a, b, c)':
+                return new SassList([
+                    new SassString('a', false),
+                    new SassString('b', false),
+                    new SassString('c', false),
+                ], ListSeparator::SLASH);
+            case '[1]':
+                return new SassList([SassNumber::create(1)], ListSeparator::UNDECIDED, true);
+            case '(1,)':
+                return new SassList([SassNumber::create(1)], ListSeparator::COMMA, false);
+            case '(a: b, c: d)':
+                $map = new Map();
+                $map->put(new SassString('a', false), new SassString('b', false));
+                $map->put(new SassString('c', false), new SassString('d', false));
+
+                return SassMap::create($map);
+            case 'map-remove((a: b), a)':
+                return SassMap::create(new Map());
+
+            default:
+                throw new \UnexpectedValueException('Unsupported source for the fake parseValue implementation: ' . $source);
+        }
+    }
+
+    protected function assertSassEquals(Value $value, Value $expected)
+    {
+        $this->assertTrue($value->equals($expected), "$value should be equal to $expected");
+    }
+
+    protected function assertNotSassEquals(Value $value, Value $expected)
+    {
+        $this->assertFalse($value->equals($expected), "$value should not be equal to $expected");
+    }
+}


### PR DESCRIPTION
Refs #265 

TODOs:
- [x] Implement `SassMap` properly
- [x] add tests for the Value APIs
- [x] ~~Implement color math (which is not there in dart-sass, but is only deprecated on our side)~~
- [x] Fix the string serialization for PHP < 7.4 (thanks CI)
- [x] Update the serialization implementation to account for updates in dart-sass for the string serialization
- [x] Implement `SassCalculation::equals()`

Using this API in our compiler will be done in follow-up PRs.