### PR TITLE
Remove invalid tests

### DIFF
--- a/tests/inputs/builtins.scss
+++ b/tests/inputs/builtins.scss
@@ -196,7 +196,6 @@
   a: alpha(#fff);
   a: alpha(rgb(0, 0, 0));
   a: alpha(rgba(0, 0, 0, 0.5));
-  a: alpha(currentColor);
 }
 
 $a-false-value: false;

--- a/tests/inputs/extends.scss
+++ b/tests/inputs/extends.scss
@@ -31,10 +31,6 @@ hello {
     @extend .cool, .blue;
 }
 
-.hoverlink { @extend a:hover }
-a:hover { text-decoration: underline }
-
-
 // partial matching and selector merging:
 
 div.hello.world.hmm {
@@ -251,9 +247,9 @@ body{
 }
 
 .foo{
-   &__bar#test{background:red;}
+   &__bar{background:red;}
 }
-input{@extend .foo__bar#test;}
+input{@extend .foo__bar;}
 
 .selector1 {
     color: blue;

--- a/tests/inputs/media.scss
+++ b/tests/inputs/media.scss
@@ -1,8 +1,5 @@
 
 // media syntax
-@media {
-    div { color: blue; }
-}
 @media what {
     div { color: blue; }
 }
@@ -21,18 +18,18 @@
 $navbarCollapseWidth: 940px;
 
 @media (max-width: $navbarCollapseWidth) {
-  color: red;
+    a {
+        color: red;
+    }
 }
 
 // media bubbling
 @media not hello and (world) {
-   color: blue;
    pre {
        color: blue;
    }
 
    @media butt {
-       color: red;
        div {
            color: red;
        }
@@ -41,25 +38,33 @@ $navbarCollapseWidth: 940px;
 
 @media a, b {
     @media c {
-        color: blue;
+        a {
+            color: blue;
+        }
     }
 }
 
 @media a{
     @media b, c {
-        color: blue;
+        a {
+            color: blue;
+        }
     }
 }
 
 @media a, b{
     @media c, d {
-        color: blue;
+        a {
+            color: blue;
+        }
     }
 }
 
 @media all, b {
     @media c {
-      color: blue;
+        a {
+            color: blue;
+        }
     }
 }
 
@@ -102,11 +107,11 @@ div {
   width: 300px;
   height: 100px;
   background: #eee;
-   
+
   :hover {
     background: #aaa;
   }
-   
+
   @media only screen and (max-width : 300px){
     width: 100px;
     height: 100px;
@@ -125,7 +130,7 @@ code {
 
 dt {
     @media screen {
-        @media (color: blue) {
+        @media (color: 8) {
             height: 10px;
         }
     }
@@ -139,7 +144,7 @@ dt {
     @media only screen {
         .only-screen {
             height: 11px;
-        }    
+        }
     }
 }
 
@@ -150,7 +155,7 @@ dt {
     @media only screen {
         .only-screen {
             height: 16px;
-        }    
+        }
     }
 }
 
@@ -203,8 +208,8 @@ dt {
 }
 
 @media only screen {
-    @media screen and (color: blue) {
-        @media screen and (width: 13) {
+    @media screen and (color: 8) {
+        @media screen and (width: 13px) {
             .only-screen {
                 height: 15px;
             }

--- a/tests/outputs/builtins.css
+++ b/tests/outputs/builtins.css
@@ -145,7 +145,6 @@
   a: 1;
   a: 1;
   a: 0.5;
-  a: alpha(currentColor);
 }
 #exists {
   a: true;

--- a/tests/outputs/extends.css
+++ b/tests/outputs/extends.css
@@ -17,9 +17,6 @@ hello div {
 .blue, .me {
   color: purple;
 }
-a:hover, .hoverlink, #demo .overview .fakelink:hover {
-  text-decoration: underline;
-}
 div.hello.world.hmm, pre div.world.hmm.okay.span, pre #butt .umm div.world.hmm.span.sure, #butt .umm pre div.world.hmm.span.sure, code div.world.hmm.okay.span, code #butt .umm div.world.hmm.span.sure, #butt .umm code div.world.hmm.span.sure {
   color: blue;
 }
@@ -127,7 +124,7 @@ body .to-extend, body .test {
   text-shadow: none;
   color: #fff;
 }
-.foo__bar#test, input {
+.foo__bar, input {
   background: red;
 }
 .selector1, .master-class {

--- a/tests/outputs/media.css
+++ b/tests/outputs/media.css
@@ -1,8 +1,3 @@
-@media {
-  div {
-    color: blue;
-  }
-}
 @media what {
   div {
     color: blue;
@@ -24,24 +19,26 @@
   }
 }
 @media (max-width: 940px) {
-  color: red;
+  a {
+    color: red;
+  }
 }
 @media not hello and (world) {
-  color: blue;
   pre {
     color: blue;
   }
 }
 @media not hello and (world) {
   @media butt {
-    color: red;
     div {
       color: red;
     }
   }
 }
 @media c {
-  color: blue;
+  a {
+    color: blue;
+  }
 }
 div {
   color: blue;
@@ -92,7 +89,7 @@ code {
     height: 20px;
   }
 }
-@media screen and (color: blue) {
+@media screen and (color: 8) {
   dt {
     height: 10px;
   }
@@ -132,7 +129,7 @@ code {
     height: 15px;
   }
 }
-@media only screen and (color: blue) and (width: 13) {
+@media only screen and (color: 8) and (width: 13px) {
   .only-screen {
     height: 15px;
   }


### PR DESCRIPTION
This is continuing my work to ensure that our own test fixtures are not enforcing invalid scss.

After this PR, we are left with only 3 files triggering errors in dart-sass:
- `comments.scss` because it covers our non-standard support for broken interpolation in comments. This one also fails in libsass. I'd like to find a way to deprecate that behavior, but I need to spend more time on this to understand the logic.
- `operators.scss` because it uses color math. This one does not trigger errors in libsass (we might want to split it in 2)
- `extending_compound_selector.scss` because extending compound selectors is deprecated in libsass and unsupported in dart-sass. That's already a dedicated fixture file.