### PR TITLE
Deprecate overriding core functions through registerFunction

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -5390,6 +5390,10 @@ class Compiler
      */
     public function registerFunction($name, $func, $prototype = null)
     {
+        if (self::isNativeFunction($name)) {
+            @trigger_error(sprintf('The "%s" function is a core sass function. Overriding it with a custom implementation through "%s" is deprecated and won\'t be supported in ScssPhp 2.0 anymore.', $name, __METHOD__), E_USER_DEPRECATED);
+        }
+
         $this->userFunctions[$this->normalizeName($name)] = [$func, $prototype];
     }
 

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -57,6 +57,20 @@ class ApiTest extends TestCase
         );
     }
 
+    /**
+     * @group legacy
+     */
+    public function testUserFunctionOverride()
+    {
+        $compiler = new Compiler();
+
+        $this->expectDeprecation('The "blue" function is a core sass function. Overriding it with a custom implementation through "ScssPhp\ScssPhp\Compiler::registerFunction" is deprecated and won\'t be supported in ScssPhp 2.0 anymore.');
+
+        $compiler->registerFunction('blue', function ($args) {
+            return Compiler::$null;
+        });
+    }
+
     public function testUserFunctionKwargs()
     {
         $this->scss = new Compiler();


### PR DESCRIPTION
Replacing a core function will lead to surprising results for authors as the function will probably not match the behavior of the core function (otherwise, there would be no point deprecating it).

Refs #209