### PR TITLE
Take sass files into account when resolving imports

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -5492,6 +5492,15 @@ class Compiler
         // see if tree is cached
         $realPath = realpath($path);
 
+        if (substr($path, -5) === '.sass') {
+            $this->sourceIndex = \count($this->sourceNames);
+            $this->sourceNames[] = $path;
+            $this->sourceLine = 1;
+            $this->sourceColumn = 1;
+
+            throw $this->error('The Sass indented syntax is not implemented.');
+        }
+
         if (isset($this->importCache[$realPath])) {
             $this->handleImportLoop($realPath);
 
@@ -5624,7 +5633,7 @@ class Compiler
     {
         $path = Path::join($baseDir, $url);
 
-        $hasExtension = preg_match('/.scss$/', $url);
+        $hasExtension = preg_match('/.s[ac]ss$/', $url);
 
         if ($hasExtension) {
             return $this->checkImportPathConflicts($this->tryImportPath($path));
@@ -5670,7 +5679,10 @@ class Compiler
      */
     private function tryImportPathWithExtensions($path)
     {
-        $result = $this->tryImportPath($path.'.scss');
+        $result = array_merge(
+            $this->tryImportPath($path.'.sass'),
+            $this->tryImportPath($path.'.scss')
+        );
 
         if ($result) {
             return $result;

--- a/tests/SassSpecTest.php
+++ b/tests/SassSpecTest.php
@@ -441,6 +441,7 @@ class SassSpecTest extends TestCase
                 $hasInput  = false;
                 $hasOutput = false;
                 $baseDir = '';
+                $hasSupportedInput = false;
 
                 $parts = explode('<===>', $subTest);
 
@@ -467,6 +468,7 @@ class SassSpecTest extends TestCase
                             break;
 
                         case 'input.scss':
+                        case 'input.sass':
                             if (! $subNname && $subDir) {
                                 $subNname = '/' . $subDir;
                             }
@@ -477,6 +479,7 @@ class SassSpecTest extends TestCase
 
                             $baseDir = $subDir;
                             $hasInput = true;
+                            $hasSupportedInput = $what === 'input.scss';
                             $input = $part;
                             break;
 
@@ -504,7 +507,7 @@ class SassSpecTest extends TestCase
                             break;
 
                         default:
-                            if ($what && (substr($what, -5) === '.scss' || substr($what, -4) === '.css')) {
+                            if ($what && (substr($what, -5) === '.scss' || substr($what, -5) === '.sass' || substr($what, -4) === '.css')) {
                                 if (strpos($first, '/') !== false) {
                                     $includes[$first] = $part;
                                 } else {
@@ -556,7 +559,10 @@ class SassSpecTest extends TestCase
                     [$output, $warning, $error, $alternativeOutputs]
                 ];
 
-                if (
+                if ($hasInput && !$hasSupportedInput) {
+                    // this is a test using the sass indented syntax for the input
+                    $skippedTests[] = $test;
+                } elseif (
                     ! $hasInput ||
                     (! $hasOutput && ! $error) ||
                     strlen($input) > $sizeLimit

--- a/tests/specs/sass-spec-exclude.txt
+++ b/tests/specs/sass-spec-exclude.txt
@@ -698,7 +698,6 @@ directives/extend/after_target/multiple_recursive
 directives/forward/escaped
 directives/if/escaped/if_only
 directives/if/escaped/with_else
-directives/import/error/conflict/extension
 directives/import/escaped
 directives/import/load/explicit_extension/sass
 directives/import/load/index/sass


### PR DESCRIPTION
This ensures that imports expected to resolve to a .sass file are resolved properly (and then fail due to the syntax being unsupported) rather than potentially resolving to a totally different .scss file compared to official implementations.

Closes #347 