### PR TITLE
Refactor the implementation of the call function

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -7456,7 +7456,7 @@ class Compiler
     protected static $libCall = ['function', 'args...'];
     protected function libCall($args, $kwargs)
     {
-        $functionReference = array_shift($args);
+        $functionReference = $args[0];
 
         if (in_array($functionReference[0], [Type::T_STRING, Type::T_KEYWORD])) {
             $name = $this->compileStringContent($this->coerceString($functionReference));
@@ -7474,18 +7474,9 @@ class Compiler
             throw $this->error('Function reference expected, got ' . $functionReference[0]);
         }
 
-        $callArgs = [];
-
-        // $kwargs['args'] is [Type::T_LIST, ',', [..]]
-        foreach ($kwargs['args'][2] as $varname => $arg) {
-            if (is_numeric($varname)) {
-                $varname = null;
-            } else {
-                $varname = [ 'var', $varname];
-            }
-
-            $callArgs[] = [$varname, $arg, false];
-        }
+        $callArgs = [
+            [null, $args[1], true]
+        ];
 
         return $this->reduce([Type::T_FUNCTION_CALL, $functionReference, $callArgs]);
     }


### PR DESCRIPTION
Instead of trying to evaluate arguments on its own, it now calls the function with a rest argument instead, which is resolved by the normal handling of arguments. this allows to simplify the logic and avoid relying on the internal representation of sass argument lists there.
This is consistent with the way dart-sass implements it.

This is equivalent to this userland implementation, except of course that function names cannot be dynamic (it makes them CSS function calls) which is precisely why `call()` exists in core:
```scss
@function call($function, $args...) {
  // Validate the type of function
  @return #{$function}($args...);
}
```

This refactoring helps with my upcoming refactoring of the way argument lists are handled.