### PR TITLE
Forbid unsupported selectors in the extend directive

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -3057,8 +3057,12 @@ class Compiler
                     $results = $this->evalSelectors([$sel]);
 
                     foreach ($results as $result) {
+                        if (\count($result) !== 1) {
+                            throw $this->error('complex selectors may not be extended.');
+                        }
+
                         // only use the first one
-                        $result = current($result);
+                        $result = $result[0];
                         $selectors = $out->selectors;
 
                         if (! $selectors && isset($child['selfParent'])) {
@@ -9411,6 +9415,10 @@ class Compiler
         $this->extendsMap = [];
 
         foreach ($extendee as $es) {
+            if (\count($es) !== 1) {
+                throw $this->error('Can\'t extend complex selector.');
+            }
+
             // only use the first one
             $this->pushExtends(reset($es), $extender, null);
         }

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -3048,7 +3048,12 @@ class Compiler
 
             case Type::T_EXTEND:
                 foreach ($child[1] as $sel) {
-                    $sel = $this->replaceSelfSelector($sel);
+                    $replacedSel = $this->replaceSelfSelector($sel);
+
+                    if ($replacedSel !== $sel) {
+                        throw $this->error('Parent selectors aren\'t allowed here.');
+                    }
+
                     $results = $this->evalSelectors([$sel]);
 
                     foreach ($results as $result) {

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -9092,9 +9092,9 @@ class Compiler
         }
 
         if (! $this->checkSelectorArgType($arg)) {
-            $var_display = ($varname ? ' $' . $varname . ':' : '');
+            $var_display = ($varname ? '$' . $varname . ': ' : '');
             $var_value = $this->compileValue($arg);
-            throw $this->error("Error:{$var_display} $var_value is not a valid selector: it must be a string,"
+            throw $this->error("$var_display$var_value is not a valid selector: it must be a string,"
                 . " a list of strings, or a list of lists of strings");
         }
 
@@ -9114,8 +9114,8 @@ class Compiler
                 foreach ($gluedSelector as $selector) {
                     foreach ($selector as $s) {
                         if (in_array(static::$selfSelector, $s)) {
-                            $var_display = ($varname ? ' $' . $varname . ':' : '');
-                            throw $this->error("Error:{$var_display} Parent selectors aren't allowed here.");
+                            $var_display = ($varname ? '$' . $varname . ': ' : '');
+                            throw $this->error("{$var_display}Parent selectors aren't allowed here.");
                         }
                     }
                 }
@@ -9124,8 +9124,8 @@ class Compiler
             return $gluedSelector;
         }
 
-        $var_display = ($varname ? ' $' . $varname . ':' : '');
-        throw $this->error("Error:{$var_display} expected more input, invalid selector.");
+        $var_display = ($varname ? '$' . $varname . ': ' : '');
+        throw $this->error("{$var_display}expected more input, invalid selector.");
     }
 
     /**

--- a/tests/ExceptionTest.php
+++ b/tests/ExceptionTest.php
@@ -133,6 +133,18 @@ END_OF_SCSS
                 ,
                 'was not found'
             ],
+            // TODO Remove this test once sass-spec is updated to run https://github.com/sass/sass-spec/pull/1636
+            [<<<'SCSS'
+a b {
+  color: blue;
+}
+c {
+  @extend a b;
+}
+SCSS
+                ,
+                'complex selectors may not be extended.'
+            ],
             [<<<'END_OF_SCSS'
 @import "missing";
 END_OF_SCSS

--- a/tests/specs/sass-spec-exclude.txt
+++ b/tests/specs/sass-spec-exclude.txt
@@ -310,8 +310,6 @@ core_functions/selector/append/format/input/initial
 core_functions/selector/append/format/input/later
 core_functions/selector/append/format/output
 core_functions/selector/append/suffix/descendant
-core_functions/selector/extend/error/extendee/complex/list
-core_functions/selector/extend/error/extendee/complex/string
 core_functions/selector/extend/format/input/multiple_extendees/list
 core_functions/selector/extend/format/input/multiple_extendees/list_of_compound
 core_functions/selector/extend/format/input/non_string/extendee
@@ -449,8 +447,6 @@ core_functions/selector/parse/structure/decomposed/middle/mixed
 core_functions/selector/parse/structure/decomposed/middle/quoted
 core_functions/selector/parse/structure/decomposed/partial/quoted
 core_functions/selector/replace/compound
-core_functions/selector/replace/error/extendee/complex/list
-core_functions/selector/replace/error/extendee/complex/string
 core_functions/selector/replace/format/input/multiple_extendees/list
 core_functions/selector/replace/format/input/multiple_extendees/list_of_compound
 core_functions/selector/replace/format/input/non_string/extendee

--- a/tests/specs/sass-spec-exclude.txt
+++ b/tests/specs/sass-spec-exclude.txt
@@ -763,7 +763,6 @@ libsass-closed-issues/issue_1482
 libsass-closed-issues/issue_1487
 libsass-closed-issues/issue_152
 libsass-closed-issues/issue_1526
-libsass-closed-issues/issue_1527/extend
 libsass-closed-issues/issue_1527/selector/first
 libsass-closed-issues/issue_1527/selector/last
 libsass-closed-issues/issue_1527/selector/only


### PR DESCRIPTION
None of the official Sass implementations are allowing to use the parent selector or complex selectors in `@extend`.
Scssphp currently generates garbage for such usage. This makes it report a proper error instead.