### PR TITLE
Improve type checks in the assertion helper

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -6725,7 +6725,7 @@ class Compiler
      */
     private function assertPercentOrUnitless($value, $varName = null, $forceTo = null, $acceptButDeprecated = false)
     {
-        $this->assertNumber($value, $varName);
+        $value = $this->assertNumber($value, $varName);
 
         if ($acceptButDeprecated) {
             if (! $value->unitless() && ! $value->hasUnit('%')) {


### PR DESCRIPTION
assertNumber returns the asserted value but restricts the type, which tells the type checker about the assertion as well.