### PR TITLE
Remove invalid syntax from some test fixtures

### DIFF
--- a/tests/inputs/map.scss
+++ b/tests/inputs/map.scss
@@ -13,8 +13,8 @@ div {
     color: map_get($map, 'color#{2}');
     foo: map_values($map);
     bar: map_keys($map2);
-    baz: map_merge($map, $map2);
-    foo: map_remove($map2, color);
+    baz: inspect(map_merge($map, $map2));
+    foo: inspect(map_remove($map2, color));
     bar: if(map_has_key($map, color), true, false);
     suppress: map_get($map, null);
 }

--- a/tests/inputs/nesting.scss
+++ b/tests/inputs/nesting.scss
@@ -15,9 +15,6 @@ div {
 }
 
 
-div: blue;
-
-
 div {
     font: 10px hello world {
         size: 10px;

--- a/tests/inputs/operators.scss
+++ b/tests/inputs/operators.scss
@@ -18,7 +18,6 @@ div {
 
     color: 4 > 3;
     color: 4 < 3;
-    color: what > 3;
 }
 
 

--- a/tests/inputs/scss_css.scss
+++ b/tests/inputs/scss_css.scss
@@ -174,24 +174,18 @@ foo {;;;;
 }
 
 
-0% {
-  a: b; }
+@keyframes foo {
+  0% {
+    a: b; }
 
 
-60% {
-  a: b; }
+  60% {
+    a: b; }
 
 
-100% {
-  a: b; }
-
-
-12px {
-  a: b; }
-
-
-"foo" {
-  a: b; }
+  100% {
+    a: b; }
+}
 
 
 foo {
@@ -440,11 +434,11 @@ foo {a /*: b; c */: d}
 
 
 @media screen and (-webkit-min-device-pixel-ratio:0) {
-  a: b; }
+  .foo {a: b;} }
 
 
 @media only screen, print and (foo: 0px) and (bar: flam(12px solid)) {
-  a: b; }
+  .foo {a: b;} }
 
 
 :-moz-any(h1, h2, h3) {
@@ -947,7 +941,7 @@ E ~ F {
   a: b; }
 
 
-@supports (a: b) and (c: d) or (not (d: e)) and ((not (f: g)) or (not ((h: i) and (j: k)))) {
+@supports ((a: b) and (c: d)) or ((not (d: e)) and ((not (f: g)) or (not ((h: i) and (j: k))))) {
   .foo {
     a: b;
   }

--- a/tests/inputs/selector_functions.scss
+++ b/tests/inputs/selector_functions.scss
@@ -131,10 +131,6 @@
 	content: "a.disabled.outgoing";
 }
 
-#{selector-unify("a", "h1")} {
-	content: "null";
-}
-
 #{selector-unify(".warning a", "main a")} {
 	content: ".warning main a, main .warning a";
 }

--- a/tests/inputs/selectors.scss
+++ b/tests/inputs/selectors.scss
@@ -85,12 +85,10 @@ E F { color: blue; }
 E > F { color: blue; }
 E + F { color: blue; }
 E ~ F { color: blue; }
-E! > F { color: blue; }
 
 // namespaces
 [foo|att=val] { color: blue }
 [*|att] { color: yellow }
-[|att] { color: green }
 [att] { color: green }
 
 // CSS2.1
@@ -154,7 +152,7 @@ div {
         color: blue;
     }
 
-    .rad&.bad {
+    &.rad.bad {
         color: blue;
     }
 

--- a/tests/inputs/variables.scss
+++ b/tests/inputs/variables.scss
@@ -24,9 +24,6 @@ pre {
     color: $cool_color;
 }
 
-$something_man: 100px;
-cool: $something_man;
-
 
 del {
     $something: blue;

--- a/tests/outputs/nesting.css
+++ b/tests/outputs/nesting.css
@@ -8,7 +8,6 @@ div {
 div pre {
   color: blue;
 }
-div: blue;
 div {
   font: 10px hello world;
   font-size: 10px;

--- a/tests/outputs/operators.css
+++ b/tests/outputs/operators.css
@@ -13,7 +13,6 @@ div {
   color: true;
   color: true;
   color: false;
-  color: what > 3;
 }
 #units {
   test: 2.5748031496in;

--- a/tests/outputs/scss_css.css
+++ b/tests/outputs/scss_css.css
@@ -182,20 +182,16 @@ foo {
 foo {
   bar: baz;
 }
-0% {
-  a: b;
-}
-60% {
-  a: b;
-}
-100% {
-  a: b;
-}
-12px {
-  a: b;
-}
-foo {
-  a: b;
+@keyframes foo {
+  0% {
+    a: b;
+  }
+  60% {
+    a: b;
+  }
+  100% {
+    a: b;
+  }
 }
 foo {
   a: 12px expression(1 + (3 / Foo.bar("baz" + "bang") + function() {return 12;}) % 12);
@@ -372,10 +368,14 @@ foo {
   }
 }
 @media screen and (-webkit-min-device-pixel-ratio: 0) {
-  a: b;
+  .foo {
+    a: b;
+  }
 }
 @media only screen, print and (foo: 0px) and (bar: flam(12px solid)) {
-  a: b;
+  .foo {
+    a: b;
+  }
 }
 :-moz-any(h1, h2, h3) {
   a: b;
@@ -753,7 +753,7 @@ E + F {
 E ~ F {
   a: b;
 }
-@supports (a: b) and (c: d) or (not (d: e)) and ((not (f: g)) or (not ((h: i) and (j: k)))) {
+@supports ((a: b) and (c: d)) or ((not (d: e)) and ((not (f: g)) or (not ((h: i) and (j: k))))) {
   .foo {
     a: b;
   }

--- a/tests/outputs/selector_functions.css
+++ b/tests/outputs/selector_functions.css
@@ -115,9 +115,6 @@ a.disabled {
 a.disabled.outgoing {
   content: "a.disabled.outgoing";
 }
- {
-  content: "null";
-}
 .warning main a, main .warning a {
   content: ".warning main a, main .warning a";
 }

--- a/tests/outputs/selectors.css
+++ b/tests/outputs/selectors.css
@@ -230,17 +230,11 @@ E + F {
 E ~ F {
   color: blue;
 }
-E! > F {
-  color: blue;
-}
 [foo|att=val] {
   color: blue;
 }
 [*|att] {
   color: yellow;
-}
-[|att] {
-  color: green;
 }
 [att] {
   color: green;
@@ -324,7 +318,7 @@ div font:something {
 .dad .simple .wolf {
   color: blue;
 }
-.rad.simple.bad {
+.simple.rad.bad {
   color: blue;
 }
 .something div .what.world {

--- a/tests/outputs/variables.css
+++ b/tests/outputs/variables.css
@@ -10,7 +10,6 @@ div {
 pre {
   color: blue;
 }
-cool: 100px;
 del {
   color: blue;
 }


### PR DESCRIPTION
Our parser and compiler accept invalid input as long as it looks a bit like Sass. But we should not have such broken cases enforced by the testsuite.