### PR TITLE
Define the signature for the unique-id function

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -8777,6 +8777,7 @@ class Compiler
         return new Number(mt_rand(0, $max - 1) / $max, '');
     }
 
+    protected static $libUniqueId = [];
     protected function libUniqueId()
     {
         static $id;

--- a/tests/specs/sass-spec-exclude.txt
+++ b/tests/specs/sass-spec-exclude.txt
@@ -622,7 +622,6 @@ core_functions/string/slice/error/type/string
 core_functions/string/slice/start/positive/after_end
 core_functions/string/to_lower_case/error/type
 core_functions/string/to_upper_case/error/type
-core_functions/string/unique_id/error/too_many_args
 core_functions/string/unquote/error/type
 css/comment/error/loud/unterminated/scss
 css/custom_properties/error/brackets/curly


### PR DESCRIPTION
This allows having proper error reporting when using it with arguments while it expects none.