### PR TITLE
Fix the handling of min and max without arguments

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -3624,7 +3624,7 @@ class Compiler
 
                 // special cases of css valid functions min/max
                 $name = strtolower($name);
-                if (\in_array($name, ['min', 'max'])) {
+                if (\in_array($name, ['min', 'max']) && count($argValues) >= 1) {
                     $cssFunction = $this->cssValidArg(
                         [Type::T_FUNCTION_CALL, $name, $argValues],
                         ['min', 'max', 'calc', 'env', 'var']

--- a/tests/specs/sass-spec-exclude.txt
+++ b/tests/specs/sass-spec-exclude.txt
@@ -267,8 +267,6 @@ core_functions/map/merge/nested/overlapping_keys
 core_functions/map/merge/nested/same_keys
 core_functions/map/values/empty
 core_functions/map/values/single
-core_functions/math/max/error/too_few_args
-core_functions/math/min/error/too_few_args
 core_functions/math/round/up/within_precision
 core_functions/math/unit/error/type
 core_functions/math/unitless/error/type


### PR DESCRIPTION
A call without arguments must not be treated like a CSS function call.