### PR TITLE
Deprecate Compiler::compile in favor of Compiler::compileString

### DIFF
--- a/bin/pscss
+++ b/bin/pscss
@@ -199,6 +199,7 @@ if ($style) {
 }
 
 $outputFile = isset($arguments[1]) ? $arguments[1] : null;
+$sourceMapFile = null;
 
 if ($sourceMap) {
     $sourceMapOptions = array(
@@ -224,14 +225,18 @@ if ($encoding) {
 }
 
 try {
-    $output = $scss->compile($data, $inputFile);
+    $result = $scss->compileString($data, $inputFile);
 } catch (SassException $e) {
     fwrite(STDERR, $e->getMessage()."\n");
     exit(1);
 }
 
 if ($outputFile) {
-    file_put_contents($outputFile, $output);
+    file_put_contents($outputFile, $result->getCss());
+
+    if ($sourceMapFile !== null && $result->getSourceMap() !== null) {
+        file_put_contents($sourceMapFile, $result->getSourceMap());
+    }
 } else {
-    echo $output;
+    echo $result->getCss();
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -121,6 +121,11 @@ parameters:
 			path: src/Compiler.php
 
 		-
+			message: "#^PHPDoc tag @throws with type ScssPhp\\\\ScssPhp\\\\Exception\\\\SassException is not subtype of Throwable$#"
+			count: 2
+			path: src/Compiler.php
+
+		-
 			message: "#^Property ScssPhp\\\\ScssPhp\\\\Compiler\\:\\:\\$env \\(ScssPhp\\\\ScssPhp\\\\Compiler\\\\Environment\\) does not accept null\\.$#"
 			count: 1
 			path: src/Compiler.php
@@ -142,16 +147,6 @@ parameters:
 
 		-
 			message: "#^Cannot call method generateJson\\(\\) on ScssPhp\\\\ScssPhp\\\\SourceMap\\\\SourceMapGenerator\\|null\\.$#"
-			count: 1
-			path: src/Compiler.php
-
-		-
-			message: "#^Parameter \\#3 \\$sourceMapFile of class ScssPhp\\\\ScssPhp\\\\CompilationResult constructor expects string\\|null, bool\\|string\\|null given\\.$#"
-			count: 1
-			path: src/Compiler.php
-
-		-
-			message: "#^Parameter \\#4 \\$sourceMapUrl of class ScssPhp\\\\ScssPhp\\\\CompilationResult constructor expects string\\|null, bool\\|string\\|null given\\.$#"
 			count: 1
 			path: src/Compiler.php
 

--- a/src/CompilationResult.php
+++ b/src/CompilationResult.php
@@ -12,8 +12,6 @@
 
 namespace ScssPhp\ScssPhp;
 
-use ScssPhp\ScssPhp\Exception\CompilerException;
-
 class CompilationResult
 {
     /**
@@ -27,16 +25,6 @@ class CompilationResult
     private $sourceMap;
 
     /**
-     * @var string|null
-     */
-    private $sourceMapFile;
-
-    /**
-     * @var string|null
-     */
-    private $sourceMapUrl;
-
-    /**
      * @var string[]
      */
     private $includedFiles;
@@ -44,16 +32,12 @@ class CompilationResult
     /**
      * @param string $css
      * @param string|null $sourceMap
-     * @param string|null $sourceMapFile
-     * @param string|null $sourceMapUrl
      * @param string[] $includedFiles
      */
-    public function __construct($css, $sourceMap, $sourceMapFile, $sourceMapUrl, array $includedFiles)
+    public function __construct($css, $sourceMap, array $includedFiles)
     {
         $this->css = $css;
         $this->sourceMap = $sourceMap;
-        $this->sourceMapFile = $sourceMapFile;
-        $this->sourceMapUrl = $sourceMapUrl;
         $this->includedFiles = $includedFiles;
     }
 
@@ -62,7 +46,7 @@ class CompilationResult
      */
     public function getCss()
     {
-        return $this->css . $this->getSourceMapCss();
+        return $this->css;
     }
 
     /**
@@ -73,11 +57,6 @@ class CompilationResult
         return $this->includedFiles;
     }
 
-    public function __toString()
-    {
-        return $this->getCss(); // To reduce the impact of the BC break
-    }
-
     /**
      * The sourceMap content, if it was generated
      *
@@ -86,41 +65,5 @@ class CompilationResult
     public function getSourceMap()
     {
         return $this->sourceMap;
-    }
-
-    /**
-     * The sourceMap Css content, if there is a sourceMap
-     * @return string
-     */
-    private function getSourceMapCss()
-    {
-        if ($this->sourceMap) {
-            if ($this->sourceMapFile) {
-                $sourceMapurl = $this->sourceMapUrl;
-                $dir  = \dirname($this->sourceMapFile);
-
-                // directory does not exist
-                if (! is_dir($dir)) {
-                    // FIXME: create the dir automatically?
-                    throw new CompilerException(
-                        sprintf('The directory "%s" does not exist. Cannot save the source map.', $dir)
-                    );
-                }
-
-                // FIXME: proper saving, with dir write check!
-                if (file_put_contents($this->sourceMapFile, $this->sourceMap) === false) {
-                    throw new CompilerException(sprintf('Cannot save the source map to "%s"', $this->sourceMapFile));
-                }
-            }
-            else {
-                $sourceMapurl = Util::encodeURIComponent($this->sourceMap);
-            }
-
-            if ($sourceMapurl) {
-                return sprintf('/*# sourceMappingURL=%s */', $sourceMapurl);
-            }
-        }
-
-        return '';
     }
 }

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -26,6 +26,9 @@ class ApiTest extends TestCase
 {
     use ExpectDeprecationTrait;
 
+    /**
+     * @var Compiler
+     */
     private $scss;
 
     public function testUserFunction()
@@ -208,6 +211,19 @@ class ApiTest extends TestCase
     /**
      * @group legacy
      */
+    public function testCompile()
+    {
+        $compiler = new Compiler();
+
+        $this->expectDeprecation('The "ScssPhp\ScssPhp\Compiler::compile" method is deprecated. Use "compileString" instead.');
+
+        $css = $compiler->compile('a { b: c}');
+        $this->assertSame("a {\n  b: c;\n}\n", $css);
+    }
+
+    /**
+     * @group legacy
+     */
     public function testDeprecatedChildCompiler()
     {
         $this->expectDeprecation('Registering custom functions by extending the Compiler and using the lib* discovery mechanism is deprecated and will be removed in 2.0. Replace the "ScssPhp\ScssPhp\Tests\DeprecatedChildCompiler::libDeprecatedChild" method with registering the "deprecated_child" function through "Compiler::registerFunction".');
@@ -222,7 +238,7 @@ class ApiTest extends TestCase
 
     public function compile($str)
     {
-        return trim($this->scss->compile($str));
+        return trim($this->scss->compileString($str)->getCss());
     }
 }
 

--- a/tests/ExceptionTest.php
+++ b/tests/ExceptionTest.php
@@ -147,6 +147,6 @@ END_OF_SCSS
         $scss = new Compiler();
         $scss->setLogger(new QuietLogger());
 
-        return trim($scss->compile($str));
+        return $scss->compileString($str);
     }
 }

--- a/tests/FrameworkTest.php
+++ b/tests/FrameworkTest.php
@@ -25,7 +25,7 @@ class FrameworkTest extends TestCase
 
         $entrypoint = dirname(__DIR__) . '/vendor/twbs/bootstrap/scss/bootstrap.scss';
 
-        $result = $compiler->compile(file_get_contents($entrypoint), $entrypoint);
+        $result = $compiler->compileString(file_get_contents($entrypoint), $entrypoint);
 
         $this->assertNotEmpty($result->getCss());
     }
@@ -45,7 +45,7 @@ class FrameworkTest extends TestCase
 @include foundation-everything;
 SCSS;
 
-        $result = $compiler->compile($scss);
+        $result = $compiler->compileString($scss);
 
         $this->assertNotEmpty($result->getCss());
     }

