### PR TITLE
Rebuild the list of excluded specs

### DIFF
--- a/tests/specs/sass-spec-exclude.txt
+++ b/tests/specs/sass-spec-exclude.txt
@@ -859,7 +859,6 @@ libsass-closed-issues/issue_713/and
 libsass-closed-issues/issue_713/not
 libsass-closed-issues/issue_713/or
 libsass-closed-issues/issue_72
-libsass-closed-issues/issue_760
 libsass-closed-issues/issue_823
 libsass-closed-issues/issue_828
 libsass-closed-issues/issue_829


### PR DESCRIPTION
#362 actually fixed one more failing spec, but not in the initial version where I rebuilt the specs. It was only unlocked later on.