### PR TITLE
Refactor the implementation of color changing functions

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1336,26 +1336,6 @@ parameters:
 			path: src/Compiler.php
 
 		-
-			message: "#^Method ScssPhp\\\\ScssPhp\\\\Compiler\\:\\:assertUnit\\(\\) has parameter \\$value with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Compiler.php
-
-		-
-			message: "#^Method ScssPhp\\\\ScssPhp\\\\Compiler\\:\\:assertPercentOrUnitless\\(\\) has parameter \\$acceptButDeprecated with no typehint specified\\.$#"
-			count: 1
-			path: src/Compiler.php
-
-		-
-			message: "#^Method ScssPhp\\\\ScssPhp\\\\Compiler\\:\\:assertPercentOrUnitless\\(\\) has parameter \\$value with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Compiler.php
-
-		-
-			message: "#^Method ScssPhp\\\\ScssPhp\\\\Compiler\\:\\:assertRange\\(\\) has parameter \\$value with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Compiler.php
-
-		-
 			message: "#^Method ScssPhp\\\\ScssPhp\\\\Compiler\\:\\:assertInteger\\(\\) has parameter \\$value with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Compiler.php
@@ -1412,11 +1392,6 @@ parameters:
 
 		-
 			message: "#^Method ScssPhp\\\\ScssPhp\\\\Compiler\\:\\:alterColor\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Compiler.php
-
-		-
-			message: "#^Variable \\$val might not be defined\\.$#"
 			count: 1
 			path: src/Compiler.php
 

--- a/src/Node/Number.php
+++ b/src/Node/Number.php
@@ -12,10 +12,13 @@
 
 namespace ScssPhp\ScssPhp\Node;
 
+use ScssPhp\ScssPhp\Base\Range;
 use ScssPhp\ScssPhp\Compiler;
+use ScssPhp\ScssPhp\Exception\RangeException;
 use ScssPhp\ScssPhp\Exception\SassScriptException;
 use ScssPhp\ScssPhp\Node;
 use ScssPhp\ScssPhp\Type;
+use ScssPhp\ScssPhp\Util;
 
 /**
  * Dimension + optional units
@@ -247,6 +250,23 @@ class Number extends Node implements \ArrayAccess
     }
 
     /**
+     * @param float|int $min
+     * @param float|int $max
+     * @param string|null $name
+     *
+     * @return float|int
+     * @throws SassScriptException
+     */
+    public function valueInRange($min, $max, $name = null)
+    {
+        try {
+            return Util::checkRange('', new Range($min, $max), $this);
+        } catch (RangeException $e) {
+            throw SassScriptException::forArgument(sprintf('Expected %s to be within %s%s and %s%3$s', $this, $min, $this->unitStr(), $max), $name);
+        }
+    }
+
+    /**
      * @param string|null $varName
      *
      * @return void
@@ -257,7 +277,22 @@ class Number extends Node implements \ArrayAccess
             return;
         }
 
-        throw SassScriptException::forArgument(sprintf('Expected %s to have no units', $this), $varName);
+        throw SassScriptException::forArgument(sprintf('Expected %s to have no units.', $this), $varName);
+    }
+
+    /**
+     * @param string      $unit
+     * @param string|null $varName
+     *
+     * @return void
+     */
+    public function assertUnit($unit, $varName = null)
+    {
+        if ($this->hasUnit($unit)) {
+            return;
+        }
+
+        throw SassScriptException::forArgument(sprintf('Expected %s to have unit "%s".', $this, $unit), $varName);
     }
 
     /**

--- a/tests/specs/sass-spec-exclude.txt
+++ b/tests/specs/sass-spec-exclude.txt
@@ -1,9 +1,7 @@
-core_functions/color/adjust_color/error/args/too_many
 core_functions/color/alpha/error/quoted_string
 core_functions/color/alpha/error/type
 core_functions/color/alpha/error/unquoted_string/no_equals
 core_functions/color/alpha/error/unquoted_string/non_identifier_before_equals
-core_functions/color/change_color/error/args/too_many
 core_functions/color/desaturate/error/bounds/too_high
 core_functions/color/desaturate/error/bounds/too_low
 core_functions/color/desaturate/error/type/lightness
@@ -216,7 +214,6 @@ core_functions/color/saturation/fraction
 core_functions/color/saturation/max
 core_functions/color/saturation/middle
 core_functions/color/saturation/named
-core_functions/color/scale_color/error/args/unknown
 core_functions/list/append/empty/comma
 core_functions/list/append/error/type/separator
 core_functions/list/append/error/unknown_separator


### PR DESCRIPTION
scale-color, adjust-color and change-color are expected to accept channels only through named arguments, not through positional ones.