### PR TITLE
Use PHP 8.0 for the windows and macOS CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,14 +17,14 @@ jobs:
                 extensions: [ '' ]
                 os: [ubuntu-latest]
                 include:
-                    - php: '7.4'
+                    - php: '8.0'
                       os: ubuntu-latest
                       extensions: ':mbstring'
                       name_suffix: ' without mbstring'
-                    - php: '7.4'
+                    - php: '8.0'
                       os: windows-latest
                       name_suffix: ' on Windows'
-                    - php: '7.4'
+                    - php: '8.0'
                       os: macos-latest
                       name_suffix: ' on macOS'
 


### PR DESCRIPTION
The github actions environment comes with PHP 8.0 preinstalled on windows and macOS (on Linux, it has both 7.4 and 8.0), which makes the setup faster than having to install another version.