### PR TITLE
Require either mbstring or iconv

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,10 @@
         "ext-json": "*",
         "ext-ctype": "*"
     },
+    "suggest": {
+        "ext-mbstring": "For best performance, mbstring should be installed as it is faster than ext-iconv",
+        "ext-iconv": "Can be used as fallback when ext-mbstring is not available"
+    },
     "require-dev": {
         "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5 || ^8.3 || ^9.4",
         "sass/sass-spec": "2021.01.20",

--- a/src/Util.php
+++ b/src/Util.php
@@ -16,7 +16,7 @@ use ScssPhp\ScssPhp\Base\Range;
 use ScssPhp\ScssPhp\Exception\RangeException;
 
 /**
- * Utilty functions
+ * Utility functions
  *
  * @author Anthon Pang <anthon.pang@gmail.com>
  */
@@ -118,7 +118,7 @@ class Util
             return @iconv_strlen($string, 'UTF-8');
         }
 
-        return strlen($string);
+        throw new \LogicException('Either mbstring (recommended) or iconv is necessary to use Scssphp.');
     }
 
     /**
@@ -155,7 +155,7 @@ class Util
             return (string)iconv_substr($string, $start, $length, 'UTF-8');
         }
 
-        return substr($string, $start, $length);
+        throw new \LogicException('Either mbstring (recommended) or iconv is necessary to use Scssphp.');
     }
 
     /**
@@ -176,6 +176,6 @@ class Util
             return iconv_strpos($haystack, $needle, $offset, 'UTF-8');
         }
 
-        return strpos($haystack, $needle, $offset);
+        throw new \LogicException('Either mbstring (recommended) or iconv is necessary to use Scssphp.');
     }
 }


### PR DESCRIPTION
Sass strings are indexed in term of Unicode codepoints. Falling back to byte-based indexes when neither mbstring nor iconv are available on the system is not spec-compliant as it changes how string indexes are working. iconv is enabled by default in PHP (this might not be true on all distributions though as they customize how they build PHP) and mbstring is quite common, especially now that UTF-8 is the norm.
Installing mbstring is recommended as it has better performance than iconv. Scssphp is only using iconv as fallback when mbstring is not available.

closes #203