### PR TITLE
Remove remaining usage of the deprecated compile API in tests

### DIFF
--- a/tests/InputTest.php
+++ b/tests/InputTest.php
@@ -34,6 +34,9 @@ function _quote($str)
  */
 class InputTest extends TestCase
 {
+    /**
+     * @var Compiler
+     */
     private $scss;
 
     protected static $inputDir = 'inputs';
@@ -81,7 +84,7 @@ class InputTest extends TestCase
     // only run when env is set
     public function buildInput($inFname, $outFname)
     {
-        $css = $this->scss->compile(file_get_contents($inFname), substr($inFname, strlen(__DIR__) + 1));
+        $css = $this->scss->compileString(file_get_contents($inFname), substr($inFname, strlen(__DIR__) + 1))->getCss();
 
         file_put_contents($outFname, $css);
     }


### PR DESCRIPTION
I missed it in #334 because this runs only when rebuilding the outputs, not when running tests (so not reported during a normal test run) and the missing phpdoc on the property means that PHPStorm was not finding it as a usage of the method.