### PR TITLE
Improve comparison script

### DIFF
--- a/tests/compare-scss.sh
+++ b/tests/compare-scss.sh
@@ -5,7 +5,7 @@ diff_tool="$1"
 
 for file in $(ls $test_dir/inputs/*.scss); do
 	out_file=$(echo $file | sed -e 's/inputs/outputs/' -e 's/\.scss$/\.css/')
-	sass=$(sass --stdin --no-source-map < $file 2> /dev/null)
+	sass=$(sass --no-source-map $file 2> /dev/null)
 	if [ $? = "0" ]; then
 		# echo $file
 		# echo "$sass"

--- a/tests/compare-scss.sh
+++ b/tests/compare-scss.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
+test_dir=$(dirname $0)
 diff_tool="$1"
 
-for file in $(ls inputs/*.scss); do
+for file in $(ls $test_dir/inputs/*.scss); do
 	out_file=$(echo $file | sed -e 's/inputs/outputs/' -e 's/\.scss$/\.css/')
 	sass=$(sass --stdin --no-source-map < $file 2> /dev/null)
 	if [ $? = "0" ]; then

--- a/tests/compare-scss.sh
+++ b/tests/compare-scss.sh
@@ -12,15 +12,15 @@ for file in $(ls $test_dir/inputs/*.scss); do
 		# echo
 
 		if [ "$(cat $out_file)" != "$sass" ]; then
-			echo "* [FAIL] $file"
+			echo "* [FAIL]    $file"
 			if [ -n "$diff_tool" ]; then
 				$diff_tool $out_file <(echo "$sass") 2> /dev/null
 			fi
 		else
-			echo "  [PASS] $file"
+			echo "  [PASS]    $file"
 		fi
 	else
-		echo "         $file"
+		echo "x [INVALID] $file"
 	fi
 done
 

--- a/tests/compare-scss.sh
+++ b/tests/compare-scss.sh
@@ -4,7 +4,7 @@ diff_tool="$1"
 
 for file in $(ls inputs/*.scss); do
 	out_file=$(echo $file | sed -e 's/inputs/outputs/' -e 's/\.scss$/\.css/')
-	sass=$(scss < $file 2> /dev/null)
+	sass=$(sass --stdin --no-source-map < $file 2> /dev/null)
 	if [ $? = "0" ]; then
 		# echo $file
 		# echo "$sass"


### PR DESCRIPTION
I discovered that the `tests` folder contained an outdated script comparing the output for our own functional tests (the ones in `tests/inputs/` with expectations in `tests/output/`, used by InputTest) to the output of ruby-sass's `scss` executable.

This script is now updated to use the dart-sass CLI instead. I also improved the way invalid scss files (i.e. the ones for which dart-sass fails) are reported.