### PR TITLE
Deprecate the scssphp-glob function

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -9554,6 +9554,10 @@ class Compiler
     protected static $libScssphpGlob = ['pattern'];
     protected function libScssphpGlob($args)
     {
+        @trigger_error(sprintf('The "scssphp-glob function is deprecated an will be removed in ScssPhp 2.0. Register your own alternative through "%s::registerFunction', __CLASS__), E_USER_DEPRECATED);
+
+        $this->logger->warn('The "scssphp-glob function is deprecated an will be removed in ScssPhp 2.0.', true);
+
         $string = $this->coerceString($args[0]);
         $pattern = $this->compileStringContent($string);
         $matches = glob($pattern);


### PR DESCRIPTION
This function is not standard in Sass. It is totally untested. And it has a confusing behavior: the argument must either be a glob based on an absolute path (not easy to do in a Sass file if it must be portable) or relative to the current working directory of the PHP process, not to the Sass file using the function, (which is not in the control of the author of the Sass file).

Closes #219