### PR TITLE
Rework CompilationResult

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -51,16 +51,6 @@ parameters:
 			path: src/Colors.php
 
 		-
-			message: "#^Array \\(array\\<string, int\\>\\) does not accept int\\|false\\.$#"
-			count: 1
-			path: src/CompilationResult.php
-
-		-
-			message: "#^Array \\(array\\<string, int\\>\\) does not accept key 0\\|string\\.$#"
-			count: 1
-			path: src/CompilationResult.php
-
-		-
 			message: "#^Property ScssPhp\\\\ScssPhp\\\\Compiler\\:\\:\\$true has no typehint specified\\.$#"
 			count: 1
 			path: src/Compiler.php
@@ -156,12 +146,12 @@ parameters:
 			path: src/Compiler.php
 
 		-
-			message: "#^Parameter \\#2 \\$sourceMapFile of method ScssPhp\\\\ScssPhp\\\\CompilationResult\\:\\:setSourceMap\\(\\) expects string\\|null, bool\\|string\\|null given\\.$#"
+			message: "#^Parameter \\#3 \\$sourceMapFile of class ScssPhp\\\\ScssPhp\\\\CompilationResult constructor expects string\\|null, bool\\|string\\|null given\\.$#"
 			count: 1
 			path: src/Compiler.php
 
 		-
-			message: "#^Parameter \\#3 \\$sourceMapUrl of method ScssPhp\\\\ScssPhp\\\\CompilationResult\\:\\:setSourceMap\\(\\) expects string\\|null, bool\\|string\\|null given\\.$#"
+			message: "#^Parameter \\#4 \\$sourceMapUrl of class ScssPhp\\\\ScssPhp\\\\CompilationResult constructor expects string\\|null, bool\\|string\\|null given\\.$#"
 			count: 1
 			path: src/Compiler.php
 
@@ -612,11 +602,6 @@ parameters:
 
 		-
 			message: "#^Method ScssPhp\\\\ScssPhp\\\\Compiler\\:\\:compileImport\\(\\) has parameter \\$rawPath with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Compiler.php
-
-		-
-			message: "#^Parameter \\#1 \\$currentDirectory of method ScssPhp\\\\ScssPhp\\\\CompilationResult\\:\\:addImportedFile\\(\\) expects string, string\\|null given\\.$#"
 			count: 1
 			path: src/Compiler.php
 
@@ -1091,17 +1076,12 @@ parameters:
 			path: src/Compiler.php
 
 		-
-			message: "#^If condition is always true\\.$#"
+			message: "#^Array \\(array\\<string, int\\>\\) does not accept int\\|false\\.$#"
 			count: 1
 			path: src/Compiler.php
 
 		-
-			message: "#^Method ScssPhp\\\\ScssPhp\\\\Compiler\\:\\:getParsedFiles\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Compiler.php
-
-		-
-			message: "#^Ternary operator condition is always true\\.$#"
+			message: "#^Array \\(array\\<string, int\\>\\) does not accept key 0\\|string\\.$#"
 			count: 1
 			path: src/Compiler.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -61,11 +61,6 @@ parameters:
 			path: src/CompilationResult.php
 
 		-
-			message: "#^Method ScssPhp\\\\ScssPhp\\\\CompilationResult\\:\\:getSourceFiles\\(\\) has no return typehint specified\\.$#"
-			count: 1
-			path: src/CompilationResult.php
-
-		-
 			message: "#^Property ScssPhp\\\\ScssPhp\\\\Compiler\\:\\:\\$true has no typehint specified\\.$#"
 			count: 1
 			path: src/Compiler.php

--- a/src/CompilationResult.php
+++ b/src/CompilationResult.php
@@ -40,7 +40,6 @@ class CompilationResult
      */
     private $sourceMapUrl;
 
-
     /**
      * All the effective parsed files
      * @var array<string, int>
@@ -172,21 +171,10 @@ class CompilationResult
         return $this->includedFiles;
     }
 
-    // A map from source file URLs to the corresponding [SourceFile]s.
-    //
-    // This can be passed to [sourceMap]'s [Mapping.spanFor] method. It's `null`
-    // if source mapping was disabled for this compilation.
-    public function getSourceFiles()
-    {
-
-    }
-
-
     public function __toString()
     {
         return $this->getCss(); // To reduce the impact of the BC break
     }
-
 
     /**
      * Store the sourceMap and its storage data

--- a/src/CompilationResult.php
+++ b/src/CompilationResult.php
@@ -209,7 +209,7 @@ class CompilationResult
      * The sourceMap Css content, if there is a sourceMap
      * @return string
      */
