### PR TITLE
Improve phpdoc based on phpstan output

### DIFF
--- a/src/Base/Range.php
+++ b/src/Base/Range.php
@@ -19,7 +19,14 @@ namespace ScssPhp\ScssPhp\Base;
  */
 class Range
 {
+    /**
+     * @var float|int
+     */
     public $first;
+
+    /**
+     * @var float|int
+     */
     public $last;
 
     /**

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -35,25 +35,47 @@ class Cache
 {
     const CACHE_VERSION = 1;
 
-    // directory used for storing data
+    /**
+     * directory used for storing data
+     *
+     * @var string|false
+     */
     public static $cacheDir = false;
 
-    // prefix for the storing data
+    /**
+     * prefix for the storing data
+     *
+     * @var string
+     */
     public static $prefix = 'scssphp_';
 
-    // force a refresh : 'once' for refreshing the first hit on a cache only, true to never use the cache in this hit
+    /**
+     * force a refresh : 'once' for refreshing the first hit on a cache only, true to never use the cache in this hit
+     *
+     * @var bool|string
+     */
     public static $forceRefresh = false;
 
-    // specifies the number of seconds after which data cached will be seen as 'garbage' and potentially cleaned up
+    /**
+     * specifies the number of seconds after which data cached will be seen as 'garbage' and potentially cleaned up
+     *
+     * @var int
+     */
     public static $gcLifetime = 604800;
 
-    // array of already refreshed cache if $forceRefresh==='once'
+    /**
+     * array of already refreshed cache if $forceRefresh==='once'
+     *
+     * @var array<string, bool>
+     */
     protected static $refreshed = [];
 
     /**
      * Constructor
      *
      * @param array $options
+     *
+     * @phpstan-param array{cacheDir?: string, prefix?: string, forceRefresh?: string} $options
      */
     public function __construct($options)
     {
@@ -85,10 +107,10 @@ class Cache
      * Get the cached result of $operation on $what,
      * which is known as dependant from the content of $options
      *
-     * @param string  $operation    parse, compile...
-     * @param mixed   $what         content key (e.g., filename to be treated)
-     * @param array   $options      any option that affect the operation result on the content
-     * @param integer $lastModified last modified timestamp
+     * @param string   $operation    parse, compile...
+     * @param mixed    $what         content key (e.g., filename to be treated)
+     * @param array    $options      any option that affect the operation result on the content
+     * @param int|null $lastModified last modified timestamp
      *
      * @return mixed
      *
@@ -128,6 +150,8 @@ class Cache
      * @param mixed  $what
      * @param mixed  $value
      * @param array  $options
+     *
+     * @return void
      */
     public function setCache($operation, $what, $value, $options = [])
     {
@@ -174,6 +198,8 @@ class Cache
     /**
      * Check that the cache dir exists and is writeable
      *
+     * @return void
+     *
      * @throws \Exception
      */
     public static function checkCacheDir()
@@ -192,6 +218,8 @@ class Cache
 
     /**
      * Delete unused cached files
+     *
+     * @return void
      */
     public static function cleanCache()
     {

--- a/src/Colors.php
+++ b/src/Colors.php
@@ -24,7 +24,7 @@ class Colors
      *
      * @see http://www.w3.org/TR/css3-color
      *
-     * @var array
+     * @var array<string, string>
      */
     protected static $cssColors = [
         'aliceblue' => '240,248,255',
@@ -183,7 +183,7 @@ class Colors
      *
      * @param string $colorName
      *
-     * @return array|null
+     * @return int[]|null
      */
     public static function colorNameToRGBa($colorName)
     {

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -1353,12 +1353,12 @@ class Compiler
         $filteredScopes = [];
         $childStash = [];
 
-        if ($scope->type === TYPE::T_ROOT) {
+        if ($scope->type === Type::T_ROOT) {
             return $scope;
         }
 
         // start from the root
-        while ($scope->parent && $scope->parent->type !== TYPE::T_ROOT) {
+        while ($scope->parent && $scope->parent->type !== Type::T_ROOT) {
             array_unshift($childStash, $scope);
             $scope = $scope->parent;
         }
@@ -2181,7 +2181,7 @@ class Compiler
                 $stm[1]->selfParent = $selfParent;
                 $ret = $this->compileChild($stm, $out);
                 $stm[1]->selfParent = null;
-            } elseif ($selfParent && \in_array($stm[0], [TYPE::T_INCLUDE, TYPE::T_EXTEND])) {
+            } elseif ($selfParent && \in_array($stm[0], [Type::T_INCLUDE, Type::T_EXTEND])) {
                 $stm['selfParent'] = $selfParent;
                 $ret = $this->compileChild($stm, $out);
                 unset($stm['selfParent']);

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -2134,7 +2134,7 @@ class Compiler
      * @param \ScssPhp\ScssPhp\Formatter\OutputBlock $out
      * @param string                                 $traceName
      *
-     * @return array|null
+     * @return array|Number|null
      */
     protected function compileChildren($stms, OutputBlock $out, $traceName = '')
     {
@@ -2652,7 +2652,7 @@ class Compiler
      *
      * @param \ScssPhp\ScssPhp\Formatter\OutputBlock $out
      * @param string                                 $type
-     * @param string|mixed                           $line
+     * @param string                                 $line
      *
      * @return void
      */
@@ -3443,7 +3443,7 @@ class Compiler
     /**
      * Function caller
      *
-     * @param string $name
+     * @param string $functionReference
      * @param array  $argValues
      *
      * @return array|Number

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -170,6 +170,11 @@ class Compiler
      * @phpstan-var self::SOURCE_MAP_*|SourceMapGenerator
      */
     protected $sourceMap = self::SOURCE_MAP_NONE;
+
+    /**
+     * @var array
+     * @phpstan-var array{sourceRoot?: string, sourceMapFilename?: string|null, sourceMapURL?: string|null, sourceMapWriteTo?: string|null, outputSourceFiles?: bool, sourceMapRootpath?: string, sourceMapBasepath?: string}
+     */
     protected $sourceMapOptions = [];
 
     /**
@@ -5260,6 +5265,8 @@ class Compiler
      * @api
      *
      * @param array $sourceMapOptions
+     *
+     * @phpstan-param  array{sourceRoot?: string, sourceMapFilename?: string|null, sourceMapURL?: string|null, sourceMapWriteTo?: string|null, outputSourceFiles?: bool, sourceMapRootpath?: string, sourceMapBasepath?: string} $sourceMapOptions
      *
      * @return void
      */

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -144,7 +144,14 @@ class Compiler
      */
     protected $importCache = [];
 
+    /**
+     * @var array
+     * @phpstan-var array<string, array{0: callable, 1: array|null}>
+     */
     protected $userFunctions = [];
+    /**
+     * @var array<string, mixed>
+     */
     protected $registeredVars = [];
     /**
      * @var array<string, bool>
@@ -161,6 +168,7 @@ class Compiler
      */
     protected $encoding = null;
     /**
+     * @var null
      * @deprecated
      */
     protected $lineNumberStyle = null;
@@ -303,6 +311,7 @@ class Compiler
      * Constructor
      *
      * @param array|null $cacheOptions
+     * @phpstan-param array{cacheDir?: string, prefix?: string, forceRefresh?: string, checkImportResolutions?: bool}|null $cacheOptions
      */
     public function __construct($cacheOptions = null)
     {
@@ -563,8 +572,8 @@ class Compiler
     /**
      * Make output block
      *
-     * @param string $type
-     * @param array  $selectors
+     * @param string|null   $type
+     * @param string[]|null $selectors
      *
      * @return \ScssPhp\ScssPhp\Formatter\OutputBlock
      */
@@ -696,7 +705,7 @@ class Compiler
     }
 
     /**
-     * Glue parts of :not( or :nth-child( ... that are in general splitted in selectors parts
+     * Glue parts of :not( or :nth-child( ... that are in general split in selectors parts
      *
      * @param array $parts
      *
@@ -1227,7 +1236,7 @@ class Compiler
     /**
      * Compile directive
      *
-     * @param \ScssPhp\ScssPhp\Block|array $block
+     * @param \ScssPhp\ScssPhp\Block|array $directive
      * @param \ScssPhp\ScssPhp\Formatter\OutputBlock $out
      *
      * @return void
@@ -1272,7 +1281,7 @@ class Compiler
      * directive names can include some interpolation
      *
      * @param string|array $directiveName
-     * @return array|string
+     * @return string
      * @throws CompilerException
      */
     protected function compileDirectiveName($directiveName)
@@ -1613,7 +1622,7 @@ class Compiler
      * Compile keyframe block
      *
      * @param \ScssPhp\ScssPhp\Block $block
-     * @param array                  $selectors
+     * @param string[]               $selectors
      *
      * @return void
      */
@@ -1679,7 +1688,7 @@ class Compiler
      * Compile nested block
      *
      * @param \ScssPhp\ScssPhp\Block $block
-     * @param array                  $selectors
+     * @param string[]               $selectors
      *
      * @return void
      */
@@ -2269,7 +2278,7 @@ class Compiler
      *
      * @param array $queryList
      *
-     * @return array
+     * @return string[]
      */
     protected function compileMediaQuery($queryList)
     {
@@ -3448,8 +3457,8 @@ class Compiler
     /**
      * Function caller
      *
-     * @param string $functionReference
-     * @param array  $argValues
+     * @param string|array $functionReference
+     * @param array        $argValues
      *
      * @return array|Number
      */
@@ -5869,7 +5878,7 @@ class Compiler
      * Sorts keyword arguments
      *
      * @param string $functionName
-     * @param array  $prototypes
+     * @param array|null  $prototypes
      * @param array  $args
      *
      * @return array|null
@@ -6693,8 +6702,7 @@ class Compiler
      * @api
      *
      * @param array|Number $value
-     * @param array $allowedUnits
-     *   null value stand for unitless
+     * @param array<string|null> $units null value stand for unitless
      * @param string $varName
      *
      * @return Number

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -515,7 +515,7 @@ class Compiler
         // Otherwise, the CSS will be rendered as-is. It can even be extended!
         $cssOnly = false;
 
-        if (substr($path, '-4') === '.css') {
+        if (substr($path, -4) === '.css') {
             $cssOnly = true;
         }
 
@@ -1163,7 +1163,7 @@ class Compiler
 
         $mediaQueries = $this->compileMediaQuery($this->multiplyMedia($this->env));
 
-        if (! empty($mediaQueries) && $mediaQueries) {
+        if (! empty($mediaQueries)) {
             $previousScope = $this->scope;
             $parentScope = $this->mediaParent($this->scope);
 
@@ -6711,7 +6711,7 @@ class Compiler
      */
     public function assertUnit($value, $units, $varName = null)
     {
-        $this->assertNumber($value, $varName);
+        $value = $this->assertNumber($value, $varName);
 
         foreach ($units as $unit) {
             if ($unit && $value->hasUnit($unit)) {

--- a/src/Compiler/CompilationResult.php
+++ b/src/Compiler/CompilationResult.php
@@ -55,13 +55,14 @@ class CompilationResult
 
     /**
      * All the @import files and urls seen in the compilation process
-     * @var array
+     * @var string[]
      */
     private $includedFiles = [];
 
     /**
      * All the @import files resolved and imported (use to check the once condition)
      * @var array
+     * @phpstan-var list<array{currentDir: string, path: string, filePath: string}>
      */
     private $importedFiles = [];
 
@@ -121,7 +122,7 @@ class CompilationResult
      *
      * @api
      *
-     * @return array
+     * @return array<string, int>
      */
     public function getParsedFiles()
     {
@@ -146,7 +147,7 @@ class CompilationResult
     /**
      * Get the list of the already imported Files
      * used by the compiler to check the once condition on @import
-     * @return array
+     * @return string[]
      */
     public function getImportedFiles()
     {
@@ -176,7 +177,7 @@ class CompilationResult
      * For filesystem imports, this contains the import path. For all other
      * imports, it contains the URL passed to the `@import`.
      *
-     * @return array
+     * @return string[]
      */
     public function getIncludedFiles()
     {

--- a/src/Compiler/Environment.php
+++ b/src/Compiler/Environment.php
@@ -20,12 +20,12 @@ namespace ScssPhp\ScssPhp\Compiler;
 class Environment
 {
     /**
-     * @var \ScssPhp\ScssPhp\Block
+     * @var \ScssPhp\ScssPhp\Block|null
      */
     public $block;
 
     /**
-     * @var \ScssPhp\ScssPhp\Compiler\Environment
+     * @var \ScssPhp\ScssPhp\Compiler\Environment|null
      */
     public $parent;
 

--- a/src/Formatter.php
+++ b/src/Formatter.php
@@ -78,7 +78,7 @@ abstract class Formatter
     protected $currentColumn;
 
     /**
-     * @var \ScssPhp\ScssPhp\SourceMap\SourceMapGenerator
+     * @var \ScssPhp\ScssPhp\SourceMap\SourceMapGenerator|null
      */
     protected $sourceMapGenerator;
 
@@ -139,6 +139,8 @@ abstract class Formatter
      * Output lines inside a block
      *
      * @param \ScssPhp\ScssPhp\Formatter\OutputBlock $block
+     *
+     * @return void
      */
     protected function blockLines(OutputBlock $block)
     {
@@ -156,9 +158,13 @@ abstract class Formatter
      * Output block selectors
      *
      * @param \ScssPhp\ScssPhp\Formatter\OutputBlock $block
+     *
+     * @return void
      */
     protected function blockSelectors(OutputBlock $block)
     {
+        assert(! empty($block->selectors));
+
         $inner = $this->indentStr();
 
         $this->write($inner
@@ -170,6 +176,8 @@ abstract class Formatter
      * Output block children
      *
      * @param \ScssPhp\ScssPhp\Formatter\OutputBlock $block
+     *
+     * @return void
      */
     protected function blockChildren(OutputBlock $block)
     {
@@ -182,6 +190,8 @@ abstract class Formatter
      * Output non-empty block
      *
      * @param \ScssPhp\ScssPhp\Formatter\OutputBlock $block
+     *
+     * @return void
      */
     protected function block(OutputBlock $block)
     {
@@ -285,6 +295,8 @@ abstract class Formatter
      * Output content
      *
      * @param string $str
+     *
+     * @return void
      */
     protected function write($str)
     {

--- a/src/Formatter/Compressed.php
+++ b/src/Formatter/Compressed.php
@@ -67,6 +67,8 @@ class Compressed extends Formatter
      */
     protected function blockSelectors(OutputBlock $block)
     {
+        assert(! empty($block->selectors));
+
         $inner = $this->indentStr();
 
         $this->write(

--- a/src/Formatter/Crunched.php
+++ b/src/Formatter/Crunched.php
@@ -69,6 +69,8 @@ class Crunched extends Formatter
      */
     protected function blockSelectors(OutputBlock $block)
     {
+        assert(! empty($block->selectors));
+
         $inner = $this->indentStr();
 
         $this->write(

--- a/src/Formatter/OutputBlock.php
+++ b/src/Formatter/OutputBlock.php
@@ -30,17 +30,17 @@ class OutputBlock
     public $depth;
 
     /**
-     * @var array
+     * @var array|null
      */
     public $selectors;
 
     /**
-     * @var array
+     * @var string[]
      */
     public $lines;
 
     /**
-     * @var array
+     * @var OutputBlock[]
      */
     public $children;
 

--- a/src/Formatter/OutputBlock.php
+++ b/src/Formatter/OutputBlock.php
@@ -50,17 +50,17 @@ class OutputBlock
     public $parent;
 
     /**
-     * @var string
+     * @var string|null
      */
     public $sourceName;
 
     /**
-     * @var integer
+     * @var integer|null
      */
     public $sourceLine;
 
     /**
-     * @var integer
+     * @var integer|null
      */
     public $sourceColumn;
 }

--- a/src/Node.php
+++ b/src/Node.php
@@ -30,12 +30,12 @@ abstract class Node
     public $sourceIndex;
 
     /**
-     * @var integer
+     * @var int|null
      */
     public $sourceLine;
 
     /**
-     * @var integer
+     * @var int|null
      */
     public $sourceColumn;
 }

--- a/src/Node/Number.php
+++ b/src/Node/Number.php
@@ -27,6 +27,8 @@ use ScssPhp\ScssPhp\Type;
  * }}
  *
  * @author Anthon Pang <anthon.pang@gmail.com>
+ *
+ * @template-implements \ArrayAccess<int, mixed>
  */
 class Number extends Node implements \ArrayAccess
 {
@@ -42,6 +44,7 @@ class Number extends Node implements \ArrayAccess
      * @see http://www.w3.org/TR/2012/WD-css3-values-20120308/
      *
      * @var array
+     * @phpstan-var array<string, array<string, float|int>>
      */
     protected static $unitTable = [
         'in' => [

--- a/src/SourceMap/Base64.php
+++ b/src/SourceMap/Base64.php
@@ -20,7 +20,7 @@ namespace ScssPhp\ScssPhp\SourceMap;
 class Base64
 {
     /**
-     * @var array
+     * @var array<int, string>
      */
     private static $encodingMap = [
         0 => 'A',
@@ -90,7 +90,7 @@ class Base64
     ];
 
     /**
-     * @var array
+     * @var array<string|int, int>
      */
     private static $decodingMap = [
         'A' => 0,

--- a/src/SourceMap/SourceMapGenerator.php
+++ b/src/SourceMap/SourceMapGenerator.php
@@ -33,6 +33,7 @@ class SourceMapGenerator
      * Array of default options
      *
      * @var array
+     * @phpstan-var array{sourceRoot: string, sourceMapFilename: string|null, sourceMapURL: string|null, sourceMapWriteTo: string|null, outputSourceFiles: bool, sourceMapRootpath: string, sourceMapBasepath: string}
      */
     protected $defaultOptions = [
         // an optional source root, useful for relocating source files
@@ -70,6 +71,7 @@ class SourceMapGenerator
      * Array of mappings
      *
      * @var array
+     * @phpstan-var list<array{generated_line: int, generated_column: int, original_line: int, original_column: int, source_file: string}>
      */
     protected $mappings = [];
 
@@ -83,16 +85,24 @@ class SourceMapGenerator
     /**
      * File to content map
      *
-     * @var array
+     * @var array<string, string>
      */
     protected $sources = [];
+
+    /**
+     * @var array<string, int>
+     */
     protected $sourceKeys = [];
 
     /**
      * @var array
+     * @phpstan-var array{sourceRoot: string, sourceMapFilename: string|null, sourceMapURL: string|null, sourceMapWriteTo: string|null, outputSourceFiles: bool, sourceMapRootpath: string, sourceMapBasepath: string}
      */
     private $options;
 
+    /**
+     * @phpstan-param array{sourceRoot?: string, sourceMapFilename?: string|null, sourceMapURL?: string|null, sourceMapWriteTo?: string|null, outputSourceFiles?: bool, sourceMapRootpath?: string, sourceMapBasepath?: string} $options
+     */
     public function __construct(array $options = [])
     {
         $this->options = array_merge($this->defaultOptions, $options);
@@ -107,6 +117,8 @@ class SourceMapGenerator
      * @param integer $originalLine    The line number in original file
      * @param integer $originalColumn  The column number in original file
      * @param string  $sourceFile      The original source file
+     *
+     * @return void
      */
     public function addMapping($generatedLine, $generatedColumn, $originalLine, $originalColumn, $sourceFile)
     {
@@ -215,7 +227,7 @@ class SourceMapGenerator
     /**
      * Returns the sources contents
      *
-     * @return array|null
+     * @return string[]|null
      */
     protected function getSourcesContent()
     {

--- a/src/Util.php
+++ b/src/Util.php
@@ -14,6 +14,7 @@ namespace ScssPhp\ScssPhp;
 
 use ScssPhp\ScssPhp\Base\Range;
 use ScssPhp\ScssPhp\Exception\RangeException;
+use ScssPhp\ScssPhp\Node\Number;
 
 /**
  * Utility functions
@@ -26,10 +27,10 @@ class Util
      * Asserts that `value` falls within `range` (inclusive), leaving
      * room for slight floating-point errors.
      *
-     * @param string                    $name  The name of the value. Used in the error message.
-     * @param \ScssPhp\ScssPhp\Base\Range $range Range of values.
-     * @param array                     $value The value to check.
-     * @param string                    $unit  The unit of the value. Used in error reporting.
+     * @param string       $name  The name of the value. Used in the error message.
+     * @param Range        $range Range of values.
+     * @param array|Number $value The value to check.
+     * @param string       $unit  The unit of the value. Used in error reporting.
      *
      * @return mixed `value` adjusted to fall within range, if it was outside by a floating-point margin.
      *
@@ -115,7 +116,7 @@ class Util
         }
 
         if (\function_exists('iconv_strlen')) {
-            return @iconv_strlen($string, 'UTF-8');
+            return (int) @iconv_strlen($string, 'UTF-8');
         }
 
         throw new \LogicException('Either mbstring (recommended) or iconv is necessary to use Scssphp.');


### PR DESCRIPTION
As part of my in-progress work on running phpstan on the project for static analysis (which is now unblocked by the release of the fix for https://github.com/phpstan/phpstan/issues/4039), I found a lot of places where the phpdoc was missing or wrong. This PR fixes a bunch of them.