### PR TITLE
Deprecate returning a PHP value from function implementations

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -796,6 +796,11 @@ parameters:
 			path: src/Compiler.php
 
 		-
+			message: "#^Method ScssPhp\\\\ScssPhp\\\\Compiler\\:\\:getTypeOf\\(\\) has parameter \\$value with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Compiler.php
+
+		-
 			message: "#^Method ScssPhp\\\\ScssPhp\\\\Compiler\\:\\:getVariables\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Compiler.php
@@ -932,6 +937,16 @@ parameters:
 
 		-
 			message: "#^Method ScssPhp\\\\ScssPhp\\\\Compiler\\:\\:listSeparatorForJoin\\(\\) has parameter \\$sep with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Compiler.php
+
+		-
+			message: "#^Method ScssPhp\\\\ScssPhp\\\\Compiler\\:\\:mapHasKey\\(\\) has parameter \\$keyValue with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Compiler.php
+
+		-
+			message: "#^Method ScssPhp\\\\ScssPhp\\\\Compiler\\:\\:mapHasKey\\(\\) has parameter \\$map with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Compiler.php
 

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -38,8 +38,28 @@ class ApiTest extends TestCase
 
         $this->scss->registerFunction('add-two', function ($args) {
             list($a, $b) = $args;
+            return new Number($a[1] + $b[1], '');
+        }, ['number1', 'number2']);
+
+        $this->assertEquals(
+            'result: 30;',
+            $this->compile('result: add-two(10, 20);')
+        );
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testUserFunctionCoercedValue()
+    {
+        $this->scss = new Compiler();
+
+        $this->scss->registerFunction('add-two', function ($args) {
+            list($a, $b) = $args;
             return $a[1] + $b[1];
         }, ['number1', 'number2']);
+
+        $this->expectDeprecation('Returning a PHP value from the "add-two" custom function is deprecated. A sass value must be returned instead.');
 
         $this->assertEquals(
             'result: 30;',
@@ -97,7 +117,7 @@ class ApiTest extends TestCase
         $this->scss->registerFunction(
             'divide',
             function ($args, $kwargs) {
-                return $kwargs['dividend'][1] / $kwargs['divisor'][1];
+                return new Number($kwargs['dividend'][1] / $kwargs['divisor'][1], '');
             },
             ['dividend', 'divisor']
         );


### PR DESCRIPTION
This enforces that functions return a proper sass value instead.
Returning null is still allowed as this is used as a special case to render a css function instead. This case will stay supported until the refactoring of values and function signatures.

This avoids using the guessing-based value coercion for returned values. Functions must manage themselves what they return (custom functions might decide to use the ValueConverter from #355 but core functions always implement the logic directly as they know what they want to return).