### PR TITLE
Expose isTruthy as a public compiler helper

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -3376,7 +3376,7 @@ class Compiler
      *
      * @return boolean
      */
-    protected function isTruthy($value)
+    public function isTruthy($value)
     {
         return $value !== static::$false && $value !== static::$null;
     }


### PR DESCRIPTION
This avoids duplicating the logic when implementing custom functions.