### PR TITLE
Avoid using the libUnquote method when dealing with selector args

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -8902,7 +8902,10 @@ class Compiler
                 . " a list of strings, or a list of lists of strings");
         }
 
-        $arg = $this->libUnquote([$arg]);
+
+        if ($arg[0] === Type::T_STRING) {
+            $arg[1] = '';
+        }
         $arg = $this->compileValue($arg);
 
         $parsedSelector = [];


### PR DESCRIPTION
The method is expected to display some warnings, so we should not use it as an internal helper at the same time, to unlock adding it.