### PR TITLE
Remove support for ignoring HTML comment delimiters during parsing

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -975,11 +975,6 @@ class Parser
 
         $this->seek($s);
 
-        // misc
-        if ($this->literal('-->', 3)) {
-            return true;
-        }
-
         // opening css block
         if (
             $this->selectors($selectors) &&
@@ -1067,10 +1062,7 @@ class Parser
         }
 
         // extra stuff
-        if (
-            $this->matchChar(';') ||
-            $this->literal('<!--', 4)
-        ) {
+        if ($this->matchChar(';')) {
             return true;
         }
 

--- a/tests/inputs/scss_css.scss
+++ b/tests/inputs/scss_css.scss
@@ -82,9 +82,7 @@ foo {
 
 
 foo {bar: baz}
-<!--
 bar {bar: baz}
--->
 baz {bar: baz}
 
 
@@ -775,11 +773,11 @@ body {
 }
 
 
-E>F { a: b;} 
+E>F { a: b;}
 
-E~F { a: b;} 
+E~F { a: b;}
 
-E+F { a: b;} 
+E+F { a: b;}
 
 * {
   a: b; }


### PR DESCRIPTION
This is not a valid Sass syntax (and has never been one).

This is something that was implemented in leafo/scssphp in the commit https://github.com/scssphp/scssphp/commit/16251d9790e57853017464bd9009f685505f50c8 which is described as `match some random stuff`.
Matching some random stuff is not how we comply to the spec.