### PR TITLE
Fix the operations on colors

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1501,11 +1501,6 @@ parameters:
 			path: src/Compiler.php
 
 		-
-			message: "#^Parameter \\#2 \\$saturation of method ScssPhp\\\\ScssPhp\\\\Compiler\\:\\:toRGB\\(\\) expects int, float\\|int given\\.$#"
-			count: 1
-			path: src/Compiler.php
-
-		-
 			message: "#^Parameter \\#2 \\$subject of function preg_match expects string, string\\|false given\\.$#"
 			count: 1
 			path: src/Compiler.php
@@ -1518,11 +1513,6 @@ parameters:
 		-
 			message: "#^Parameter \\#3 \\$blackness of method ScssPhp\\\\ScssPhp\\\\Compiler\\:\\:HWBtoRGB\\(\\) expects int, float\\|int given\\.$#"
 			count: 1
-			path: src/Compiler.php
-
-		-
-			message: "#^Parameter \\#3 \\$lightness of method ScssPhp\\\\ScssPhp\\\\Compiler\\:\\:toRGB\\(\\) expects int, float\\|int given\\.$#"
-			count: 2
 			path: src/Compiler.php
 
 		-

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -7369,6 +7369,10 @@ class Compiler
             if ($c[$i] > 255) {
                 $c[$i] = 255;
             }
+
+            if (!\is_int($c[$i])) {
+                $c[$i] = round($c[$i]);
+            }
         }
 
         return $c;
@@ -7451,9 +7455,9 @@ class Compiler
      *
      * @internal
      *
-     * @param integer $hue        H from 0 to 360
-     * @param integer $saturation S from 0 to 100
-     * @param integer $lightness  L from 0 to 100
+     * @param int|float $hue        H from 0 to 360
+     * @param int|float $saturation S from 0 to 100
+     * @param int|float $lightness  L from 0 to 100
      *
      * @return array
      */
@@ -7941,7 +7945,7 @@ class Compiler
             throw $this->error('Error: argument `$color` of `red($color)` must be a color');
         }
 
-        return new Number($color[1], '');
+        return new Number((int) $color[1], '');
     }
 
     protected static $libGreen = ['color'];
@@ -7953,7 +7957,7 @@ class Compiler
             throw $this->error('Error: argument `$color` of `green($color)` must be a color');
         }
 
-        return new Number($color[2], '');
+        return new Number((int) $color[2], '');
     }
 
     protected static $libBlue = ['color'];
@@ -7965,7 +7969,7 @@ class Compiler
             throw $this->error('Error: argument `$color` of `blue($color)` must be a color');
         }
 
-        return new Number($color[3], '');
+        return new Number((int) $color[3], '');
     }
 
     protected static $libAlpha = ['color'];


### PR DESCRIPTION
Colors are expected to support only integers for the R, G and B channels. But some operations were producing floats. Due to becoming stricter on integer validation in other parts of the compiler, this bug became visible.

Closes #397