-    public function getSourceMapCss()
+    private function getSourceMapCss()
     {
         if ($this->sourceMap) {
             if ($this->sourceMapFile) {

--- a/src/CompilationResult.php
+++ b/src/CompilationResult.php
@@ -47,12 +47,6 @@ class CompilationResult
     private $parsedFiles = [];
 
     /**
-     * All the @import files and urls seen in the compilation process
-     * @var string[]
-     */
-    private $includedFiles = [];
-
-    /**
      * All the @import files resolved and imported (use to check the once condition)
      * @var array
      * @phpstan-var list<array{currentDir: string, path: string, filePath: string}>
@@ -116,7 +110,6 @@ class CompilationResult
     public function addImportedFile($currentDirectory, $path, $filePath)
     {
         $this->importedFiles[] = ['currentDir' => $currentDirectory, 'path' => $path, 'filePath' => $filePath];
-        $this->addIncludedFile($filePath);
     }
 
 
@@ -142,33 +135,11 @@ class CompilationResult
     }
 
     /**
-     * Save the included files
-     * @param string $path
-     *
-     * @return void
-     */
-    public function addIncludedFile($path)
-    {
-        // unquote the included path if needed
-        foreach (['"', '"'] as $quote) {
-            if (strpos($path, $quote) === 0 && substr($path, -1) === $quote) {
-                $path = substr($path, 1, -1);
-                break;
-            }
-        }
-
-        $this->includedFiles[] = $path;
-    }
-
-    /**
-     * For filesystem imports, this contains the import path. For all other
-     * imports, it contains the URL passed to the `@import`.
-     *
      * @return string[]
      */
     public function getIncludedFiles()
     {
-        return $this->includedFiles;
+        return array_column($this->importedFiles, 'filePath');
     }
 
     public function __toString()

--- a/src/CompilationResult.php
+++ b/src/CompilationResult.php
@@ -14,21 +14,17 @@ namespace ScssPhp\ScssPhp;
 
 use ScssPhp\ScssPhp\Exception\CompilerException;
 
-/**
- * Compiler environment
- *
- */
 class CompilationResult
 {
     /**
      * @var string
      */
-    private $css = '';
+    private $css;
 
     /**
-     * @var string
+     * @var string|null
      */
-    private $sourceMap = '';
+    private $sourceMap;
 
     /**
      * @var string|null
@@ -41,26 +37,24 @@ class CompilationResult
     private $sourceMapUrl;
 
     /**
-     * All the effective parsed files
-     * @var array<string, int>
+     * @var string[]
      */
-    private $parsedFiles = [];
-
-    /**
-     * All the @import files resolved and imported (use to check the once condition)
-     * @var array
-     * @phpstan-var list<array{currentDir: string, path: string, filePath: string}>
-     */
-    private $importedFiles = [];
+    private $includedFiles;
 
     /**
      * @param string $css
-     *
-     * @return void
+     * @param string|null $sourceMap
+     * @param string|null $sourceMapFile
+     * @param string|null $sourceMapUrl
+     * @param string[] $includedFiles
      */
-    public function setCss($css)
+    public function __construct($css, $sourceMap, $sourceMapFile, $sourceMapUrl, array $includedFiles)
     {
         $this->css = $css;
+        $this->sourceMap = $sourceMap;
+        $this->sourceMapFile = $sourceMapFile;
+        $this->sourceMapUrl = $sourceMapUrl;
+        $this->includedFiles = $includedFiles;
     }
 
     /**
@@ -72,98 +66,16 @@ class CompilationResult
     }
 
     /**
-     * Adds to list of parsed files
-     *
-     * @api
-     *
-     * @param string|null $path
-     *
-     * @return void
-     */
-    public function addParsedFile($path)
-    {
-        if (! \is_null($path) && is_file($path)) {
-            $this->parsedFiles[realpath($path)] = filemtime($path);
-        }
-    }
-
-    /**
-     * Returns list of parsed files
-     *
-     * @api
-     *
-     * @return array<string, int>
-     */
-    public function getParsedFiles()
-    {
-        return $this->parsedFiles;
-    }
-
-    /**
-     * Save the imported files with their resolving path context
-     * @param string $currentDirectory
-     * @param string $path
-     * @param string $filePath
-     *
-     * @return void
-     */
-    public function addImportedFile($currentDirectory, $path, $filePath)
-    {
-        $this->importedFiles[] = ['currentDir' => $currentDirectory, 'path' => $path, 'filePath' => $filePath];
-    }
-
-
-    /**
-     * Get the list of the already imported Files
-     * used by the compiler to check the once condition on @import
-     * @return string[]
-     */
-    public function getImportedFiles()
-    {
-        return array_column($this->importedFiles, 'filePath');
-    }
-
-    /**
-     * @return array
-     * @phpstan-return list<array{currentDir: string, path: string, filePath: string}>
-     *
-     * @internal
-     */
-    public function getImports()
-    {
-        return $this->importedFiles;
-    }
-
-    /**
      * @return string[]
      */
     public function getIncludedFiles()
     {
-        return array_column($this->importedFiles, 'filePath');
+        return $this->includedFiles;
     }
 
     public function __toString()
     {
         return $this->getCss(); // To reduce the impact of the BC break
-    }
-
-    /**
-     * Store the sourceMap and its storage data
-     * @param string $sourceMap
-     * @param null|string $sourceMapFile
-     * @param null|string $sourceMapUrl
-     *
-     * @return void
-     */
-    public function setSourceMap($sourceMap, $sourceMapFile = null, $sourceMapUrl = null)
-    {
-        $this->sourceMap = $sourceMap;
-        if (empty($sourceMapFile) || empty($sourceMapUrl)) {
-            $this->sourceMapUrl = $this->sourceMapFile = null;
-        } else {
-            $this->sourceMapFile = $sourceMapFile;
-            $this->sourceMapUrl = $sourceMapUrl;
-        }
     }
 
     /**

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -387,7 +387,7 @@ class Compiler
      * @param string $code
      * @param string $path
      *
-     * @return string
+     * @return CompilationResult
      */
     public function compile($code, $path = null)
     {
@@ -5166,7 +5166,7 @@ class Compiler
      *
      * @api
      *
-     * @param string $path
+     * @param string|null $path
      *
      * @deprecated
      * @return void

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -2577,9 +2577,7 @@ class Compiler
                 return true;
             }
 
-            $path = $this->compileImportPath($rawPath);
-            $this->appendRootDirective('@import ' . $path . ';', $out);
-            $this->compilationResult->addIncludedFile($path);
+            $this->appendRootDirective('@import ' . $this->compileImportPath($rawPath) . ';', $out);
 
             return false;
         }
@@ -2592,9 +2590,7 @@ class Compiler
 
             foreach ($rawPath[2] as $path) {
                 if ($path[0] !== Type::T_STRING) {
-                    $path = $this->compileImportPath($rawPath);
-                    $this->appendRootDirective('@import ' . $path . ';', $out);
-                    $this->compilationResult->addIncludedFile($path);
+                    $this->appendRootDirective('@import ' . $this->compileImportPath($rawPath) . ';', $out);
 
                     return false;
                 }
@@ -2607,9 +2603,7 @@ class Compiler
             return true;
         }
 
-        $path = $this->compileImportPath($rawPath);
-        $this->appendRootDirective('@import ' . $path . ';', $out);
-        $this->compilationResult->addIncludedFile($path);
+        $this->appendRootDirective('@import ' . $this->compileImportPath($rawPath) . ';', $out);
 
         return false;
     }

--- a/src/Compiler/CachedResult.php
+++ b/src/Compiler/CachedResult.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Compiler;
+
+use ScssPhp\ScssPhp\CompilationResult;
+
+/**
+ * @internal
+ */
+class CachedResult
+{
+    /**
+     * @var CompilationResult
+     */
+    private $result;
+
+    /**
+     * @var array<string, int>
+     */
+    private $parsedFiles;
+
+    /**
+     * @var array
+     * @phpstan-var list<array{currentDir: string|null, path: string, filePath: string}>
+     */
+    private $resolvedImports;
+
+    /**
+     * @param CompilationResult  $result
+     * @param array<string, int> $parsedFiles
+     * @param array              $resolvedImports
+     *
+     * @phpstan-param list<array{currentDir: string|null, path: string, filePath: string}> $resolvedImports
+     */
+    public function __construct(CompilationResult $result, array $parsedFiles, array $resolvedImports)
+    {
+        $this->result = $result;
+        $this->parsedFiles = $parsedFiles;
+        $this->resolvedImports = $resolvedImports;
+    }
+
+    /**
+     * @return CompilationResult
+     */
+    public function getResult()
+    {
+        return $this->result;
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    public function getParsedFiles()
+    {
+        return $this->parsedFiles;
+    }
+
+    /**
+     * @return array
+     *
+     * @phpstan-return list<array{currentDir: string|null, path: string, filePath: string}>
+     */
+    public function getResolvedImports()
+    {
+        return $this->resolvedImports;
+    }
+}


### PR DESCRIPTION
This reworks the CompilationResult result object introduced in #270. This has to be merged before the next release (otherwise CompilationResult will be covered by BC and prevent the changes)

- `Scssphp\Scssphp\CompilationResult` is now an immutable value object instead of a mutable one
- `Scssphp\Scssphp\CompilationResult` now longer exposes some internal API publicly
- metadata used only by the caching layer are not exposed in the CompilationResult anymore. They are kept internal (the object stored in the cache is an internal `CachedResult` object wrapping the CompilationResult)
- metadata collected during the compilation are stored in properties of the Compiler (that are reset at the end of the compilation to free memory, except for `parsedFiles` which has a deprecated getter)
- the Compiler no longer retains a reference to the CompilationResult after returning it (which kept reference to much more memory than just `parsedFiles` as there is the CSS and sourcemap in there)
- `getParsedFiles` is not exposed in CompilationResult, in favor of `getIncludedFiles`, which returns a list of file paths. When looking at various open-source packages using scssphp, any usage of `$compiler->getParsedFiles()` I found were actually usages of `array_keys($compiler->getParsedFiles()`

/cc @Cerdic as you implement the initial version. 