### PR TITLE
Fix the handling of non-provided paths

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1431,11 +1431,6 @@ parameters:
 			path: src/Compiler.php
 
 		-
-			message: "#^Parameter \\#1 \\$path of method ScssPhp\\\\ScssPhp\\\\Compiler\\:\\:parserFactory\\(\\) expects string, string\\|null given\\.$#"
-			count: 1
-			path: src/Compiler.php
-
-		-
 			message: "#^Parameter \\#1 \\$r of static method ScssPhp\\\\ScssPhp\\\\Colors\\:\\:RGBaToColorName\\(\\) expects int, float\\|int\\|string given\\.$#"
 			count: 1
 			path: src/Compiler.php

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -224,7 +224,7 @@ class Compiler
      */
     protected $charsetSeen;
     /**
-     * @var array<int, string>
+     * @var array<int, string|null>
      */
     protected $sourceNames;
 
@@ -608,7 +608,7 @@ class Compiler
     /**
      * Instantiate parser
      *
-     * @param string $path
+     * @param string|null $path
      *
      * @return \ScssPhp\ScssPhp\Parser
      */
@@ -621,7 +621,7 @@ class Compiler
         // Otherwise, the CSS will be rendered as-is. It can even be extended!
         $cssOnly = false;
 
-        if (substr($path, -4) === '.css') {
+        if ($path !== null && substr($path, -4) === '.css') {
             $cssOnly = true;
         }
 
@@ -5838,12 +5838,16 @@ class Compiler
     }
 
     /**
-     * @param string $path
+     * @param string|null $path
      *
      * @return string
      */
     private function getPrettyPath($path)
     {
+        if ($path === null) {
+            return '(unknown file)';
+        }
+
         $normalizedPath = $path;
         $normalizedRootDirectory = $this->rootDirectory.'/';
 
@@ -6071,6 +6075,10 @@ class Compiler
             }
 
             $file = $this->sourceNames[$env->block->sourceIndex];
+
+            if ($file === null) {
+                continue;
+            }
 
             if (realpath($file) === $name) {
                 throw $this->error('An @import loop has been found: %s imports %s', $file, basename($file));

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -124,7 +124,7 @@ class Parser
      *
      * @api
      *
-     * @param string               $sourceName
+     * @param string|null          $sourceName
      * @param integer              $sourceIndex
      * @param string|null          $encoding
      * @param Cache|null           $cache


### PR DESCRIPTION
Some wrong phpdoc was omitting the possibility for the source name to be null when a path is not provided, which led to missing it in a few places. With PHP 8.1 deprecating passing null to a bunch of core functions, this was detected.