### PR TITLE
Overhaul the variable registration API

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -5193,11 +5193,48 @@ class Compiler
                 $name = substr($name, 1);
             }
 
-            if (! $parser->parseValue($strValue, $value)) {
+            if (!\is_string($strValue) || ! $parser->parseValue($strValue, $value)) {
                 $value = $this->coerceValue($strValue);
             }
 
             $this->set($name, $value);
+        }
+    }
+
+    /**
+     * Replaces variables.
+     *
+     * @param array<string, mixed> $variables
+     *
+     * @return void
+     */
+    public function replaceVariables(array $variables)
+    {
+        $this->registeredVars = [];
+        $this->addVariables($variables);
+    }
+
+    /**
+     * Replaces variables.
+     *
+     * @param array<string, mixed> $variables
+     *
+     * @return void
+     */
+    public function addVariables(array $variables)
+    {
+        $triggerWarning = false;
+
+        foreach ($variables as $name => $value) {
+            if (!$value instanceof Number && !\is_array($value)) {
+                $triggerWarning = true;
+            }
+
+            $this->registeredVars[$name] = $value;
+        }
+
+        if ($triggerWarning) {
+            @trigger_error('Passing raw values to as custom variables to the Compiler is deprecated. Use "\ScssPhp\ScssPhp\ValueConverter::parseValue" or "\ScssPhp\ScssPhp\ValueConverter::fromPhp" to convert them instead.', E_USER_DEPRECATED);
         }
     }
 
@@ -5212,7 +5249,9 @@ class Compiler
      */
     public function setVariables(array $variables)
     {
-        $this->registeredVars = array_merge($this->registeredVars, $variables);
+        @trigger_error('The method "setVariables" of the Compiler is deprecated. Use the "addVariables" method for the equivalent behavior or "replaceVariables" if merging with previous variables was not desired.');
+
+        $this->addVariables($variables);
     }
 
     /**

--- a/src/ValueConverter.php
+++ b/src/ValueConverter.php
@@ -1,0 +1,153 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp;
+
+use ScssPhp\ScssPhp\Node\Number;
+
+final class ValueConverter
+{
+    // Prevent instantiating it
+    private function __construct()
+    {
+    }
+
+    /**
+     * Parses a value from a Scss source string.
+     *
+     * The returned value is guaranteed to be supported by the
+     * Compiler methods for registering custom variables. No other
+     * guarantee about it is provided. It should be considered
+     * opaque values by the caller.
+     *
+     * @param string $source
+     *
+     * @return mixed
+     */
+    public static function parseValue($source)
+    {
+        $parser = new Parser(__CLASS__);
+
+        if (!$parser->parseValue($source, $value)) {
+            throw new \InvalidArgumentException(sprintf('Invalid value source "%s".', $source));
+        }
+
+        return $value;
+    }
+
+    /**
+     * Converts a PHP value to a Sass value
+     *
+     * The returned value is guaranteed to be supported by the
+     * Compiler methods for registering custom variables. No other
+     * guarantee about it is provided. It should be considered
+     * opaque values by the caller.
+     *
+     * @param mixed $value
+     *
+     * @return mixed
+     */
+    public static function fromPhp($value)
+    {
+        if ($value instanceof Number) {
+            return $value;
+        }
+
+        if (is_array($value) && isset($value[0]) && \in_array($value[0], [Type::T_NULL, Type::T_COLOR, Type::T_KEYWORD, Type::T_LIST, Type::T_MAP, Type::T_STRING])) {
+            return $value;
+        }
+
+        if ($value === null) {
+            return Compiler::$null;
+        }
+
+        if ($value === true) {
+            return Compiler::$true;
+        }
+
+        if ($value === false) {
+            return Compiler::$false;
+        }
+
+        if ($value === '') {
+            return Compiler::$false;
+        }
+
+        if (\is_int($value) || \is_float($value)) {
+            return new Number($value, '');
+        }
+
+        if (!is_string($value)) {
+            throw new \InvalidArgumentException(sprintf('Cannot convert the value of type "%s" to a Sass value.', gettype($value)));
+        }
+
+        if (\is_numeric($value)) {
+            return new Number(floatval($value), '');
+        }
+
+        // hexa color?
+        if (preg_match('/^#([0-9a-f]+)$/i', $value, $m)) {
+            $nofValues = \strlen($m[1]);
+
+            if (\in_array($nofValues, [3, 4, 6, 8])) {
+                $nbChannels = 3;
+                $color      = [];
+                $num        = hexdec($m[1]);
+
+                switch ($nofValues) {
+                    case 4:
+                        $nbChannels = 4;
+                    // then continuing with the case 3:
+                    case 3:
+                        for ($i = 0; $i < $nbChannels; $i++) {
+                            $t = $num & 0xf;
+                            array_unshift($color, $t << 4 | $t);
+                            $num >>= 4;
+                        }
+
+                        break;
+
+                    case 8:
+                        $nbChannels = 4;
+                    // then continuing with the case 6:
+                    case 6:
+                        for ($i = 0; $i < $nbChannels; $i++) {
+                            array_unshift($color, $num & 0xff);
+                            $num >>= 8;
+                        }
+
+                        break;
+                }
+
+                if ($nbChannels === 4) {
+                    if ($color[3] === 255) {
+                        $color[3] = 1; // fully opaque
+                    } else {
+                        $color[3] = round($color[3] / 255, Number::PRECISION);
+                    }
+                }
+
+                array_unshift($color, Type::T_COLOR);
+
+                return $color;
+            }
+        }
+
+        if ($rgba = Colors::colorNameToRGBa(strtolower($value))) {
+            return isset($rgba[3])
+                ? [Type::T_COLOR, $rgba[0], $rgba[1], $rgba[2], $rgba[3]]
+                : [Type::T_COLOR, $rgba[0], $rgba[1], $rgba[2]];
+        }
+
+        return [Type::T_KEYWORD, $value];
+    }
+}

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -15,6 +15,7 @@ namespace ScssPhp\ScssPhp\Tests;
 use PHPUnit\Framework\TestCase;
 use ScssPhp\ScssPhp\Compiler;
 use ScssPhp\ScssPhp\Node\Number;
