### PR TITLE
Rework the ValueConverter

### DIFF
--- a/src/ValueConverter.php
+++ b/src/ValueConverter.php
@@ -79,75 +79,17 @@ final class ValueConverter
         }
 
         if ($value === '') {
-            return Compiler::$false;
+            return Compiler::$emptyString;
         }
 
         if (\is_int($value) || \is_float($value)) {
             return new Number($value, '');
         }
 
-        if (!is_string($value)) {
-            throw new \InvalidArgumentException(sprintf('Cannot convert the value of type "%s" to a Sass value.', gettype($value)));
+        if (\is_string($value)) {
+            return [Type::T_STRING, '"', [$value]];
         }
 
-        if (\is_numeric($value)) {
-            return new Number(floatval($value), '');
-        }
-
-        // hexa color?
-        if (preg_match('/^#([0-9a-f]+)$/i', $value, $m)) {
-            $nofValues = \strlen($m[1]);
-
-            if (\in_array($nofValues, [3, 4, 6, 8])) {
-                $nbChannels = 3;
-                $color      = [];
-                $num        = hexdec($m[1]);
-
-                switch ($nofValues) {
-                    case 4:
-                        $nbChannels = 4;
-                    // then continuing with the case 3:
-                    case 3:
-                        for ($i = 0; $i < $nbChannels; $i++) {
-                            $t = $num & 0xf;
-                            array_unshift($color, $t << 4 | $t);
-                            $num >>= 4;
-                        }
-
-                        break;
-
-                    case 8:
-                        $nbChannels = 4;
-                    // then continuing with the case 6:
-                    case 6:
-                        for ($i = 0; $i < $nbChannels; $i++) {
-                            array_unshift($color, $num & 0xff);
-                            $num >>= 8;
-                        }
-
-                        break;
-                }
-
-                if ($nbChannels === 4) {
-                    if ($color[3] === 255) {
-                        $color[3] = 1; // fully opaque
-                    } else {
-                        $color[3] = round($color[3] / 255, Number::PRECISION);
-                    }
-                }
-
-                array_unshift($color, Type::T_COLOR);
-
-                return $color;
-            }
-        }
-
-        if ($rgba = Colors::colorNameToRGBa(strtolower($value))) {
-            return isset($rgba[3])
-                ? [Type::T_COLOR, $rgba[0], $rgba[1], $rgba[2], $rgba[3]]
-                : [Type::T_COLOR, $rgba[0], $rgba[1], $rgba[2]];
-        }
-
-        return [Type::T_KEYWORD, $value];
+        throw new \InvalidArgumentException(sprintf('Cannot convert the value of type "%s" to a Sass value.', gettype($value)));
     }
 }


### PR DESCRIPTION
PHP strings are now always converted to Sass strings in `fromPhp` instead of trying to parse them as colors or numbers. This reduces the risk of surprise when using the API. To parse colors in hex format or color names, the `parseValue` method should be used instead.

This also fixes a bug in the conversion of empty strings.