### PR TITLE
Add a public helper to get the text of a Sass string

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -791,6 +791,11 @@ parameters:
 			path: src/Compiler.php
 
 		-
+			message: "#^Method ScssPhp\\\\ScssPhp\\\\Compiler\\:\\:getStringText\\(\\) has parameter \\$value with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Compiler.php
+
+		-
 			message: "#^Method ScssPhp\\\\ScssPhp\\\\Compiler\\:\\:getVariables\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Compiler.php

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -4679,6 +4679,25 @@ class Compiler
     }
 
     /**
+     * Gets the text of a Sass string
+     *
+     * Calling this method on anything else than a SassString is unsupported. Use {@see assertString} first
+     * to ensure that the value is indeed a string.
+     *
+     * @param array $value
+     *
+     * @return string
+     */
+    public function getStringText(array $value)
+    {
+        if ($value[0] !== Type::T_STRING) {
+            throw new \InvalidArgumentException('The argument is not a sass string. Did you forgot to use "assertString"?');
+        }
+
+        return $this->compileValue($value);
+    }
+
+    /**
      * Compile string content
      *
      * @param array $string
@@ -7079,12 +7098,17 @@ class Compiler
     }
 
     /**
-     * Assert value is a string (or keyword)
+     * Assert value is a string
+     *
+     * This method deals with internal implementation details of the value
+     * representation where unquoted strings can sometimes be stored under
+     * other types.
+     * The returned value is always using the T_STRING type.
      *
      * @api
      *
      * @param array|Number $value
-     * @param string $varName
+     * @param string|null  $varName
      *
      * @return array
      *


### PR DESCRIPTION
This is necessary to allow implementing custom functions dealing with sass strings as argument through an external callback rather than extending the Compiler class.
This does not directly expose `compileStringContent` for 2 reasons:
- the name is a lot less clear about the intent
- it would expose the second argument, which is internal