+use ScssPhp\ScssPhp\ValueConverter;
 use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 
 /**
@@ -130,9 +131,8 @@ class ApiTest extends TestCase
         $this->scss = new Compiler();
 
         $basePath = __DIR__ . \DIRECTORY_SEPARATOR . 'inputs';
-        $basePathAsScss = '"' . str_replace('\\', '\\\\', $basePath) . '"';
 
-        $this->scss->setVariables(['base-path' => $basePathAsScss]);
+        $this->scss->addVariables(['base-path' => ValueConverter::fromPhp($basePath)]);
         $this->scss->addImportPath(__DIR__ . \DIRECTORY_SEPARATOR . 'inputs');
 
         $this->assertEquals(
@@ -148,7 +148,7 @@ class ApiTest extends TestCase
     {
         $this->scss = new Compiler();
 
-        $this->scss->setVariables($variables);
+        $this->scss->replaceVariables(array_map('ScssPhp\ScssPhp\ValueConverter::parseValue', $variables));
 
         $this->assertEquals($expected, $this->compile($scss));
     }
@@ -183,8 +183,8 @@ class ApiTest extends TestCase
                 ".default {\n  color: red;\n}",
                 '$color: red;' . "\n" . '.default { color: $color; }',
                 [
-                ],
                     'color' => 'blue',
+                ],
             ],
             // override !default
             [


### PR DESCRIPTION
The new API has 2 methods. One adding new variables (like the old setVariables but with a name reflecting its behavior) and one replacing all variables.
Values are expected to be converted to sass values using the new ValueConverter API before being passed to the Compiler registration methods (passing non-converted values triggers a deprecation warning). This prepares for the refactoring of the representation of values scheduled for a 2.x release, in which the ValueConverter will return values using the new API. Because of that, the type returned by the ValueConverter should be treated as opaque.

Closes #309 