### PR TITLE
Upgrade sass-spec

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,16 +48,16 @@
             "type": "package",
             "package": {
                 "name": "sass/sass-spec",
-                "version": "2021.05.05",
+                "version": "2021.05.06",
                 "source": {
                     "type": "git",
                     "url": "https://github.com/sass/sass-spec.git",
-                    "reference": "17effffaf45a67396d71e25c5966e12460b5b358"
+                    "reference": "bbf590f53f07a5cf63f57845d855f00eeffa32d9"
                 },
                 "dist": {
                     "type": "zip",
-                    "url": "https://api.github.com/repos/sass/sass-spec/zipball/17effffaf45a67396d71e25c5966e12460b5b358",
-                    "reference": "17effffaf45a67396d71e25c5966e12460b5b358",
+                    "url": "https://api.github.com/repos/sass/sass-spec/zipball/bbf590f53f07a5cf63f57845d855f00eeffa32d9",
+                    "reference": "bbf590f53f07a5cf63f57845d855f00eeffa32d9",
                     "shasum": ""
                 }
             }

--- a/tests/specs/sass-spec-exclude.txt
+++ b/tests/specs/sass-spec-exclude.txt
@@ -577,6 +577,8 @@ core_functions/selector/unify/simple/universal/and_universal/explicit/and_any
 core_functions/selector/unify/simple/universal/and_universal/explicit/and_default
 core_functions/selector/unify/simple/universal/and_universal/explicit/and_empty
 core_functions/string/unquote/error/type
+css/comment/error/loud/interpolation/failure
+css/comment/error/loud/interpolation/unterminated
 css/comment/error/loud/unterminated/scss
 css/custom_properties/error/brackets/curly
 css/custom_properties/error/brackets/curly_in_square


### PR DESCRIPTION
the newly excluded tests are the ones mentioned in #364 which enforce that interpolation works normally in loud comments rather than silently ignoring errors like we do (with a deprecation warning)