--- a/tests/InputTest.php
+++ b/tests/InputTest.php
@@ -64,7 +64,7 @@ class InputTest extends TestCase
         $input = file_get_contents($inFname);
         $output = file_get_contents($outFname);
 
-        $css = $this->scss->compile($input, substr($inFname, strlen(__DIR__) + 1));
+        $css = $this->scss->compileString($input, substr($inFname, strlen(__DIR__) + 1))->getCss();
         $this->assertEquals($output, $css);
     }
 

--- a/tests/SassSpecTest.php
+++ b/tests/SassSpecTest.php
@@ -306,7 +306,7 @@ class SassSpecTest extends TestCase
         if (! strlen($error)) {
             if (getenv('BUILD')) {
                 try {
-                    $actual = $compiler->compile($scss, $inputPath);
+                    $actual = $compiler->compileString($scss, $inputPath)->getCss();
                 } catch (\Exception $e) {
                     $this->appendToExclusionList($name);
                     fclose($fp_err_stream);
@@ -315,7 +315,7 @@ class SassSpecTest extends TestCase
                     //throwException($e);
                 }
             } else {
-                $actual = $compiler->compile($scss, $inputPath);
+                $actual = $compiler->compileString($scss, $inputPath)->getCss();
             }
 
             // normalize css for comparison purpose
@@ -364,7 +364,7 @@ class SassSpecTest extends TestCase
         } else {
             if (getenv('BUILD')) {
                 try {
-                    $compiler->compile($scss, $inputPath);
+                    $compiler->compileString($scss, $inputPath);
                     throw new \Exception('Expecting a SassException for error tests');
                 } catch (SassException $e) {
                     // TODO assert the error message ?
@@ -375,7 +375,7 @@ class SassSpecTest extends TestCase
                 $this->assertNull(null);
             } else {
                 $this->expectException(SassException::class);
-                $compiler->compile($scss, $inputPath);
+                $compiler->compileString($scss, $inputPath);
                 // TODO assert the error message ?
             }
 


### PR DESCRIPTION
This restores backward compatibility on the `compile()` method by keeping a string return value.
The modern API using a CompilationResult object is now available through `compileString` instead. This modern API does not write the sourcemap to the filesystem when configuring an external sourcemap. This is expected to be done by the caller (similar to the fact the CSS is not written to disk). However, the sourcemap comment is present in the CSS.

Closes #320 