### PR TITLE
Rewrite the documentation

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,2 +1,2 @@
 source 'https://rubygems.org'
-gem 'github-pages'
+gem 'github-pages', '~> 214', group: :jekyll_plugins

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -20,6 +20,14 @@ exclude:
 # Github Pages
 github: [Repository metadata]
 plugins:
+# Default gh-pages plugins
+- jekyll-commonmark-ghpages
+- jekyll-relative-links
+- jekyll-optional-front-matter
+- jekyll-readme-index
+- jekyll-default-layout
+- jekyll-titles-from-headings
+# Additional plugins
 - jekyll-mentions
 - jemoji
 - jekyll-redirect-from

--- a/docs/_sass/_leafo.scss
+++ b/docs/_sass/_leafo.scss
@@ -268,5 +268,6 @@ p {
         border: 1px solid #222;
         padding: 10px;
         margin: 0 0 15px;
+        overflow-x: auto;
     }
 }

--- a/docs/_sass/_leafo.scss
+++ b/docs/_sass/_leafo.scss
@@ -170,6 +170,7 @@ body {
     overflow: hidden;
     color: $text_color;
     font-size: 18px;
+    line-height: 1.5;
     padding-bottom: 20px;
 
     .inner {
@@ -239,14 +240,10 @@ body {
     }
 }
 
-
-p {
-    line-height: 150%;
-    code {
-        background: rgba(0,0,0, 0.1);
-        border-radius: 4px;
-        padding: 1px 4px;
-    }
+:not(pre) > code {
+    background: rgba(0,0,0, 0.1);
+    border-radius: 4px;
+    padding: 1px 4px;
 }
 
 .comments {

--- a/docs/community/index.md
+++ b/docs/community/index.md
@@ -67,6 +67,6 @@ allow others to use your modifications and give credit to [Sass][3],
 [Ubuntu][1], and [Drupal][2].
 
   [0]: https://creativecommons.org/licenses/by-sa/3.0/us/
-  [1]: http://www.ubuntu.com/about/about-ubuntu/conduct
+  [1]: https://www.ubuntu.com/about/about-ubuntu/conduct
   [2]: https://www.drupal.org/dcoc
-  [3]: http://sass-lang.com/community-guidelines
+  [3]: https://sass-lang.com/community-guidelines

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -1,11 +1,6 @@
----
-layout: default
-title: Changelog
----
+# Changelog
 
-## Changelog
-
-### **1.4.1** -- Jan 4, 2021
+## **1.4.1** -- Jan 4, 2021
 
 * Fix support for absolute paths in imports (stof)
 * Fix support for custom properties in plain CSS imports (willpower232)
@@ -16,7 +11,7 @@ title: Changelog
 * Fix the parser to apply `realpath` to the path used for error reporting as well (Cerdic)
 * Fix the phpdoc in the Compiler (stof)
 
-### **1.4** -- Nov 7, 2020
+## **1.4** -- Nov 7, 2020
 
 * fix the injection of the `@charset` rule without mbstring (stof)
 * Add a CI job running tests without mbstring (stof)
@@ -43,7 +38,7 @@ title: Changelog
 * Fix the implementation of modulo (stof)
 * Mark the `units-level-3` feature as implemented (stof)
 
-### **1.3** -- Oct 29, 2020
+## **1.3** -- Oct 29, 2020
   * Better `quote()` compliance (Cerdic)
   * Improve string compliance with sass-spec (Cerdic)
   * Fix issue with argument values being swapped (jljr222, Cerdic)
@@ -59,7 +54,7 @@ title: Changelog
   * Move `gh-pages` to `/docs` folder on main branch (stof, robocoder)
   * Add php 8 support for phpunit (adlenton)
 
-### **1.2.1** -- Sep 7, 2020
+## **1.2.1** -- Sep 7, 2020
   * Fix `@import url()` parsing (leonardfischer, Cerdic)
   * Fix various directive parsing issues (zoglo, CatoTH, Cerdic)
   * Fix `min()`, `max()` (Cerdic)
@@ -69,7 +64,7 @@ title: Changelog
   * Fix `random()` (Cerdic)
   * Fix `list-separator()` on empty or one element list (Cerdic)
 
-### **1.2** -- Aug 26, 2020
+## **1.2** -- Aug 26, 2020
   * Many, many sass-spec test improvements (stof, Cerdic)
   * Partial fix of special cases in hsl/hsla functions (Cerdic)
   * In certain interpolations, the spec seems to prefer to force a double quote for output strings (Cerdic)
@@ -120,7 +115,7 @@ title: Changelog
   * Update to PSR-12 (robocoder)
   * Add php 8 nightly to Travis CI (robocoder)
 
-### **1.1.1** -- Jun 4, 2020
+## **1.1.1** -- Jun 4, 2020
   * Fix extend and class concatenation (develth, Cerdic)
   * Fix arguments selector issue (stempora, Cerdic)
   * Fix regression when members units are not normalizable (jszczypk, Cerdic)
@@ -128,14 +123,14 @@ title: Changelog
   * 32-bit fixes for Base64VLQ `encode()` and `unique-id()` (remicollet, robocoder)
   * Fix index of map within list of maps (stempora, robocoder)
 
-### **1.1.0** -- Apr 21, 2020
+## **1.1.0** -- Apr 21, 2020
   * Fix the handling of call traces for exceptions of native functions (stof)
   * Add named call stack entries for imports (stof)
   * Fix leaks in the call stack (stof)
   * Qualify function calls when the compiler can optimize them (stof)
   * Remove deprecated Parser::to() and Parser::show() methods (robocoder)
 
-### **1.0.9** -- Apr 1, 2020
+## **1.0.9** -- Apr 1, 2020
   * Fix parsing issues around `#, +, -, --` (Cerdic)
   * Fix `@import` compatibility (Cerdic)
   * Add vendor-prefixed `scssphp-glob()` function (havutcuoglu, robocoder)
@@ -143,7 +138,7 @@ title: Changelog
   * Fix multiple issues with Bootstrap 4.4.1 and master (fuzegit, Cerdic)
   * Fix variables interpolation bug (Seonic, Cerdic)
 
-### **1.0.8** -- Feb 20, 2020
+## **1.0.8** -- Feb 20, 2020
   * Import of valid scss files fails silently (oyejorge, Cerdic)
   * Undefined $libName (enricobono, robocoder)
   * Fix division and modulo per sass-spec (Cerdic)
@@ -151,12 +146,12 @@ title: Changelog
   * Introduce support for custom properties (Cerdic)
   * Function compatibility issues with functions (abs, ceil, floor, max, min, percentage, random, round), units, and conversions. (Cerdic)
 
-### **1.0.7** -- Jan 31, 2020
+## **1.0.7** -- Jan 31, 2020
   * Fix problem with Bootstrap 4.4 / Responsive containers (nvindice, Cerdic)
   * Fix issue with pseudoelement selectors order in `@extend`'ed elements (CrazyManLabs, Cerdic)
   * `example/Server.php` moved to https://github.com/scssphp/server
 
-### **1.0.6** -- Dec 12, 2019
+## **1.0.6** -- Dec 12, 2019
   * Many sass-spec compatibility fixes (Cerdic)
   * Discriminate shorthands vs real divisions in border-radius property (joakipe, Cerdic)
   * Base64VLQ - 32-bit overflow fixes from Closure implementation (remicollet, robocoder)
@@ -165,13 +160,13 @@ title: Changelog
   * Using `@extend` creates invalid output with nested classnames (bmbrands, Cerdic)
   * Fixed sourceMapGenerator bug if semicolons are stripped. (ugogon)
 
-### **1.0.5** -- Oct 3, 2019
+## **1.0.5** -- Oct 3, 2019
   * interpolation fixes (Cerdic)
   * phpunit test updates (stof)
   * undefined sourceIndex (connerbw, robocoder)
   * using is_null(), is_dir(), is_file() for consistency (robocoder)
 
-### **1.0.4** -- Sep 6, 2019
+## **1.0.4** -- Sep 6, 2019
   * `border-radius` shorthand support (alex-shul, Cerdic)
   * allow `zip()` function to use all types as arguments (devdot, Cerdic)
   * `@each` forcing unwanted type conversion (devdot)
@@ -180,17 +175,17 @@ title: Changelog
   * composer and travis configuration updates
   * remove obsolete `Base64VLQEncoder` class
 
-### **1.0.3** -- Aug 7, 2019
+## **1.0.3** -- Aug 7, 2019
   * `@at-root`, `@import`, and `url(//host/image.png)` fixes (Cerdic)
   * join operator with interpolated values vs vars or static values (julienmru, Cerdic)
   * Implemented passing Arguments to Content Blocks (jensniedling, Cerdic)
   * Support whitespaces inside :not() (schliesser)
   * Compile non-roots comments also (fabsn182, Cerdic)
 
-### **1.0.2** -- July 6, 2019
+## **1.0.2** -- July 6, 2019
   * Version: actually bump the version number
 
-### **1.0.1** -- July 6, 2019
+## **1.0.1** -- July 6, 2019
   * Fix iteration on map (alexsaalberg049 , Cerdic)
   * More compatibility with reference implementation (Cerdic)
   * Cache: bump `CACHE_VERSION` (Cerdic)
@@ -198,12 +193,12 @@ title: Changelog
   * travis updates and improved tests (Cerdic)
   * Nested formatted improvements (Cerdic)
 
-### **1.0.0** -- June 4, 2019
+## **1.0.0** -- June 4, 2019
   * Moving development to ScssPhp organization, https://github.com/scssphp/
   * Online documentation can be found at http://scssphp.github.com/scssphp/
   * Renamed namespace from Leafo to ScssPhp
 
-### **0.8.4** -- June 18, 2019
+## **0.8.4** -- June 18, 2019
   * This is the final tag on the leafo/scssphp repo; PHP requirements downgraded to 5.4+ for this repo/package only.
   * Support parent selector and selector functions (Cerdic)
   * Improve `and`/`or` compatibility (robocoder)
@@ -217,7 +212,7 @@ title: Changelog
   * Add source column to thrown error message (slprime, robocoder)
   * Detect invalid CSS outside of selector (JMitnik, robocoder)
 
-### **0.8.3** -- May 31, 2019
+## **0.8.3** -- May 31, 2019
   * grid-template-columns (gKreator, Cerdic)
   * `self` in selector and parse improvements (designerno1, Cerdic)
   * invalid css output when using interpolation with mixins (Jasonkoolman, Cerdic)
@@ -234,10 +229,10 @@ title: Changelog
   * failed interpolation in placeholder (GuidoJansen, Cerdic)
   * parentheses in selector causes loss of whitespace (Netmosfera, Cerdic)
 
-### **0.8.2** -- May 9, 2019
+## **0.8.2** -- May 9, 2019
   * requires php 5.6+
 
-### **0.8.1** -- May 9, 2019
+## **0.8.1** -- May 9, 2019
   * grid-row & grid-column shorthand (claytron5000, Cerdic)
   * `@`mixin `@`supports `@`include compilation error (geoidesic, Cerdic)
   * `@`media expression slicing (tdutrion, Cerdic)
@@ -248,7 +243,7 @@ title: Changelog
   * :not(), :nth-child() and other selectors before `@`extend (STV11C, Cerdic)
   * commentsSeen and phpdoc update (nextend)
 
-### **0.8.0** -- May 2, 2019
+## **0.8.0** -- May 2, 2019
   * Variables from inner override variables in parents (Daijobou, Cerdic)
   * Bootstrap issues with `@`at-root, self (l2a, Cerdic)
   * `@`supports inside rule (Marat-Tanalin, Cerdic)
@@ -257,7 +252,7 @@ title: Changelog
   * Travis test updates (Cerdic)
   * Add Bootstrap and Foundation framework tests (Cerdic)
 
-### **0.7.8** -- April 24, 2019
+## **0.7.8** -- April 24, 2019
   * Partial support for #rrggbbaa CSS Level 4 colors with alpha (charlymz)
   * Avoid infinitely duplicating parts when extending selector (cyberalien)
   * Fix rooted SCSS URIs normalized incorrectly with double slashes (evanceit)
@@ -274,93 +269,93 @@ title: Changelog
   * Generate inline sourcemap in command-line (dexxa)
   * Fix backslash escape (bastianjoel)
 
-### **0.7.7** -- July 21, 2018
+## **0.7.7** -- July 21, 2018
   * Actually merge maps instead of concatenating (s7eph4n)
   * Treat 0 as special unitless number (of2607)
   * Partial fix for call() with ellipsis (gabor-udvari)
   * Misc peephole optimization
 
-### **0.7.6** -- May 23, 2018
+## **0.7.6** -- May 23, 2018
   * `mix()` alpha fix (Uriziel01)
   * `transparentize()` alpha sensitive to locale (leonardfischer, timelsass)
   * notices when compiling UIKit (azjezz)
   * faster parsing for base64 data: url()s (wout)
 
-### **0.7.5** -- February 8, 2018
+## **0.7.5** -- February 8, 2018
   * Fix `for` loop with units (of2607)
   * Fix side-effects in abs(), ceil(), floor(), and round() (jugyhead)
   * Add option for custom SourceMapGenerator (dleffler)
 
-### **0.7.4** -- December 21, 2017
+## **0.7.4** -- December 21, 2017
   * Fat fingered cleanup; broke source maps (dleffler)
 
-### **0.7.3** -- December 19, 2017
+## **0.7.3** -- December 19, 2017
   * Add inline sourcemaps (oyejorge, NicolaF)
   * Add file-based sourcemaps (dleffler)
 
-### **0.7.2** -- December 14, 2017
+## **0.7.2** -- December 14, 2017
   * Change default precision to 10 to match scss 3.5.0
   * Use number_format instead of locale (Arlisaha)
 
-### **0.7.1** -- October 13, 2017
+## **0.7.1** -- October 13, 2017
   * Server moved to exoample/ folder
   * Server::serveFrom() helper removed
   * Removed .phar build
   * Workaround `each()` deprecated in PHP 7.2RC (marinaglancy)
 
-### **0.6.7** -- February 23, 2017
+## **0.6.7** -- February 23, 2017
   * fix list interpolation
   * pscss: enable --line-numbers and --debug-info for stdin
   * checkRange() throws RangeException
 
-### **0.6.6** -- September 10, 2016
+## **0.6.6** -- September 10, 2016
   * Do not extend decorated tags with another tag (FMCorz)
   * Merge shared direct relationship when extending (FMCorz)
   * Extend resolution was generating invalid selectors (FMCorz)
   * Resolve function arguments using mixin content scope (FMCorz)
   * Let `@`content work when a block isn’t passed in. (diemer)
 
-### **0.6.5** -- June 20, 2016
+## **0.6.5** -- June 20, 2016
   * ignore BOM (nwiborg)
   * fix another mixin and variable scope issue (mahagr)
   * Compiler: coerceValue support for #rgb values (thesjg)
   * preserve un-normalized variable name for error message (kissifrot)
 
-### **0.6.4** -- June 15, 2016
+## **0.6.4** -- June 15, 2016
   * parsing multiple assignment flags (Limych)
   * `@`warn should not write to stdout (atomicalnet)
   * evaluating null and/or 'foo' (micranet)
   * case insensitive directives regression (Limych)
   * Compiler: scope change to some properties and methods to facilitate subclassing (jo)
 
-### **0.6.3** -- January 14, 2016
+## **0.6.3** -- January 14, 2016
   * extend + parent + placeholder fix (atna)
   * nested content infinite loop (Lusito)
   * only divide by 100 if percent (jkrehm)
   * Parser: refactoring and performance optimizations (oyejorge)
 
-### **0.6.2** -- December 16, 2015
+## **0.6.2** -- December 16, 2015
   * bin/pscss --iso8859-1
   * add rebeccapurple (from css color draft)
   * improve utf-8 support
 
-### **0.6.1** -- December 13, 2015
+## **0.6.1** -- December 13, 2015
   * bin/pscss --continue-on-error
   * fix BEM and `@`extend infinite loop
   * Compiler: setIgnoreErrors(boolean)
   * exception refactoring
   * implement `@`extend !optional and `keywords($args)` built-in
 
-### **0.6.0** -- December 5, 2015
+## **0.6.0** -- December 5, 2015
   * handle escaped quotes inside quoted strings (with and without interpolation present)
   * Compiler: undefined sourceParser when re-using a single Compiler instance
   * Parser: `getLineNo()` removed
 
-### **0.5.1** -- November 11, 2015
+## **0.5.1** -- November 11, 2015
   * `@`scssphp-import-once
   * avoid notices with custom error handlers that don't check if `error_reporting()` returns 0
 
-### **0.5.0** -- November 11, 2015
+## **0.5.0** -- November 11, 2015
   * Raise minimum supported version to PHP 5.4
   * Drop HHVM support/hacks
   * Remove deprecated classmap.php
@@ -369,7 +364,7 @@ title: Changelog
   * Compiler: `str-splice()` fixes
   * Node\Number: fixes incompatible units
 
-### **0.4.0** -- November 8, 2015
+## **0.4.0** -- November 8, 2015
   * Parser: remove deprecated `show()` and `to()` methods
   * Parser, Compiler: convert stdClass to Block, Node, and OutputBlock abstractions
   * New control directives: `@`break, `@`continue, and naked `@`return
@@ -380,7 +375,7 @@ title: Changelog
   * Compiler: `str-slice()` - handle negative index
   * Compiler: pass kwargs to built-ins and user registered functions as 2nd argument (instead of Compiler instance)
 
-### **0.3.3** -- October 23, 2015
+## **0.3.3** -- October 23, 2015
   * Compiler: add `getVariables()` and `addFeature()` API methods
   * Compiler: can pass negative indices to `nth()` and `set-nth()`
   * Compiler: can pass map as args to mixin expecting varargs
@@ -388,7 +383,7 @@ title: Changelog
   * Compiler: improve `@`at-root support
   * Nested formatter: suppress empty blocks
 
-### **0.3.2** -- October 4, 2015
+## **0.3.2** -- October 4, 2015
   * Fix `@`extend behavior when interpolating a variable that contains a selector list
   * Hoist `@`keyframes so children selectors are not prefixed by parent selector
   * Don't wrap `@`import inside `@`media query
@@ -398,37 +393,37 @@ title: Changelog
   * Short-circuit evaluation for `and`, `or`, and `if()`
   * Compiler: getParsedFiles() now includes the main file
 
-### **0.3.1** -- September 11, 2015
+## **0.3.1** -- September 11, 2015
   * Fix bootstrap v4-dev regression from 0.3.0
 
-### **0.3.0** -- September 6, 2015
+## **0.3.0** -- September 6, 2015
   * Compiler getParsedFiles() now returns a map of imported files and their corresponding timestamps
   * Fix multiple variable scope bugs, including `@`each
   * Fix regression from 0.2.1
 
-### **0.2.1** -- September 5, 2015
+## **0.2.1** -- September 5, 2015
   * Fix map-get(null)
   * Fix nested function definition (variable scoping)
   * Fix extend bug with BEM syntax
   * Fix selector regression from 0.1.9
 
-### **0.2.0** -- August 25, 2015
+## **0.2.0** -- August 25, 2015
   * Smaller git archives
   * Detect `@`import loops
   * Doc blocks everywhere!
 
-### **0.1.10** -- August 23, 2015
+## **0.1.10** -- August 23, 2015
   * Fix 3 year old `@`extend bug
   * Fix autoloader. (ext)
 
-### **0.1.9** -- August 1, 2015
+## **0.1.9** -- August 1, 2015
   * Adoption of the Sass Community Guidelines
   * Nested selector fixes with lists, interpolated string, and parent selector
   * Implement list-separator() and set-nth() built-ins
   * Implement `@`warn and `@`error
   * Removed spaceship operator pending discussion with reference implementators
 
-### **0.1.8** -- July 18, 2015
+## **0.1.8** -- July 18, 2015
   * Online documentation moved to http://leafo.github.com/scssphp/
   * Fix index() - map support; now returns null (instead of false) when value not found
   * Fix lighten(), darken() - percentages don't require % unit
@@ -438,71 +433,71 @@ title: Changelog
   * Fix `@`return inside `@`each
   * Add box support to generate .phar
 
-### **0.1.7** -- July 1, 2015
+## **0.1.7** -- July 1, 2015
   * bin/pscss: added --line-numbers and --debug-info options
   * Compiler: added setLineNumberStyle() and 'q' unit
   * Parser: deprecated show() and to() methods
   * simplified licensing (MIT)
   * refactoring internals and misc bug fixes (maps, empty list, function-exists())
 
-### **0.1.6** -- June 22, 2015
+## **0.1.6** -- June 22, 2015
   * !global
   * more built-in functions
   * Server: checkedCachedCompile() (zimzat)
   * Server: showErrorsAsCSS() to display errors in a pseudo-element (khamer)
   * misc bug fixes
 
-### **0.1.5** -- June 2, 2015
+## **0.1.5** -- June 2, 2015
   * misc bug fixes
 
-### **0.1.4** -- June 2, 2015
+## **0.1.4** -- June 2, 2015
   * add new string functions (okj579)
   * add compileFile() and checkCompile() (NoxNebula, saas786, panique)
   * fix regular expression in findImport() (lucvn)
   * needsCompile() shouldn't compare meta-etag with browser etag (edwinveldhuizen)
 
-### **0.1.3** -- May 31, 2015
+## **0.1.3** -- May 31, 2015
   * map support (okj579)
   * misc bug fixes (etu, bgarret, aaukt)
 
-### **0.1.1** -- Aug 12, 2014
+## **0.1.1** -- Aug 12, 2014
   * add stub classes -- a backward compatibility layer (vladimmi)
 
-### **0.1.0** -- Aug 9, 2014
+## **0.1.0** -- Aug 9, 2014
   * raise PHP requirement (5.3+)
   * reformat/reorganize source files to be PSR-2 compliant
 
-### **0.0.15** -- Aug 6, 2014
+## **0.0.15** -- Aug 6, 2014
   * fix regression with default values in functions (torkiljohnsen)
 
-### **0.0.14** -- Aug 5, 2014
+## **0.0.14** -- Aug 5, 2014
   * `@`keyframes $name - didn't work inside mixin (sergeylukin)
   * Bourbon transform(translateX()) didn't work (dovy and greynor)
 
-### **0.0.13** -- Aug 4, 2014
+## **0.0.13** -- Aug 4, 2014
   * handle If-None-Match in client request, and send ETag in response (NSmithUK)
   * normalize quotation marks (NoxNebula)
   * improve handling of escape sequence in selectors (matt3224)
   * add "scss_formatter_crunched" which strips comments
   * internal: generate more accurate parse tree
 
-### **0.0.12** -- July 6, 2014
+## **0.0.12** -- July 6, 2014
   * revert erroneous import-partials-fix (smuuf)
   * handle If-Modified-Since in client request, and send Last-Modified in response (braver)
   * add hhvm to travis-ci testing
 
-### **0.0.11** -- July 5, 2014
+## **0.0.11** -- July 5, 2014
   * support multi-line continuation character (backslash) per CSS2.1 and CSS3 spec (caiosm1005)
   * imported partials should not be compiled (squarestar)
   * add setVariables() and unsetVariable() to interface (leafo/lessphp)
   * micro-optimizing is_null() (Yahasana)
 
-### **0.0.10** -- April 14, 2014
+## **0.0.10** -- April 14, 2014
   * fix media query merging (timonbaetz)
   * inline if should treat null as false (wonderslug)
   * optimizing toHSL() (jfsullivan)
 
-### **0.0.9** -- December 23, 2013
+## **0.0.9** -- December 23, 2013
   * fix `@`for/`@`while inside `@`content block (sergeylukin)
   * fix functions in mixin_content (timonbaetz)
   * fix infinite loop when target extends itself (oscherler)
@@ -511,13 +506,13 @@ title: Changelog
   * add public function helpers (toBool, get, findImport, assertList, assertColor, assertNumber, throwError) (Burgov, atdt)
   * add optional cache buster prefix to serve() method (iMoses)
 
-### **0.0.8** -- September 16, 2013
+## **0.0.8** -- September 16, 2013
   * Avoid IE7 content: counter bug
   * Support transparent as color name
   * Recursively create cache dir (turksheadsw)
   * Fix for INPUT NOT FOUND (morgen32)
 
-### **0.0.7** -- May 24, 2013
+## **0.0.7** -- May 24, 2013
   * Port various fixes from leafo/lessphp.
   * Improve filter precision.
   * Parsing large image data-urls does not work.
@@ -529,7 +524,7 @@ title: Changelog
   * Fix passing of varargs to another mixin.
   * Fix interpolation bug in expToString() (Matti Jarvinen).
 
-### **0.0.5** -- March 11, 2013
+## **0.0.5** -- March 11, 2013
   * Better compile time errors
   * Fix top level properties inside of a nested `@media` (Anthon Pang)
   * Fix some issues with `@extends` (Anthon Pang)
@@ -541,7 +536,7 @@ title: Changelog
   * Add zip, index, comparable functions (Martin Hasoň)
   * A bunch of parser and bug fixes
 
-### **0.0.4** -- Nov 3nd, 2012
+## **0.0.4** -- Nov 3nd, 2012
   * [Import path can be a function](docs/#import-paths) (Christian Lück).
   * Correctly parse media queries with more than one item (Christian Lück).
   * Add `ie_hex_str`, `abs`, `min`, `max` functions (Martin Hasoň)
@@ -550,16 +545,16 @@ title: Changelog
   * Add [`@content`](http://sass-lang.com/docs/yardoc/file.SASS_REFERENCE.html#mixin-content) support.
   * Misc bug fixes.
 
-### **0.0.3** -- August 2nd, 2012
+## **0.0.3** -- August 2nd, 2012
   * Add missing and/or/not operators.
   * Expression evaluation happens correctly.
   * Import file caching and _partial filename support.
   * Misc bug fixes.
 
-### **0.0.2** -- July 30th, 2012
+## **0.0.2** -- July 30th, 2012
   * SCSS server is aware of imports
   * added custom function interface
   * compressed formatter
   * wrote <a href="{{ site.baseurl }}/docs/">documentation</a>
 
-### **0.0.1** -- July 29th, 2012 -- Initial Release
+## **0.0.1** -- July 29th, 2012 -- Initial Release

--- a/docs/docs/extending/README.md
+++ b/docs/docs/extending/README.md
@@ -1,0 +1,8 @@
+# Extending scssphp
+
+scssphp supports various extension points:
+
+- [Preset variables](./preset-variables.md)
+- [Custom functions](./custom-functions.md)
+- [Custom importers](./importers.md)
+- [Custom loggers for warnings](./logger.md)

--- a/docs/docs/extending/custom-functions.md
+++ b/docs/docs/extending/custom-functions.md
@@ -1,0 +1,137 @@
+# Implementing custom host functions
+
+It is possible to register custom functions written in PHP that can be called
+from SCSS. Some possible applications include appending your assets directory
+to a URL with an `asset-url` function, or converting image URLs to an embedded
+data URI to reduce the number of requests on a page with a `data-uri` function.
+Note that functions declared in SCSS with `@function` are allowed to shadow the
+host functions if they reuse the same name.
+
+We can add and remove functions using the methods `registerFunction` and
+`unregisterFunction` of the `Compiler`.
+
+* `registerFunction($functionName, $callable, $argumentDeclaration)` assigns the
+  callable value to the name `$functionName`. The name is normalized using the
+  rules of SCSS, meaning underscores and dashes are interchangeable. If a
+  function with the same name already exists then it is replaced. The
+  `$argumentDeclaration` argument is an array of parameter names (without the
+  `$`).
+
+* `unregisterFunction($functionName)` removes `$functionName` from the list of
+  available functions.
+
+Functions should declare explicitly their argument, to allow the compiler to
+validate arguments and support keyword arguments for them. However, a deprecated
+alternative API also exists accepting any arguments with a different signature
+for the callable.
+
+Custom host functions have to work with Sass values which are described in the
+[documentation about values](./values.md).
+
+Functions must return either `null` or a Sass value. Returning `null` means that
+the function call will be compiled as a CSS function call. This is generally not
+needed for custom functions as they should probably not shadow CSS functions to
+avoid confusion (some built-in Sass functions rely on that however, like `rgb()`).
+
+## Argument declaration
+
+The argument declaration is an array of strings. Each string defines an argument.
+Argument names must be valid Sass variable names, without the leading `$`. It is
+recommended using dashes rather than underscores (i.e. using normalized names).
+There are 3 kinds of arguments that can be declared:
+
+- `name` declares a mandatory argument named `name`
+- `name:default` declares an optional argument named `name` with `default` as
+  the default value. The default value is parsed as a Sass value.
+- `name...` declares a rest argument named `name`. The rest argument must always
+  be the last one.
+
+The compiler will take care of validating arguments against the function
+signature, supporting the same features that for calls to functions defined in
+SCSS directly. However, it is still the responsibility of the callable to
+validate the values themselves. The `Compiler::assert*` helpers should be used
+to validate the type, providing the argument name for better error reporting.
+To report custom errors, the callable must use the
+`\ScssPhp\ScssPhp\Exception\SassScriptException` to ensure proper error
+reporting.
+
+## Implementing the function
+
+### Functions declaring their arguments
+
+The callable receives 2 arguments. However, the second one is passed only for
+historical reasons (and for some special internal usages) and should not be used
+anymore.
+
+The first argument is an array of Sass values, with one value per declared
+arguments. The compiler guarantees that all arguments are always provided to the
+callable. A rest argument receives a Sass argument list as the value.
+
+As an example, a function called `add-two` is registered, which adds two numbers
+together (this example is useless as the built-in Sass addition is more powerful
+regarding units).
+
+```php
+use ScssPhp\ScssPhp\Compiler;
+use ScssPhp\ScssPhp\Node\Number;
+
+$compiler = new Compiler();
+
+$compiler->registerFunction(
+  'add-two',
+  function($args) use ($compiler) {
+    $number1 = $compiler->assertNumber($args[0], 'number1');
+    $number2 = $compiler->assertNumber($args[1], 'number2');
+
+    $number1->assertNoUnits('number1');
+    $number2->assertNoUnits('number2');
+
+    return new Number($number1->getDimension() + $number2->getDimension(), '');
+  },
+  ['number1', 'number2']
+);
+
+$compiler->compileString('.ex1 { result: add-two(10, 10); }')->getCss();
+$compiler->compileString('.ex1 { result: add-two($number1: 10, $number2: 10); }')->getCss();
+```
+
+### Functions not declaring their arguments
+
+When arguments are not declared (`null` is passed as the argument declaration
+when registering the function), the compiler will accept any arguments when
+calling the function. The callable will receive 2 arguments: a list of
+positional arguments and a list of keyword arguments (with names which are not
+normalized, and so confusing to use).
+
+This usage is deprecated as of scssphp 1.5 and will not be supported in 2.0.
+
+The direct migration is to declare the function with a rest argument:
+
+```diff
+ $compiler->registerFunction(
+   'foo',
+-  function ($positionalArgs, $keywordArgs) use ($compiler) {
++  function ($args) use ($compiler) {
++    $restArgument = $args[0];
++    $positionalArgs = $restArgument[2];
++    $keywordArgs = $compiler->getArgumentListKeywords($restArgument);
+     // Do something to return a value
+-  }
++  },
++  ['args...']
+ );
+```
+
+However, in most cases, function actually expect a given signature implicitly
+rather than accepting anything. In such case, it is better to migrate to an
+explicit signature and to rework the callable to account for that.
+
+## Reporting errors or warnings
+
+Errors in the execution of functions must be reported by using the
+`\ScssPhp\ScssPhp\Exception\SassScriptException` for proper error reporting.
+When the error is related to the validation of an argument, the
+`SassScriptException::forArgument` method should be used to instantiate the
+exception.
+
+Warnings can be reported using the `\ScssPhp\ScssPhp\Warn` API:

--- a/docs/docs/extending/importers.md
+++ b/docs/docs/extending/importers.md
@@ -34,5 +34,5 @@ $compiler->addImportPath(function($path) {
 });
 
 // will import 'stylesheets/sub.scss'
-echo $compiler->compileString('{% raw %}@{% endraw %}import "sub.scss";')->getCss();
+echo $compiler->compileString('@import "sub.scss";')->getCss();
 ```

--- a/docs/docs/extending/importers.md
+++ b/docs/docs/extending/importers.md
@@ -1,0 +1,38 @@
+# Customizing the resolution of importers
+
+Custom resolution of imports can be implemented by passing a callable in
+import paths.
+
+Note: callable strings are not supported, as strings are treated as directory
+names. If your resolution logic is implemented as a named PHP function, use
+`\Closure::fromCallable` to wrap it (or a custom solution if using older PHP
+versions that don't have that helper).
+
+The callable will be called with a single string argument, which is the URI
+being imported and should return the absolute path of a file or `null` if it
+does not support that import.
+
+For legacy reasons, custom importers are also called for CSS imports, allowing
+to treat them like Sass imports. However, that behavior is deprecated. Custom
+importers should check their input with `\ScssPhp\ScssPhp\Compiler::isCssImport`
+and always return `null` for them.
+
+```php
+use ScssPhp\ScssPhp\Compiler;
+
+$compiler = new Compiler();
+$compiler->addImportPath(function($path) {
+    if (Compiler::isCssImport($path)) {
+        return null;
+    }
+
+    if (!file_exists('stylesheets/'.$path)) {
+        return null;
+    }
+
+    return __DIR__.'/stylesheets/'.$path;
+});
+
+// will import 'stylesheets/sub.scss'
+echo $compiler->compileString('{% raw %}@{% endraw %}import "sub.scss";')->getCss();
+```

--- a/docs/docs/extending/logger.md
+++ b/docs/docs/extending/logger.md
@@ -1,0 +1,14 @@
+# Customizing the handling of warnings
+
+The compiler supports configuring the reporting of warning and debug messages
+of Sass thanks to the `\ScssPhp\ScssPhp\Logger\LoggerInterface`. A custom logger
+can be set through the `setLogger` method of the `Compiler` instance.
+
+By default, Sass warnings are reported to STDERR.
+
+The library provides 2 built-in implementations of the interface:
+- `\ScssPhp\ScssPhp\Logger\StreamLogger` writes the logs to a PHP stream (a file
+  handle for instance)
+- `\ScssPhp\ScssPhp\Logger\QuietLogger` ignores all warnings. Its usage is not
+  recommended outside some testing scenarios as Sass warnings should not be
+  silently ignored.

--- a/docs/docs/extending/preset-variables.md
+++ b/docs/docs/extending/preset-variables.md
@@ -1,0 +1,40 @@
+# Preset variables
+
+You can preset variables before compilation by using the `replaceVariables($vars)`
+or `addVariables($vars)` methods of the Compiler. `Compiler::getVariables`
+allows to get the list of registered variables. `Compiler::unsetVariable($name)`
+allows to unset a variable (the exact name used for the registration must be
+passed).
+
+Presetting variables is semantically equivalent to prepending variable
+declarations at the beginning of the input. If the variable is also defined in
+your scss source, use the `!default` flag in the source to prevent your preset
+variables from being overridden.
+
+Variable names can optionally include the leading `$` and can use dashes or
+underscores interchangeably. If multiple preset variables have the same
+normalized name, the last one wins (as they are declared in order). The
+recommendation is to stick with normalized names (no leading `$` and dashes
+rather than underscores) to avoid confusion.
+
+Variable values must be converted to the [internal representation of Sass values](./values.md)
+using the `\ScssPhp\ScssPhp\ValueConverter` API. This API exposes 2 helpers:
+
+- `ValueConverter::parseValue` parses a string containing a SCSS representation
+  of a value.
+- `ValueConverter::fromPhp` converts a PHP scalar (or null) to the equivalent
+  SCSS value. Note that not all Sass values can be represented as a PHP scalar
+  (numbers with units or colors for instance).
+
+```php
+use ScssPhp\ScssPhp\Compiler;
+use ScssPhp\ScssPhp\ValueConverter;
+
+$compiler = new Compiler();
+$compiler->replaceVariables(array(
+    'var' => ValueConverter::parseValue('false'),
+    'size' => ValueConverter::parseValue('25px'),
+));
+
+echo $compiler->compileString('$var: true !default; @debug $var;')->getCss();
+```

--- a/docs/docs/extending/values.md
+++ b/docs/docs/extending/values.md
@@ -1,0 +1,106 @@
+# Working with Sass values
+
+Note: this documentation applies to working with values inside Sass functions.
+When working on the internals of the compiler, things are more complex.
+
+scssphp represents Sass values using `array|\ScssPhp\ScssPhp\Node\Number`. The
+index `0` of the array will be the type of value (one of the
+`\ScssPhp\ScssPhp\Type` constants, but not all these constants are about value
+types).
+
+The `Compiler` class exposes various `assert*` methods to check the type of
+values. These methods return the asserted value (which may not be exactly the
+same as the input due to complex implementation details, so the return value
+should be used).
+
+If a string representation of a value is needed to include it in an error
+message, the `Compiler::compileValue` method can be used.
+
+## Value representation
+
+### Null
+
+Sass' `null` value is representation using `[Type::T_NULL]`. It can be
+referenced as `Compiler::$null`.
+
+### Booleans
+
+Sass' boolean values are represented as `Compiler::$true` and `Compiler::$false`.
+
+When accepting a parameter in a function, it is generally better to use
+`Compiler::isTruthy` instead of explicitly checking for boolean value.
+
+### Numbers
+
+Sass' numbers are represented using the `\ScssPhp\ScssPhp\Node\Number` class.
+
+### Strings
+
+Sass' strings are represented as an array with 3 elements:
+
+- `Type::T_STRING`
+- the quote character. this is either the empty string for unquoted strings or
+  a quote character (`"` or `'`). When creating new quoted strings, use the `"`
+  character (the rendering will not always respect this quoting character anyway).
+- the string content, as an array of string parts. The exact structure for parts
+  is considered an internal implementation detail. Use `Compiler::getStringText`
+  to get the text of the string. When creating new strings, put the string
+  content as the single item in the array (or use `ValueConverter::fromPhp`).
+
+Note: arguments received by functions may not always use the `Type::T_STRING`
+due to internal details. However, `Compiler::assertString` guarantees that its
+return value is actually a string using `Type::T_STRING`.
+
+### Colors
+
+Sass' colors are represented as an array with 4 or 5 elements (the alpha
+channel is optional):
+
+- `Type::T_COLOR`
+- an integer between 0 and 255 for the red channel
+- an integer between 0 and 255 for the green channel
+- an integer between 0 and 255 for the blue channel
+- an optional float between 0 and 1 for the alpha channel (omitting it is the
+  same as having 1 as value)
+
+Note: arguments might receive a `Type::T_KEYWORD` corresponding to a color
+keyword. Always use `Compiler::assertColor` to get the actual color.
+
+### Maps
+
+Sass' maps are represented as an array with 3 elements:
+
+- `Type::T_MAP`
+- an array of keys
+- an array of values
+
+The actual handling of keys is weird, as it does not rely on the equality rules
+of values (which is not spec compliant). When writing custom functions, it is
+advised to stay away from maps as arguments or return value for now.
+
+As Sass empty lists can be used as maps, always use `Compiler::assertMap` to get
+the actual map value (this helper takes care of converting empty lists).
+
+### Lists
+
+Sass' lists are represented as an array with 3 elements:
+
+- `Type::T_LIST`
+- the list separator as a string (the empty string represents undecided delimiters)
+- an array of values
+
+Bracketed lists are represented by adding an `enclosing` key with a value of
+`bracket`.
+
+Note that the handling of the list separator is not fully compliant. List values
+might have an undecided separators in cases where they should not in Sass.
+
+### Argument lists
+
+Sass's argument lists are representing the list of rest arguments for variadic
+functions.
+
+They are represented as a Sass list (see above) containing positional arguments
+with an additional element in the array to store the keyword arguments. To
+access keyword arguments of the Sass argument list, use
+`Compiler::getArgumentListKeywords`.

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -42,7 +42,7 @@ message.
 
 ### Import Paths
 
-When you import a file using the `{% raw %}@{% endraw %}import` directive,
+When you import a file using the `@import` directive,
 the import is resolved relatively to the current file. The input of `compileString`
 is considered to be in the provided path. If no path is provided, relative imports
 won't be resolved. Imports paths will need to be used.
@@ -63,7 +63,7 @@ $compiler = new Compiler();
 $compiler->setImportPaths('assets/stylesheets/');
 
 // will search for 'assets/stylesheets/mixins.scss'
-echo $compiler->compileString('{% raw %}@{% endraw %}import "mixins.scss";')->getCss();
+echo $compiler->compileString('@import "mixins.scss";')->getCss();
 ```
 
 Besides adding static import paths, it's also possible to add
@@ -151,7 +151,7 @@ $compiler->setSourceMapOptions([
     'sourceRoot' => '/',
 ]);
 
-$result = $compiler->compileString('{% raw %}@{% endraw %}import "sub.scss";');
+$result = $compiler->compileString('@import "sub.scss";');
 
 file_put_contents('/var/www/vhost/my-style.map', $result->getSourceMap());
 file_put_contents('/var/www/vhost/my-style.css', $result->getCss());

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Documentation
 ---
 
@@ -9,7 +8,7 @@ title: Documentation
 
 ### Including
 
-The project can be loaded through a `composer` generated auto-loader.
+The project can be loaded through the `composer` generated auto-loader.
 
 Alternatively, the entire project can be loaded through a utility file.
 Just include it somewhere to start using it:
@@ -27,90 +26,51 @@ options, then run the compiler with the `compile` method.
 ```php
 use ScssPhp\ScssPhp\Compiler;
 
-$scss = new Compiler();
+$compiler = new Compiler();
 
-echo $scss->compile('
+echo $compiler->compileString('
   $color: #abc;
   div { color: lighten($color, 20%); }
-');
+')->getCss();
 ```
 
-* `compile($scssCode)` will attempt to compile a string of SCSS code. If it
-  succeeds, the CSS will be returned as a string. If there is any error, an
-  exception is thrown with an appropriate error message.
+`compileString($scssCode, $path = null)` will attempt to compile a string of
+SCSS code. If it succeeds, a `\ScssPhp\ScssPhp\CompilationResult` containing the
+CSS will be returned. If there is any error, a
+`\ScssPhp\ScssPhp\Exception\SassException` is thrown with an appropriate error
+message.
 
 ### Import Paths
 
 When you import a file using the `{% raw %}@{% endraw %}import` directive,
-the import is resolved relatively to the current file. The input of `compile`
-is considered to be in the current working directory (`getcwd()`) unless its
-path is provided.
+the import is resolved relatively to the current file. The input of `compileString`
+is considered to be in the provided path. If no path is provided, relative imports
+won't be resolved. Imports paths will need to be used.
 In case you want to load files from other folders, there are two methods for
  manipulating the import path: `addImportPath`, and `setImportPaths`.
 
 * `addImportPath($path)` will append `$path` to the list of the import
   paths that are searched.
 
-* `setImportPaths($pathArray)` will replace the entire import path with
+* `setImportPaths($pathArray)` will replace the entire list of import paths with
   `$pathArray`. The value of `$pathArray` will be converted to an array if it
   isn't one already.
 
 ```php
 use ScssPhp\ScssPhp\Compiler;
 
-$scss = new Compiler();
-$scss->setImportPaths('assets/stylesheets/');
+$compiler = new Compiler();
+$compiler->setImportPaths('assets/stylesheets/');
 
 // will search for 'assets/stylesheets/mixins.scss'
-echo $scss->compile('{% raw %}@{% endraw %}import "mixins.scss";');
+echo $compiler->compileString('{% raw %}@{% endraw %}import "mixins.scss";')->getCss();
 ```
 
-Besides adding static import paths, it's also possible to add custom import
-functions. This allows you to load paths from a database, or HTTP, or using
-files that SCSS would otherwise not process (such as vanilla CSS imports).
+Besides adding static import paths, it's also possible to add
+[custom import functions](./extending/importers.md).
 
-```php
-use ScssPhp\ScssPhp\Compiler;
-
-$scss = new Compiler();
-$scss->addImportPath(function($path) {
-    if (!file_exists('stylesheets/'.$path)) return null;
-    return 'stylesheets/'.$path;
-});
-
-// will import 'stylesheets/vanilla.css'
-echo $scss->compile('{% raw %}@{% endraw %}import "vanilla.css";');
-```
-
-A list of the compiled files (both the primary file and its imports) can be
-retrieved using the `getParsedFiles` method.
-
-* `getParsedFiles()` returns an associative array where the keys are
-  the file names and the values are the corresponding file's last-modified
-  timestamp.
-
-### Preset Variables
-
-You can preset variables before compilation by using the `setVariables($vars)`
-method. If the variable is also defined in your scss source, use the `!default`
-flag to prevent your preset variables from being overridden.
-
-```php
-use ScssPhp\ScssPhp\Compiler;
-
-$scss = new Compiler();
-$scss->setVariables(array(
-    'var' => 'false',
-));
-
-echo $scss->compile('$var: true !default;');
-```
-
-Note: the value is the scss source to be parsed. If you want to parse a string,
-you have to represent it as a string, e.g. `'var' => '"string"'`.
-
-Likewise, you can retrieve the preset variables using the `getVariables()`
-method, and unset a variable using the `unsetVariable($name)` method.
+A list of the included files can be retrieved using the `getIncludedFiles`
+method of the `CompilationResult`. The input file is not included in this list.
 
 ### Output Formatting
 
@@ -172,14 +132,14 @@ To enable source maps, use the `setSourceMap()` and `setSourceMapOptions()` meth
 ```php
 use ScssPhp\ScssPhp\Compiler;
 
-$scss = new Compiler();
-$scss->setSourceMap(Compiler::SOURCE_MAP_FILE);
-$scss->setSourceMapOptions([
+$compiler = new Compiler();
+$compiler->setSourceMap(Compiler::SOURCE_MAP_FILE);
+$compiler->setSourceMapOptions([
     // absolute path to write .map file
     'sourceMapWriteTo'  => '/var/www/vhost/my-style.map',
 
     // relative or full url to the above .map file
-    'sourceMapURL'      => 'content/themes/THEME/assets/css/my-style.map',
+    'sourceMapURL' => './my-style.map',
 
     // (optional) relative or full url to the .css file
     'sourceMapFilename' => 'my-style.css',
@@ -188,89 +148,21 @@ $scss->setSourceMapOptions([
     'sourceMapBasepath' => '/var/www/vhost',
 
     // (optional) prepended to 'source' field entries for relocating source files
-    'sourceRoot'        => '/',
+    'sourceRoot' => '/',
 ]);
+
+$result = $compiler->compileString('{% raw %}@{% endraw %}import "sub.scss";');
+
+file_put_contents('/var/www/vhost/my-style.map', $result->getSourceMap());
+file_put_contents('/var/www/vhost/my-style.css', $result->getCss());
 
 // use Compiler::SOURCE_MAP_INLINE for inline (comment-based) source maps
 ```
 
-### Custom Functions
+### Extending scssphp
 
-It's possible to register custom functions written in PHP that can be called
-from SCSS. Some possible applications include appending your assets directory
-to a URL with an `asset-url` function, or converting image URLs to an embedded
-data URI to reduce the number of requests on a page with a `data-uri` function.
-
-We can add and remove functions using the methods `registerFunction` and
-`unregisterFunction`.
-
-* `registerFunction($functionName, $callable, $prototype)` assigns the callable value to
-  the name `$functionName`. The name is normalized using the rules of SCSS,
-  meaning underscores and dashes are interchangeable. If a function with the
-  same name already exists then it is replaced. The optional `$prototype` is an
-  array of parameter names.
-
-* `unregisterFunction($functionName)` removes `$functionName` from the list of
-  available functions.
-
-The `$callable` can be anything that PHP knows how to call using
-`call_user_func`. The function receives two arguments when invoked. The first
-is an array of SCSS typed arguments that the function was sent. The second is an
-array of SCSS values corresponding to keyword arguments (aka kwargs).
-
-The SCSS *typed arguments* and *kwargs* are actually just arrays or Number objects
-that represent SCSS values. SCSS has different types than PHP, and this is how
-**scssphp** represents them internally.
-
-There is a large variety of types. Experiment with a debugging function like `print_r`
-to examine the possible inputs.
-
-The return value of the custom function can either be a SCSS type or a basic
-PHP type (such as a string or a number). If it's a PHP type, it will be converted
-automatically to the corresponding SCSS type.
-
-As an example, a function called `add-two` is registered, which adds two numbers
-together. PHP's anonymous function syntax is used to define the function.
-
-```php
-use ScssPhp\ScssPhp\Compiler;
-
-$scss = new Compiler();
-
-$scss->registerFunction(
-  'add-two',
-  function($args) {
-    list($a, $b) = $args;
-
-    return $a[1] + $b[1];
-  }
-);
-
-$scss->compile('.ex1 { result: add-two(10, 10); }');
-```
-
-Using a prototype and kwargs, functions can take named parameters. In this next example,
-we register a function called `divide` which divides a named dividend by a named divisor.
-
-```php
-use ScssPhp\ScssPhp\Compiler;
-
-$scss = new Compiler();
-
-$scss->registerFunction(
-  'divide',
-  function($args, $kwargs) {
-    return $kwargs['dividend'][1] / $kwargs['divisor'][1];
-  },
-  array('dividend', 'divisor')
-);
-
-$scss->compile('.ex2 { result: divide($divisor: 2, $dividend: 30); }');
-```
-
-Note: in the above examples, we lose the units of the number, and we
-also don't do any type checking. This will have undefined results if we give it
-anything other than two numbers.
+The Compiler supports several extension points for advanced usages. They are
+documented in [the documentation about extension points](./extending/).
 
 ### Security Considerations
 
@@ -283,9 +175,9 @@ the exception stack trace may contain sensitive data.
 use ScssPhp\ScssPhp\Compiler;
 
 try {
-    $scss = new Compiler();
+    $compiler = new Compiler();
 
-    echo $scss->compile($content);
+    echo $compiler->compileString($content)->getCss();
 } catch (\Exception $e) {
     echo '';
     syslog(LOG_ERR, 'scssphp: Unable to compile content');

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,4 @@
----
-layout: default
----
-
-**scssphp** is a compiler for [SCSS][0] 3.x written in PHP.
+**scssphp** is a compiler for [SCSS][0] written in PHP.
 
 SCSS is a CSS preprocessor language that adds many features like variables,
 mixins, imports, nesting, color manipulation, functions, and control directives.
@@ -11,8 +7,8 @@ mixins, imports, nesting, color manipulation, functions, and control directives.
 line tool for running the compiler from a terminal/shell or script.
 
 <div class="github-buttons">
-<iframe src="http://ghbtns.com/github-btn.html?user=scssphp&repo=scssphp&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110px" height="20px"></iframe>
-<iframe src="http://ghbtns.com/github-btn.html?user=scssphp&repo=scssphp&type=fork&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="95px" height="20px"></iframe>
+<iframe src="https://ghbtns.com/github-btn.html?user=scssphp&repo=scssphp&type=star&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="150" height="20"></iframe>
+<iframe src="https://ghbtns.com/github-btn.html?user=scssphp&repo=scssphp&type=fork&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="150" height="20"></iframe>
 </div>
 
 <a name="installing"></a>
@@ -25,7 +21,8 @@ You can always download the latest version here:
 You can also find the latest source online:
 <{{ site.repo_url }}/>
 
-If you use [Packagist][2] for installing packages, then you can update your `composer.json` like so:
+If you use [Packagist][2] for installing packages, then you can update your
+`composer.json` like so:
 
 ```json
 {
@@ -36,8 +33,8 @@ If you use [Packagist][2] for installing packages, then you can update your `com
 ```
 
 Note: git archives of stable versions no longer include the `tests/` folder.
-To install the unit tests, download the complete package source using `composer`'s
-`--prefer-source` option.
+To install the unit tests, download the complete package source using
+`composer`'s `--prefer-source` option.
 
 **scssphp** requires PHP version 5.6 (or above).
 
@@ -45,66 +42,75 @@ To install the unit tests, download the complete package source using `composer`
 
 For a complete guide to the syntax of SCSS, consult the [official documentation][1].
 
+Note that **scssphp** is not fully compliant with the Sass specification yet.
+Sass modules are not implemented yet either.
+
 ## Command Line Tool
 
 A really basic command line tool is included for integration with scripts. It
 is called `pscss`. It reads SCSS from either a named input file or standard in,
 and returns the CSS to standard out.
 
-Usage: bin/pscss [options] [input-file]
+Usage: `bin/pscss [options] [input-file] [output-file]`
 
 ### Options
 
-If passed the flag `-h` (or `--help`), input is ignored and a summary of the command's usage is returned.
+If passed the flag `-h` (or `--help`), input is ignored and a summary of the
+command's usage is returned.
 
-If passed the flag `-v` (or `--version`), input is ignored and the current version is returned.
+If passed the flag `-v` (or `--version`), input is ignored and the current
+version is returned.
 
-If passed the flag `-T`, a formatted parse tree is returned instead of the compiled CSS.
-
-The flag `-s` (or `--style`) can be used to set the [output style](docs/#output-formatting):
+The flag `-s` (or `--style`) can be used to set the
+[output style](docs/#output-formatting):
 
 ```bash
-$ bin/pscss -s compressed < styles.scss
+$ bin/pscss -s compressed styles.scss
 ```
 
-The flag `-I` (or `--load_path`) can be used to set import paths for the loader. On Unix/Linux systems,
-the paths are colon separated. On Windows, they are separate by a semi-colon.
+The flag `-I` (or `--load_path`) can be used to set import paths for the loader.
+On Unix/Linux systems, the paths are colon separated. On Windows, they are
+separated by a semi-colon.
 
 ## SCSSPHP Library Reference
 
-Complete documentation for **scssphp** is located at <a href="{{ site.baseurl }}/docs/">{{ site.baseurl }}/docs/</a>.
-
-To use the scssphp library either require `scss.inc.php` or use your `composer` generated auto-loader, and then
-invoke the `Compiler` class:
+To use the scssphp library either require `scss.inc.php` or use your `composer`
+generated auto-loader, and then invoke the `\ScssPhp\ScssPhp\Compiler` class:
 
 ```php
 require_once "scssphp/scss.inc.php";
 
 use ScssPhp\ScssPhp\Compiler;
 
-$scss = new Compiler();
+$compiler = new Compiler();
 
-echo $scss->compile('
+echo $compiler->compileString('
   $color: #abc;
   div { color: lighten($color, 20%); }
-');
+')->getCss();
 ```
 
-The `compile` method takes `SCSS` as a string, and returns the `CSS`. If there
-is an error when compiling, an exception is thrown with an appropriate
-message.
+The `compileString` method takes the `SCSS` source code as a string and an
+optional path of the input file (to resolve relative imports), and returns
+a `CompilationResult` value object containing the CSS and some additional
+data. If there is an error when compiling, a `\ScssPhp\ScssPhp\Exception\SassException`
+is thrown with an appropriate message.
 
-For a more detailed guide, consult <a href="{{ site.baseurl }}/docs/">{{ site.baseurl }}/docs/</a>.
+For a more detailed guide, [consult the documentation](docs/).
 
 <a name="issues"></a>
 
 ## Issues
 
-Please submit bug reports and feature requests to the [the issue tracker][3]. Pull requests also welcome.
+Please submit bug reports and feature requests to the [the issue tracker][3].
+Pull requests are also welcome.
+
+Any feature request about implementing new language feature will be rejected.
+They must be submitted to the upstream Sass project instead.
 
 ## Changelog
 
-For a list of **scssphp** changes, refer to <a href="{{ site.baseurl }}/docs/changelog.html">{{ site.baseurl }}/docs/changelog.html</a>.
+For a list of **scssphp** changes, refer to [the changelog](docs/changelog.md).
 
   [0]: https://sass-lang.com/
   [1]: https://sass-lang.com/documentation


### PR DESCRIPTION
The documentation is now updated to cover the new APIs of the library.
Documentation about extension points of the library has been extracted in a new section of the documentation and its content has been completed to explain extension points better.

Links between pages have been replaced with relative links to the markdown files (which are converted by the jekyll plugin), allowing links to work fine when reading the markdown files on github directly rather than using the website.

Closes #369 