### PR TITLE
Fix bootstrap compilation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,7 @@
         "squizlabs/php_codesniffer": "~3.5",
         "symfony/phpunit-bridge": "^5.1",
         "twbs/bootstrap": "~5.0",
+        "twbs/bootstrap4": "4.6.0",
         "zurb/foundation": "~6.5"
     },
     "repositories": [
@@ -58,6 +59,24 @@
                     "type": "zip",
                     "url": "https://api.github.com/repos/sass/sass-spec/zipball/b9bf24a936528f333fb30ee59ca550c6da551c11",
                     "reference": "b9bf24a936528f333fb30ee59ca550c6da551c11",
+                    "shasum": ""
+                }
+            }
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "twbs/bootstrap4",
+                "version": "v4.6.0",
+                "source": {
+                    "type": "git",
+                    "url": "https://github.com/twbs/bootstrap.git",
+                    "reference": "6ffb0b48e455430f8a5359ed689ad64c1143fac2"
+                },
+                "dist": {
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/twbs/bootstrap/zipball/6ffb0b48e455430f8a5359ed689ad64c1143fac2",
+                    "reference": "6ffb0b48e455430f8a5359ed689ad64c1143fac2",
                     "shasum": ""
                 }
             }

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -8584,48 +8584,32 @@ will be an error in future versions of Sass.\n         on line $line of $fname";
     protected static $libNth = ['list', 'n'];
     protected function libNth($args)
     {
-        $list = $this->coerceList($args[0]);
-        $n = $this->assertInteger($args[1], 'n');
-
-        if ($n === 0) {
-            throw SassScriptException::forArgument('List index may not be 0.', 'n');
-        }
-
-        $listLength = \count($list[2]);
-
-        if (abs($n) > $listLength) {
-            throw SassScriptException::forArgument("Invalid index $n for a list with $listLength elements.", 'n');
-        }
+        $list = $this->coerceList($args[0], ',', false);
+        $n = $this->assertNumber($args[1])->getDimension();
 
         if ($n > 0) {
             $n--;
-        } else {
-            $n += $listLength;
+        } elseif ($n < 0) {
+            $n += \count($list[2]);
         }
 
-        return $list[2][$n];
+        return isset($list[2][$n]) ? $list[2][$n] : static::$defaultValue;
     }
 
     protected static $libSetNth = ['list', 'n', 'value'];
     protected function libSetNth($args)
     {
         $list = $this->coerceList($args[0]);
-        $n = $this->assertInteger($args[1], 'n');
-
-        if ($n === 0) {
-            throw SassScriptException::forArgument('List index may not be 0.', 'n');
-        }
-
-        $listLength = \count($list[2]);
-
-        if (abs($n) > $listLength) {
-            throw SassScriptException::forArgument("Invalid index $n for a list with $listLength elements.", 'n');
-        }
+        $n = $this->assertNumber($args[1])->getDimension();
 
         if ($n > 0) {
             $n--;
-        } else {
-            $n += $listLength;
+        } elseif ($n < 0) {
+            $n += \count($list[2]);
+        }
+
+        if (! isset($list[2][$n])) {
+            throw $this->error('Invalid argument for "n"');
         }
 
         $list[2][$n] = $args[2];

--- a/tests/FrameworkTest.php
+++ b/tests/FrameworkTest.php
@@ -30,6 +30,36 @@ class FrameworkTest extends TestCase
         $this->assertNotEmpty($result->getCss());
     }
 
+    public function testBootstrap4()
+    {
+        $compiler = new Compiler();
+        $compiler->setLogger(new QuietLogger());
+
+        $entrypoint = dirname(__DIR__) . '/vendor/twbs/bootstrap4/scss/bootstrap.scss';
+
+        $result = $compiler->compileString(file_get_contents($entrypoint), $entrypoint);
+
+        $this->assertNotEmpty($result->getCss());
+    }
+
+    public function testBootstrap4CustomSettings()
+    {
+        $compiler = new Compiler();
+        $compiler->addImportPath(dirname(__DIR__) . '/vendor/twbs/bootstrap4/scss');
+        $compiler->setLogger(new QuietLogger());
+
+        $scss = <<<'SCSS'
+$enable-shadows: true;
+$enable-gradients: true;
+
+@import "bootstrap";
+SCSS;
+
+        $result = $compiler->compileString($scss);
+
+        $this->assertNotEmpty($result->getCss());
+    }
+
     public function testFoundation()
     {
         $compiler = new Compiler();

--- a/tests/specs/sass-spec-exclude.txt
+++ b/tests/specs/sass-spec-exclude.txt
@@ -225,7 +225,11 @@ core_functions/list/join/multi/map/second/space
 core_functions/list/join/single/both/comma/last
 core_functions/list/join/single/first/undecided/and_comma
 core_functions/list/join/single/non_list/first/comma
+core_functions/list/nth/error/index/0
+core_functions/list/nth/error/index/too_high
+core_functions/list/nth/error/index/too_low
 core_functions/list/separator/empty/comma
+core_functions/list/set_nth/error/index/0
 core_functions/list/utils/empty_map/same_as_empty_list
 core_functions/list/utils/real_separator/empty/comma
 core_functions/list/utils/real_separator/empty/undecided


### PR DESCRIPTION
Closes #403 

This reverts #380. fixing spec compliance for lists to avoid breaking list functions is too much work, as it looks like it requires fixing interpolation first.
As Bootstrap seems to compile fine without the `nth` refactoring (even though some other list-related code might have bugs that we already had in 1.4 due to not being spec compliant), I prefer delaying the spec compliance fix to a 2.x release rewriting the parser.