### PR TITLE
Remove invalid test from the fixtures

### DIFF
--- a/tests/inputs/if.scss
+++ b/tests/inputs/if.scss
@@ -63,17 +63,6 @@ div {
 
 }
 
-// doesn't work in scss, thing loses scope
-del {
-    @if false {
-        $thing: yes;
-    } @else {
-        $thing: no;
-    }
-
-    thing: $thing;
-}
-
 $return: (1);
 @if $return == () {
     @warn 'empty list';

--- a/tests/outputs/if.css
+++ b/tests/outputs/if.css
@@ -17,9 +17,6 @@ div {
   color: blue;
   border-color: green;
 }
-del {
-  thing: no;
-}
 .debug {
   color: red;
 }


### PR DESCRIPTION
This test was actually enforcing a non-compliant scoping rule (and the comment acknowledges that). This does not make sense to keep that in our testsuite.