### PR TITLE
Prefix errors when displaying them in the CLI

### DIFF
--- a/bin/pscss
+++ b/bin/pscss
@@ -226,7 +226,7 @@ if ($encoding) {
 try {
     $output = $scss->compile($data, $inputFile);
 } catch (SassException $e) {
-    fwrite(STDERR, $e->getMessage()."\n");
+    fwrite(STDERR, 'Error: '.$e->getMessage()."\n");
     exit(1);
 }
 


### PR DESCRIPTION
This make the CLI compatible with the expectation of the official sass-spec runner.