### PR TITLE
Fix the implementation of list-separator

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -8172,13 +8172,9 @@ class Compiler
         return \count($list[2]);
     }
 
-    //protected static $libListSeparator = ['list...'];
+    protected static $libListSeparator = ['list'];
     protected function libListSeparator($args)
     {
-        if (\count($args) > 1) {
-            return 'comma';
-        }
-
         if (! \in_array($args[0][0], [Type::T_LIST, Type::T_MAP])) {
             return 'space';
         }

--- a/tests/inputs/list.scss
+++ b/tests/inputs/list.scss
@@ -37,6 +37,6 @@ div {
 
 div {
 x:list-separator(1px 2px 3px);
-y:list-separator(1px, 2px, 3px);
+y:list-separator((1px, 2px, 3px));
 z:list-separator('foo');
 }

--- a/tests/specs/sass-spec-exclude.txt
+++ b/tests/specs/sass-spec-exclude.txt
@@ -239,8 +239,6 @@ core_functions/list/nth/error/index/0
 core_functions/list/nth/error/index/too_high
 core_functions/list/nth/error/index/too_low
 core_functions/list/separator/empty/comma
-core_functions/list/separator/error/too_few_args
-core_functions/list/separator/error/too_many_args
 core_functions/list/set_nth/error/index/0
 core_functions/list/utils/empty_map/same_as_empty_list
 core_functions/list/utils/real_separator/empty/comma


### PR DESCRIPTION
The implementation was done based on a variadic argument, because of a mistake in the way to write one of our own tests.