### PR TITLE
Upgrade phpstan

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -141,11 +141,6 @@ parameters:
 			path: src/Compiler.php
 
 		-
-			message: "#^Cannot access offset 0 on \\(int\\|string\\)\\.$#"
-			count: 1
-			path: src/Compiler.php
-
-		-
 			message: "#^Cannot access offset 1 on array\\<int, string\\>\\|false\\.$#"
 			count: 2
 			path: src/Compiler.php
@@ -1366,6 +1361,11 @@ parameters:
 			path: src/Compiler.php
 
 		-
+			message: "#^Offset 0 does not exist on \\(int\\|string\\)\\.$#"
+			count: 1
+			path: src/Compiler.php
+
+		-
 			message: "#^Offset 2 does not exist on array\\(\\)\\.$#"
 			count: 1
 			path: src/Compiler.php
@@ -1516,8 +1516,13 @@ parameters:
 			path: src/Compiler.php
 
 		-
-			message: "#^Parameter \\#3 \\$lightness of method ScssPhp\\\\ScssPhp\\\\Compiler\\:\\:toRGB\\(\\) expects int, float\\|int given\\.$#"
+			message: "#^Parameter \\#3 \\$blackness of method ScssPhp\\\\ScssPhp\\\\Compiler\\:\\:HWBtoRGB\\(\\) expects int, float\\|int given\\.$#"
 			count: 1
+			path: src/Compiler.php
+
+		-
+			message: "#^Parameter \\#3 \\$lightness of method ScssPhp\\\\ScssPhp\\\\Compiler\\:\\:toRGB\\(\\) expects int, float\\|int given\\.$#"
+			count: 2
 			path: src/Compiler.php
 
 		-

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -7712,6 +7712,8 @@ class Compiler
      * @param callable $fn
      *
      * @return array
+     *
+     * @phpstan-param callable(float|int, float|int|null, float|int): (float|int) $fn
      */
     protected function alterColor(array $args, $operation, $fn)
     {
@@ -7803,16 +7805,16 @@ class Compiler
         }
 
         if ($hasRgb) {
-            $color[1] = round(\call_user_func($fn, $color[1], $red, 255));
-            $color[2] = round(\call_user_func($fn, $color[2], $green, 255));
-            $color[3] = round(\call_user_func($fn, $color[3], $blue, 255));
+            $color[1] = round($fn($color[1], $red, 255));
+            $color[2] = round($fn($color[2], $green, 255));
+            $color[3] = round($fn($color[3], $blue, 255));
         } elseif ($hasWB) {
             $hwb = $this->RGBtoHWB($color[1], $color[2], $color[3]);
             if ($hue !== null) {
                 $hwb[1] = $change ? $hue : $hwb[1] + $hue;
             }
-            $hwb[2] = \call_user_func($fn, $hwb[2], $whiteness, 100);
-            $hwb[3] = \call_user_func($fn, $hwb[3], $blackness, 100);
+            $hwb[2] = $fn($hwb[2], $whiteness, 100);
+            $hwb[3] = $fn($hwb[3], $blackness, 100);
 
             $rgb = $this->HWBtoRGB($hwb[1], $hwb[2], $hwb[3]);
 
@@ -7827,8 +7829,8 @@ class Compiler
             if ($hue !== null) {
                 $hsl[1] = $change ? $hue : $hsl[1] + $hue;
             }
-            $hsl[2] = \call_user_func($fn, $hsl[2], $saturation, 100);
-            $hsl[3] = \call_user_func($fn, $hsl[3], $lightness, 100);
+            $hsl[2] = $fn($hsl[2], $saturation, 100);
+            $hsl[3] = $fn($hsl[3], $lightness, 100);
 
             $rgb = $this->toRGB($hsl[1], $hsl[2], $hsl[3]);
 
@@ -7841,7 +7843,7 @@ class Compiler
 
         if ($alpha !== null) {
             $existingAlpha = isset($color[4]) ? $color[4] : 1;
-            $color[4] = \call_user_func($fn, $existingAlpha, $alpha, 1);
+            $color[4] = $fn($existingAlpha, $alpha, 1);
         }
 
         return $color;

--- a/vendor-bin/phpstan/composer.json
+++ b/vendor-bin/phpstan/composer.json
@@ -3,6 +3,6 @@
         "sort-packages": true
     },
     "require": {
-        "phpstan/phpstan": "^0.12.83"
+        "phpstan/phpstan": "^0.12.87"
     }
 }


### PR DESCRIPTION
Some error messages have changed in the latest version of phpstan, which requires regenerating the baseline.

This also improve the types for `alterColor` to specify types for the callback arguments, to avoid an error `Comparison operation "<" between (array|float|int) and 0 results in an error.` due to the new version of phpstan inferring `$new + $base` as `float|int|array` when it does not know the type of the variables. Removing `call_user_func` to call the callbacks helps the type checks as `call_user_func` is not typed in a generic way to handle arguments properly (which I don't think is possible with phpstan generics anyway as I don't think they are as expressive as the typescript ones yet)