### PR TITLE
Enforce defining arguments for all functions

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1246,11 +1246,6 @@ parameters:
 			path: src/Compiler.php
 
 		-
-			message: "#^Method ScssPhp\\\\ScssPhp\\\\Compiler\\:\\:registerFunction\\(\\) has parameter \\$prototype with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Compiler.php
-
-		-
 			message: "#^Method ScssPhp\\\\ScssPhp\\\\Compiler\\:\\:replaceSelfSelector\\(\\) has parameter \\$selectors with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Compiler.php

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -5520,19 +5520,23 @@ class Compiler
      *
      * @api
      *
-     * @param string   $name
-     * @param callable $func
-     * @param array|null $prototype
+     * @param string        $name
+     * @param callable      $callback
+     * @param string[]|null $argumentDeclaration
      *
      * @return void
      */
-    public function registerFunction($name, $func, $prototype = null)
+    public function registerFunction($name, $callback, $argumentDeclaration = null)
     {
         if (self::isNativeFunction($name)) {
             @trigger_error(sprintf('The "%s" function is a core sass function. Overriding it with a custom implementation through "%s" is deprecated and won\'t be supported in ScssPhp 2.0 anymore.', $name, __METHOD__), E_USER_DEPRECATED);
         }
 
-        $this->userFunctions[$this->normalizeName($name)] = [$func, $prototype];
+        if ($argumentDeclaration === null) {
+            @trigger_error('Omitting the argument declaration when registering custom function is deprecated and won\'t be supported in ScssPhp 2.0 anymore.', E_USER_DEPRECATED);
+        }
+
+        $this->userFunctions[$this->normalizeName($name)] = [$callback, $argumentDeclaration];
     }
 
     /**

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -8467,6 +8467,7 @@ will be an error in future versions of Sass.\n         on line $line of $fname";
         return new Number(abs($num->getDimension()), $num->getNumeratorUnits(), $num->getDenominatorUnits());
     }
 
+    protected static $libMin = ['numbers...'];
     protected function libMin($args)
     {
         /**
@@ -8474,7 +8475,7 @@ will be an error in future versions of Sass.\n         on line $line of $fname";
          */
         $min = null;
 
-        foreach ($args as $arg) {
+        foreach ($args[0][2] as $arg) {
             $number = $this->assertNumber($arg);
 
             if (\is_null($min) || $min->greaterThan($number)) {
@@ -8489,6 +8490,7 @@ will be an error in future versions of Sass.\n         on line $line of $fname";
         throw $this->error('At least one argument must be passed.');
     }
 
+    protected static $libMax = ['numbers...'];
     protected function libMax($args)
     {
         /**
@@ -8496,7 +8498,7 @@ will be an error in future versions of Sass.\n         on line $line of $fname";
          */
         $max = null;
 
-        foreach ($args as $arg) {
+        foreach ($args[0][2] as $arg) {
             $number = $this->assertNumber($arg);
 
             if (\is_null($max) || $max->lessThan($number)) {

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -8807,21 +8807,23 @@ will be an error in future versions of Sass.\n         on line $line of $fname";
         return $res;
     }
 
+    protected static $libZip = ['lists...'];
     protected function libZip($args)
     {
-        foreach ($args as $key => $arg) {
-            $args[$key] = $this->coerceList($arg);
+        $argLists = [];
+        foreach ($args[0][2] as $arg) {
+            $argLists[] = $this->coerceList($arg);
         }
 
         $lists = [];
-        $firstList = array_shift($args);
+        $firstList = array_shift($argLists);
 
         $result = [Type::T_LIST, ',', $lists];
         if (! \is_null($firstList)) {
             foreach ($firstList[2] as $key => $item) {
                 $list = [Type::T_LIST, '', [$item]];
 
-                foreach ($args as $arg) {
+                foreach ($argLists as $arg) {
                     if (isset($arg[2][$key])) {
                         $list[2][] = $arg[2][$key];
                     } else {

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -39,7 +39,7 @@ class ApiTest extends TestCase
         $this->scss->registerFunction('add-two', function ($args) {
             list($a, $b) = $args;
             return $a[1] + $b[1];
-        });
+        }, ['number1', 'number2']);
 
         $this->assertEquals(
             'result: 30;',
@@ -53,12 +53,27 @@ class ApiTest extends TestCase
 
         $this->scss->registerFunction('get-null', function ($args) {
             return Compiler::$null;
-        });
+        }, []);
 
         $this->assertEquals(
             '',
             $this->compile('result: get-null();')
         );
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testUserFunctionWithoutArgumentDeclaration()
+    {
+        $this->scss = new Compiler();
+
+        $this->expectDeprecation('Omitting the argument declaration when registering custom function is deprecated and won\'t be supported in ScssPhp 2.0 anymore.');
+
+        $this->scss->registerFunction('get-null', function () {
+            return Compiler::$null;
+        });
+
     }
 
     /**
@@ -72,7 +87,7 @@ class ApiTest extends TestCase
 
         $compiler->registerFunction('blue', function ($args) {
             return Compiler::$null;
-        });
+        }, []);
     }
 
     public function testUserFunctionKwargs()

--- a/tests/CompilerTest.php
+++ b/tests/CompilerTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace ScssPhp\ScssPhp\Tests;
+
+use ScssPhp\ScssPhp\Compiler;
+use PHPUnit\Framework\TestCase;
+
+class CompilerTest extends TestCase
+{
+    /**
+     * @dataProvider provideSassFunctionMethods
+     */
+    public function testArgumentDeclaration($method)
+    {
+        $r = new \ReflectionClass(Compiler::class);
+
+        $this->assertTrue($r->hasProperty($method));
+
+        $p = $r->getProperty($method);
+
+        $this->assertTrue($p->isStatic());
+    }
+
+    public static function provideSassFunctionMethods()
+    {
+        $r = new \ReflectionClass(Compiler::class);
+
+        foreach ($r->getMethods() as $method) {
+            if (0 !== strpos($method->name, 'lib')) {
+                continue;
+            }
+
+            yield $method->name => [$method->name];
+        }
+    }
+}


### PR DESCRIPTION
This deprecates registering custom functions through `registerFunction` without providing the argument declaration (formerly called `prototype` but I renamed the argument to help understanding it).
This also adds a test ensuring that all core functions are declaring their arguments (and it fixes the few missing ones found by that test).
There is still another way to register functions: extending the compiler and using our `lib*` naming convention. This one does not check for missing argument declarations, but it is already deprecated anyway.

Closes #368 