### PR TITLE
Add a high-level API to report warning

### DIFF
--- a/src/Warn.php
+++ b/src/Warn.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp;
+
+final class Warn
+{
+    /**
+     * @var callable|null
+     * @phpstan-var (callable(string, bool): void)|null
+     */
+    private static $callback;
+
+    /**
+     * Prints a warning message associated with the current `@import` or function call.
+     *
+     * This may only be called within a custom function or importer callback.
+     *
+     * @param string $message
+     *
+     * @return void
+     */
+    public static function warning($message)
+    {
+        self::reportWarning($message, false);
+    }
+
+    /**
+     * Prints a deprecation warning message associated with the current `@import` or function call.
+     *
+     * This may only be called within a custom function or importer callback.
+     *
+     * @param string $message
+     *
+     * @return void
+     */
+    public static function deprecation($message)
+    {
+        self::reportWarning($message, true);
+    }
+
+    /**
+     * @param callable|null $callback
+     *
+     * @return callable|null The previous warn callback
+     *
+     * @phpstan-param (callable(string, bool): void)|null $callback
+     *
+     * @phpstan-return (callable(string, bool): void)|null
+     *
+     * @internal
+     */
+    public static function setCallback(callable $callback = null)
+    {
+        $previousCallback = self::$callback;
+        self::$callback = $callback;
+
+        return $previousCallback;
+    }
+
+    /**
+     * @param string $message
+     * @param bool   $deprecation
+     *
+     * @return void
+     */
+    private static function reportWarning($message, $deprecation)
+    {
+        if (self::$callback === null) {
+            throw new \BadMethodCallException('The warning Reporter may only be called within a custom function or importer callback.');
+        }
+
+        \call_user_func(self::$callback, $message, $deprecation);
+    }
+}


### PR DESCRIPTION
The goal of this API is to allow implementing custom functions without the need for a reference to the Compiler object. This is the next step after #239 which allowed avoid the Compiler instance to report errors.

This API is a public API for projects registering custom functions. However, it is also used internally (it is necessary to unlock #266).
For now, the warning message is logged as is. A future improvement once #303 is solved will be to inject the trace automatically for all warnings, as done in dart-sass. I even already implemented it without including it in this PR due to sass-spec failures (where we would no longer match the libsass warnings due to adding a trace but not matching the dart-sass ones due to having a different trace format), which is the reason why I opened #303.
The architecture using a globally available function which forwards to a callback set by the compiler while it runs is inspired from dart-sass, which does something similar.

For now, the Compiler is still useful  in custom function if you want to use all the assertion helpers. However, these helper don't really need to be in the Compiler as they don't depend on the compiler instance (except to access the other helpers). So they could be moved (with a BC layer) into static methods on a `ValueHelper` class (already mentioned in https://github.com/scssphp/scssphp/issues/309).
Once #265 lands, all the assertion methods of the new API will be on the Value classes directly instead (see #301 as they are already implemented).