### PR TITLE
Refactor the implementation of sass argument lists

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -766,6 +766,11 @@ parameters:
 			path: src/Compiler.php
 
 		-
+			message: "#^Method ScssPhp\\\\ScssPhp\\\\Compiler\\:\\:getArgumentListKeywords\\(\\) has parameter \\$value with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Compiler.php
+
+		-
 			message: "#^Method ScssPhp\\\\ScssPhp\\\\Compiler\\:\\:getBuiltinFunction\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Compiler.php

--- a/tests/specs/sass-spec-exclude.txt
+++ b/tests/specs/sass-spec-exclude.txt
@@ -295,8 +295,6 @@ core_functions/meta/inspect/list/nested/comma/in_space/unbracketed
 core_functions/meta/inspect/list/nested/space/in_space/unbracketed
 core_functions/meta/inspect/map/list/key/comma
 core_functions/meta/inspect/map/list/value/comma
-core_functions/meta/keywords/empty/positional
-core_functions/meta/keywords/error/type/non_arg_list
 core_functions/meta/mixin_exists/error/argument/type/name
 core_functions/meta/variable_exists/error/argument/type
 core_functions/selector/append/error/leading_combinator


### PR DESCRIPTION
Argument lists are expected to be a list containing positional arguments, with a way to access named arguments. The representation of the value was mixing the named arguments with the positional ones in the list, which was breaking the usage as a list (not covered by sass-spec) and also returning wrong data in the `keywords` function.
This is fixing bugs for the usage of an argument list in Sass code.
This is technically a BC break for custom host function that expect to accept arbitrary named arguments while declaring arguments explicitly. However, this is considered OK. This representation of argument lists is not documented anywhere. And in previous releases of scssphp, there was no such usages in the core either to allow discovering how to do it (change-color, scale-color and adjust-color) were not implemented in terms of a rest argument). The documentation about implementing custom functions was showing how to achieve this for a function without an argument declaration only. So it is unlikely that anyone discovered how to do it in a way impacted by the BC break.