### PR TITLE
Implement the stylesheet parser ported from dart-sass

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,6 +1,16 @@
 parameters:
 	ignoreErrors:
 		-
+			message: "#^PHPDoc tag @template T for class ScssPhp\\\\ScssPhp\\\\Ast\\\\Sass\\\\Statement\\\\ParentStatement with bound type array\\<ScssPhp\\\\ScssPhp\\\\Ast\\\\Sass\\\\Statement\\> is not supported\\.$#"
+			count: 1
+			path: src/Ast/Sass/Statement/ParentStatement.php
+
+		-
+			message: "#^PHPDoc tag @template T for class ScssPhp\\\\ScssPhp\\\\Ast\\\\Sass\\\\Statement\\\\ParentStatement with bound type null is not supported\\.$#"
+			count: 1
+			path: src/Ast/Sass/Statement/ParentStatement.php
+
+		-
 			message: "#^Property ScssPhp\\\\ScssPhp\\\\Block\\:\\:\\$children type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Block.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -46,11 +46,6 @@ parameters:
 			path: src/Cache.php
 
 		-
-			message: "#^Result of \\|\\| is always false\\.$#"
-			count: 3
-			path: src/Colors.php
-
-		-
 			message: "#^Access to an undefined property ScssPhp\\\\ScssPhp\\\\Block\\:\\:\\$hasValue\\.$#"
 			count: 1
 			path: src/Compiler.php
@@ -1267,7 +1262,7 @@ parameters:
 
 		-
 			message: "#^Negated boolean expression is always false\\.$#"
-			count: 2
+			count: 1
 			path: src/Compiler.php
 
 		-

--- a/phpstan-no-baseline.neon
+++ b/phpstan-no-baseline.neon
@@ -4,7 +4,15 @@ parameters:
     treatPhpDocTypesAsCertain: false
     paths:
         - ./src/
+    scanDirectories:
+        - vendor-bin/phpstan/vendor/symfony/
     ignoreErrors:
+        # We want to document the enum as return type, without caring about the exact values.
+        -
+            message: "#^Method ScssPhp\\\\ScssPhp\\\\Parser\\\\StylesheetParser\\:\\:unaryOperatorFor\\(\\) never returns 'not' so it can be removed from the return typehint\\.$#"
+            count: 1
+            path: src/Parser/StylesheetParser.php
+
         # Ignore errors about not having typehints for definitions of builtin functions. These won't be typed until they are extracted.
         -
             message: "#^Property ScssPhp\\\\ScssPhp\\\\Compiler\\:\\:\\$lib[\\w]+ has no typehint specified\\.$#"

--- a/phpstan-no-baseline.neon
+++ b/phpstan-no-baseline.neon
@@ -1,6 +1,7 @@
 parameters:
     level: 8
     inferPrivatePropertyTypeFromConstructor: true
+    treatPhpDocTypesAsCertain: false
     paths:
         - ./src/
     ignoreErrors:

--- a/src/Ast/AstNode.php
+++ b/src/Ast/AstNode.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast;
+
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+
+/**
+ * A node in an abstract syntax tree.
+ *
+ * @internal
+ */
+interface AstNode
+{
+    public function getSpan(): FileSpan;
+}

--- a/src/Ast/Sass/Argument.php
+++ b/src/Ast/Sass/Argument.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass;
+
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+use ScssPhp\ScssPhp\Util\SpanUtil;
+
+/**
+ * An argument declared as part of an {@see ArgumentDeclaration}.
+ *
+ * @internal
+ */
+final class Argument implements SassNode, SassDeclaration
+{
+    /**
+     * @var string
+     * @readonly
+     */
+    private $name;
+
+    /**
+     * @var Expression|null
+     * @readonly
+     */
+    private $defaultValue;
+
+    /**
+     * @var FileSpan
+     * @readonly
+     */
+    private $span;
+
+    public function __construct(string $name, FileSpan $span, ?Expression $defaultValue = null)
+    {
+        $this->name = $name;
+        $this->defaultValue = $defaultValue;
+        $this->span = $span;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getNameSpan(): FileSpan
+    {
+        if ($this->defaultValue === null) {
+            return $this->span;
+        }
+
+        return SpanUtil::initialIdentifier($this->span, 1);
+    }
+
+    public function getDefaultValue(): ?Expression
+    {
+        return $this->defaultValue;
+    }
+
+    public function getSpan(): FileSpan
+    {
+        return $this->span;
+    }
+}

--- a/src/Ast/Sass/ArgumentDeclaration.php
+++ b/src/Ast/Sass/ArgumentDeclaration.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass;
+
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+
+/**
+ * An argument declaration, as for a function or mixin definition.
+ *
+ * @internal
+ */
+final class ArgumentDeclaration implements SassNode
+{
+    /**
+     * @var list<Argument>
+     * @readonly
+     */
+    private $arguments;
+
+    /**
+     * @var string|null
+     * @readonly
+     */
+    private $restArgument;
+
+    /**
+     * @var FileSpan
+     * @readonly
+     */
+    private $span;
+
+    /**
+     * @param list<Argument> $arguments
+     * @param FileSpan      $span
+     * @param string|null $restArgument
+     */
+    public function __construct(array $arguments, FileSpan $span, ?string $restArgument = null)
+    {
+        $this->arguments = $arguments;
+        $this->restArgument = $restArgument;
+        $this->span = $span;
+    }
+
+    public static function createEmpty(FileSpan $span): ArgumentDeclaration
+    {
+        return new self([], $span);
+    }
+
+    public function isEmpty(): bool
+    {
+        return \count($this->arguments) === 0 && $this->restArgument === null;
+    }
+
+    /**
+     * @return list<Argument>
+     */
+    public function getArguments(): array
+    {
+        return $this->arguments;
+    }
+
+    public function getRestArgument(): ?string
+    {
+        return $this->restArgument;
+    }
+
+    public function getSpan(): FileSpan
+    {
+        return $this->span;
+    }
+}

--- a/src/Ast/Sass/ArgumentInvocation.php
+++ b/src/Ast/Sass/ArgumentInvocation.php
@@ -1,0 +1,111 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass;
+
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+
+/**
+ * A set of arguments passed in to a function or mixin.
+ *
+ * @internal
+ */
+final class ArgumentInvocation implements SassNode
+{
+    /**
+     * @var list<Expression>
+     * @readonly
+     */
+    private $positional;
+
+    /**
+     * @var array<string, Expression>
+     * @readonly
+     */
+    private $named;
+
+    /**
+     * @var Expression|null
+     * @readonly
+     */
+    private $rest;
+
+    /**
+     * @var Expression|null
+     */
+    private $keywordRest;
+
+    /**
+     * @var FileSpan
+     * @readonly
+     */
+    private $span;
+
+    /**
+     * @param list<Expression>          $positional
+     * @param array<string, Expression> $named
+     * @param FileSpan                  $span
+     * @param Expression|null           $rest
+     * @param Expression|null           $keywordRest
+     */
+    public function __construct(array $positional, array $named, FileSpan $span, ?Expression $rest = null, ?Expression $keywordRest = null)
+    {
+        assert($keywordRest === null || $rest !== null);
+
+        $this->positional = $positional;
+        $this->named = $named;
+        $this->rest = $rest;
+        $this->keywordRest = $keywordRest;
+        $this->span = $span;
+    }
+
+    public static function createEmpty(FileSpan $span): ArgumentInvocation
+    {
+        return new self([], [], $span);
+    }
+
+    public function isEmpty(): bool
+    {
+        return \count($this->positional) === 0 && \count($this->named) === 0 && $this->rest === null;
+    }
+
+    /**
+     * @return list<Expression>
+     */
+    public function getPositional(): array
+    {
+        return $this->positional;
+    }
+
+    /**
+     * @return array<string, Expression>
+     */
+    public function getNamed(): array
+    {
+        return $this->named;
+    }
+
+    public function getRest(): ?Expression
+    {
+        return $this->rest;
+    }
+
+    public function getKeywordRest(): ?Expression
+    {
+        return $this->keywordRest;
+    }
+
+    public function getSpan(): FileSpan
+    {
+        return $this->span;
+    }
+}

--- a/src/Ast/Sass/CallableInvocation.php
+++ b/src/Ast/Sass/CallableInvocation.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass;
+
+interface CallableInvocation extends SassNode
+{
+    public function getArguments(): ArgumentInvocation;
+}

--- a/src/Ast/Sass/ConfiguredVariable.php
+++ b/src/Ast/Sass/ConfiguredVariable.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass;
+
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+use ScssPhp\ScssPhp\Util\SpanUtil;
+
+/**
+ * A variable configured by a `with` clause in a `@use` or `@forward` rule.
+ *
+ * @internal
+ */
+final class ConfiguredVariable implements SassNode, SassDeclaration
+{
+    /**
+     * @var string
+     * @readonly
+     */
+    private $name;
+
+    /**
+     * @var Expression
+     * @readonly
+     */
+    private $expression;
+
+    /**
+     * @var FileSpan
+     * @readonly
+     */
+    private $span;
+
+    /**
+     * @var bool
+     * @readonly
+     */
+    private $guarded;
+
+    public function __construct(string $name, Expression $expression, FileSpan $span, bool $guarded = false)
+    {
+        $this->name = $name;
+        $this->expression = $expression;
+        $this->span = $span;
+        $this->guarded = $guarded;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getExpression(): Expression
+    {
+        return $this->expression;
+    }
+
+    public function getSpan(): FileSpan
+    {
+        return $this->span;
+    }
+
+    public function isGuarded(): bool
+    {
+        return $this->guarded;
+    }
+
+    public function getNameSpan(): FileSpan
+    {
+        return SpanUtil::initialIdentifier($this->span, 1);
+    }
+}

--- a/src/Ast/Sass/Expression.php
+++ b/src/Ast/Sass/Expression.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass;
+
+use ScssPhp\ScssPhp\Visitor\ExpressionVisitor;
+
+/**
+ * A SassScript expression in a Sass syntax tree.
+ *
+ * @internal
+ */
+interface Expression extends SassNode
+{
+    /**
+     * @template T
+     * @param ExpressionVisitor<T> $visitor
+     * @return T
+     */
+    public function accepts(ExpressionVisitor $visitor);
+}

--- a/src/Ast/Sass/Expression/BinaryOperationExpression.php
+++ b/src/Ast/Sass/Expression/BinaryOperationExpression.php
@@ -1,0 +1,114 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass\Expression;
+
+use ScssPhp\ScssPhp\Ast\Sass\Expression;
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+use ScssPhp\ScssPhp\Visitor\ExpressionVisitor;
+
+final class BinaryOperationExpression implements Expression
+{
+    /**
+     * @var BinaryOperator::*
+     * @readonly
+     */
+    private $operator;
+
+    /**
+     * @var Expression
+     * @readonly
+     */
+    private $left;
+
+    /**
+     * @var Expression
+     * @readonly
+     */
+    private $right;
+
+    /**
+     * Whether this is a dividedBy operation that may be interpreted as slash-separated numbers.
+     *
+     * @var bool
+     */
+    private $allowsSlash = false;
+
+    /**
+     * @param BinaryOperator::* $operator
+     */
+    public function __construct(string $operator, Expression $left, Expression $right)
+    {
+        $this->operator = $operator;
+        $this->left = $left;
+        $this->right = $right;
+    }
+
+    /**
+     * Creates a dividedBy operation that may be interpreted as slash-separated numbers.
+     */
+    public static function slash(Expression $left, Expression $right): self
+    {
+        $operation = new self(BinaryOperator::DIVIDED_BY, $left, $right);
+        $operation->allowsSlash = true;
+
+        return $operation;
+    }
+
+    /**
+     * @return BinaryOperator::*
+     */
+    public function getOperator(): string
+    {
+        return $this->operator;
+    }
+
+    public function getLeft(): Expression
+    {
+        return $this->left;
+    }
+
+    public function getRight(): Expression
+    {
+        return $this->right;
+    }
+
+    public function allowsSlash(): bool
+    {
+        return $this->allowsSlash;
+    }
+
+    public function getSpan(): FileSpan
+    {
+        $left = $this->left;
+
+        while ($left instanceof BinaryOperationExpression) {
+            $left = $left->left;
+        }
+
+        $right = $this->right;
+
+        while ($right instanceof BinaryOperationExpression) {
+            $right = $right->right;
+        }
+
+        $leftSpan = $left->getSpan();
+        $rightSpan = $right->getSpan();
+
+        return $leftSpan->expand($rightSpan);
+    }
+
+    public function accepts(ExpressionVisitor $visitor)
+    {
+        return $visitor->visitBinaryOperationExpression($this);
+    }
+}

--- a/src/Ast/Sass/Expression/BinaryOperator.php
+++ b/src/Ast/Sass/Expression/BinaryOperator.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass\Expression;
+
+/**
+ * @internal
+ */
+final class BinaryOperator
+{
+    const SINGLE_EQUALS = '=';
+    const OR = 'or';
+    const AND = 'and';
+    const EQUALS = '==';
+    const NOT_EQUALS = '!=';
+    const GREATER_THAN = '>';
+    const GREATER_THAN_OR_EQUALS = '>=';
+    const LESS_THAN = '<';
+    const LESS_THAN_OR_EQUALS = '<=';
+    const PLUS = '+';
+    const MINUS = '-';
+    const TIMES = '*';
+    const DIVIDED_BY = '/';
+    const MODULO = '%';
+
+    /**
+     * @param BinaryOperator::* $operator
+     */
+    public static function getPrecedence(string $operator): int
+    {
+        switch ($operator) {
+            case self::SINGLE_EQUALS:
+                return 0;
+
+            case self::OR:
+                return 1;
+
+            case self::AND:
+                return 2;
+
+            case self::EQUALS:
+            case self::NOT_EQUALS:
+                return 3;
+
+            case self::GREATER_THAN:
+            case self::GREATER_THAN_OR_EQUALS:
+            case self::LESS_THAN:
+            case self::LESS_THAN_OR_EQUALS:
+                return 4;
+
+            case self::PLUS:
+            case self::MINUS:
+                return 5;
+
+            case self::TIMES:
+            case self::DIVIDED_BY:
+            case self::MODULO:
+                return 6;
+        }
+
+        throw new \InvalidArgumentException(sprintf('Unknown operator "%s".', $operator));
+    }
+}

--- a/src/Ast/Sass/Expression/BooleanExpression.php
+++ b/src/Ast/Sass/Expression/BooleanExpression.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass\Expression;
+
+use ScssPhp\ScssPhp\Ast\Sass\Expression;
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+use ScssPhp\ScssPhp\Visitor\ExpressionVisitor;
+
+/**
+ * A boolean literal, `true` or `false`.
+ *
+ * @internal
+ */
+final class BooleanExpression implements Expression
+{
+    /**
+     * @var bool
+     * @readonly
+     */
+    private $value;
+
+    /**
+     * @var FileSpan
+     * @readonly
+     */
+    private $span;
+
+    public function __construct(bool $value, FileSpan $span)
+    {
+        $this->value = $value;
+        $this->span = $span;
+    }
+
+    public function getValue(): bool
+    {
+        return $this->value;
+    }
+
+    public function getSpan(): FileSpan
+    {
+        return $this->span;
+    }
+
+    public function accepts(ExpressionVisitor $visitor)
+    {
+        return $visitor->visitBooleanExpression($this);
+    }
+}

--- a/src/Ast/Sass/Expression/CalculationExpression.php
+++ b/src/Ast/Sass/Expression/CalculationExpression.php
@@ -1,0 +1,230 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass\Expression;
+
+use ScssPhp\ScssPhp\Ast\Sass\Expression;
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+use ScssPhp\ScssPhp\Visitor\ExpressionVisitor;
+
+/**
+ * A calculation literal.
+ *
+ * @internal
+ */
+class CalculationExpression implements Expression
+{
+    /**
+     * This calculation's name.
+     *
+     * @var string
+     * @readonly
+     */
+    private $name;
+
+    /**
+     * The arguments for the calculation.
+     *
+     * @var list<Expression>
+     * @readonly
+     */
+    private $arguments;
+
+    /**
+     * @var FileSpan
+     * @readonly
+     */
+    private $span;
+
+    /**
+     * Returns a `calc()` calculation expression.
+     *
+     * @param Expression $argument
+     * @param FileSpan   $span
+     *
+     * @return CalculationExpression
+     */
+    public static function calc(Expression $argument, FileSpan $span): CalculationExpression
+    {
+        return new CalculationExpression('calc', [$argument], $span);
+    }
+
+    /**
+     * Returns a `min()` calculation expression.
+     *
+     * @param list<Expression> $arguments
+     * @param FileSpan         $span
+     *
+     * @return CalculationExpression
+     */
+    public static function min(array $arguments, FileSpan $span): CalculationExpression
+    {
+        if (!$arguments) {
+            throw new \InvalidArgumentException('min() requires at least one argument.');
+        }
+
+        return new CalculationExpression('min', $arguments, $span);
+    }
+
+    /**
+     * Returns a `max()` calculation expression.
+     *
+     * @param list<Expression> $arguments
+     * @param FileSpan         $span
+     *
+     * @return CalculationExpression
+     */
+    public static function max(array $arguments, FileSpan $span): CalculationExpression
+    {
+        if (!$arguments) {
+            throw new \InvalidArgumentException('max() requires at least one argument.');
+        }
+
+        return new CalculationExpression('max', $arguments, $span);
+    }
+
+    /**
+     * Returns a `clamp()` calculation expression.
+     *
+     * @param Expression $min
+     * @param Expression $value
+     * @param Expression $max
+     * @param FileSpan   $span
+     *
+     * @return CalculationExpression
+     */
+    public static function clamp(Expression $min, Expression $value, Expression $max, FileSpan $span): CalculationExpression
+    {
+        return new CalculationExpression('clamp', [$min, $value, $max], $span);
+    }
+
+    /**
+     * Returns a calculation expression with the given name and arguments.
+     *
+     * Unlike the other constructors, this doesn't verify that the arguments are
+     * valid for the name.
+     *
+     * @param string           $name
+     * @param list<Expression> $arguments
+     * @param FileSpan         $span
+     */
+    public function __construct(string $name, array $arguments, FileSpan $span)
+    {
+        self::verifyArguments($arguments);
+        $this->name = $name;
+        $this->arguments = $arguments;
+        $this->span = $span;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return list<Expression>
+     */
+    public function getArguments(): array
+    {
+        return $this->arguments;
+    }
+
+    public function getSpan(): FileSpan
+    {
+        return $this->span;
+    }
+
+    public function accepts(ExpressionVisitor $visitor)
+    {
+        return $visitor->visitCalculationExpression($this);
+    }
+
+    /**
+     * @param list<Expression> $arguments
+     *
+     * @throws \InvalidArgumentException if $arguments aren't valid calculation arguments.
+     */
+    private static function verifyArguments(array $arguments): void
+    {
+        foreach ($arguments as $argument) {
+            self::verify($argument);
+        }
+    }
+
+    /**
+     * @throws \InvalidArgumentException if $expression isn't a valid calculation argument.
+     */
+    private static function verify(Expression $expression): void
+    {
+        if ($expression instanceof NumberExpression) {
+            return;
+        }
+
+        if ($expression instanceof CalculationExpression) {
+            return;
+        }
+
+        if ($expression instanceof VariableExpression) {
+            return;
+        }
+
+        if ($expression instanceof FunctionExpression) {
+            return;
+        }
+
+        if ($expression instanceof IfExpression) {
+            return;
+        }
+
+        if ($expression instanceof StringExpression) {
+            if ($expression->hasQuotes()) {
+                throw new \InvalidArgumentException('Invalid calculation argument.');
+            }
+
+            return;
+        }
+
+        if ($expression instanceof ParenthesizedExpression) {
+            self::verify($expression->getExpression());
+
+            return;
+        }
+
+        if ($expression instanceof BinaryOperationExpression) {
+            self::verify($expression->getLeft());
+            self::verify($expression->getRight());
+
+            if ($expression->getOperator() === BinaryOperator::PLUS) {
+                return;
+            }
+
+            if ($expression->getOperator() === BinaryOperator::MINUS) {
+                return;
+            }
+
+            if ($expression->getOperator() === BinaryOperator::TIMES) {
+                return;
+            }
+
+            if ($expression->getOperator() === BinaryOperator::DIVIDED_BY) {
+                return;
+            }
+
+            throw new \InvalidArgumentException('Invalid calculation argument.');
+        }
+
+        throw new \InvalidArgumentException('Invalid calculation argument.');
+    }
+}

--- a/src/Ast/Sass/Expression/ColorExpression.php
+++ b/src/Ast/Sass/Expression/ColorExpression.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass\Expression;
+
+use ScssPhp\ScssPhp\Ast\Sass\Expression;
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+use ScssPhp\ScssPhp\Value\SassColor;
+use ScssPhp\ScssPhp\Visitor\ExpressionVisitor;
+
+/**
+ * A color literal.
+ *
+ * @internal
+ */
+final class ColorExpression implements Expression
+{
+    /**
+     * @var SassColor
+     * @readonly
+     */
+    private $value;
+
+    /**
+     * @var FileSpan
+     * @readonly
+     */
+    private $span;
+
+    public function __construct(SassColor $value, FileSpan $span)
+    {
+        $this->value = $value;
+        $this->span = $span;
+    }
+
+    public function getValue(): SassColor
+    {
+        return $this->value;
+    }
+
+    public function getSpan(): FileSpan
+    {
+        return $this->span;
+    }
+
+    public function accepts(ExpressionVisitor $visitor)
+    {
+        return $visitor->visitColorExpression($this);
+    }
+}

--- a/src/Ast/Sass/Expression/FunctionExpression.php
+++ b/src/Ast/Sass/Expression/FunctionExpression.php
@@ -1,0 +1,128 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass\Expression;
+
+use ScssPhp\ScssPhp\Ast\Sass\ArgumentInvocation;
+use ScssPhp\ScssPhp\Ast\Sass\CallableInvocation;
+use ScssPhp\ScssPhp\Ast\Sass\Expression;
+use ScssPhp\ScssPhp\Ast\Sass\SassReference;
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+use ScssPhp\ScssPhp\Util\SpanUtil;
+use ScssPhp\ScssPhp\Visitor\ExpressionVisitor;
+
+/**
+ * A function invocation.
+ *
+ * This may be a plain CSS function or a Sass function,  but may not include
+ * interpolation.
+ *
+ * @internal
+ */
+final class FunctionExpression implements Expression, CallableInvocation, SassReference
+{
+    /**
+     * The name of the function being invoked, with underscores left as-is.
+     *
+     * @var string
+     * @readonly
+     */
+    private $originalName;
+
+    /**
+     * The arguments to pass to the function.
+     *
+     * @var ArgumentInvocation
+     * @readonly
+     */
+    private $arguments;
+
+    /**
+     * The namespace of the function being invoked, or `null` if it's invoked
+     * without a namespace.
+     *
+     * @var string|null
+     * @readonly
+     */
+    private $namespace;
+
+    /**
+     * @var FileSpan
+     * @readonly
+     */
+    private $span;
+
+    public function __construct(string $originalName, ArgumentInvocation $arguments, FileSpan $span, ?string $namespace = null)
+    {
+        $this->span = $span;
+        $this->originalName = $originalName;
+        $this->arguments = $arguments;
+        $this->namespace = $namespace;
+    }
+
+    /**
+     * @return string
+     */
+    public function getOriginalName(): string
+    {
+        return $this->originalName;
+    }
+
+    /**
+     * The name of the function being invoked, with underscores converted to
+     * hyphens.
+     *
+     * If this function is a plain CSS function, use {@see getOriginalName} instead.
+     */
+    public function getName(): string
+    {
+        return str_replace('_', '-', $this->originalName);
+    }
+
+    public function getArguments(): ArgumentInvocation
+    {
+        return $this->arguments;
+    }
+
+    public function getNamespace(): ?string
+    {
+        return $this->namespace;
+    }
+
+    public function getSpan(): FileSpan
+    {
+        return $this->span;
+    }
+
+    public function getNameSpan(): FileSpan
+    {
+        if ($this->namespace === null) {
+            return SpanUtil::initialIdentifier($this->span);
+        }
+
+        return SpanUtil::initialIdentifier(SpanUtil::withoutNamespace($this->span));
+    }
+
+    public function getNamespaceSpan(): ?FileSpan
+    {
+        if ($this->namespace === null) {
+            return null;
+        }
+
+        return SpanUtil::initialIdentifier($this->span);
+    }
+
+    public function accepts(ExpressionVisitor $visitor)
+    {
+        return $visitor->visitFunctionExpression($this);
+    }
+}

--- a/src/Ast/Sass/Expression/IfExpression.php
+++ b/src/Ast/Sass/Expression/IfExpression.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass\Expression;
+
+use ScssPhp\ScssPhp\Ast\Sass\ArgumentInvocation;
+use ScssPhp\ScssPhp\Ast\Sass\CallableInvocation;
+use ScssPhp\ScssPhp\Ast\Sass\Expression;
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+use ScssPhp\ScssPhp\Visitor\ExpressionVisitor;
+
+/**
+ * A ternary expression.
+ *
+ * This is defined as a separate syntactic construct rather than a normal
+ * function because only one of the `$if-true` and `$if-false` arguments are
+ * evaluated.
+ *
+ * @internal
+ */
+final class IfExpression implements Expression, CallableInvocation
+{
+    /**
+     * The arguments passed to `if()`.
+     *
+     * @var ArgumentInvocation
+     * @readonly
+     */
+    private $arguments;
+
+    /**
+     * @var FileSpan
+     * @readonly
+     */
+    private $span;
+
+    public function __construct(ArgumentInvocation $arguments, FileSpan $span)
+    {
+        $this->span = $span;
+        $this->arguments = $arguments;
+    }
+
+    public function getArguments(): ArgumentInvocation
+    {
+        return $this->arguments;
+    }
+
+    public function getSpan(): FileSpan
+    {
+        return $this->span;
+    }
+
+    public function accepts(ExpressionVisitor $visitor)
+    {
+        return $visitor->visitIfExpression($this);
+    }
+}

--- a/src/Ast/Sass/Expression/InterpolatedFunctionExpression.php
+++ b/src/Ast/Sass/Expression/InterpolatedFunctionExpression.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass\Expression;
+
+use ScssPhp\ScssPhp\Ast\Sass\ArgumentInvocation;
+use ScssPhp\ScssPhp\Ast\Sass\CallableInvocation;
+use ScssPhp\ScssPhp\Ast\Sass\Expression;
+use ScssPhp\ScssPhp\Ast\Sass\Interpolation;
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+use ScssPhp\ScssPhp\Visitor\ExpressionVisitor;
+
+/**
+ * An interpolated function invocation.
+ *
+ * This is always a plain CSS function.
+ *
+ * @internal
+ */
+final class InterpolatedFunctionExpression implements Expression, CallableInvocation
+{
+    /**
+     * The name of the function being invoked.
+     *
+     * @var Interpolation
+     * @readonly
+     */
+    private $name;
+
+    /**
+     * The arguments to pass to the function.
+     *
+     * @var ArgumentInvocation
+     * @readonly
+     */
+    private $arguments;
+
+    /**
+     * @var FileSpan
+     * @readonly
+     */
+    private $span;
+
+    public function __construct(Interpolation $name, ArgumentInvocation $arguments, FileSpan $span)
+    {
+        $this->span = $span;
+        $this->name = $name;
+        $this->arguments = $arguments;
+    }
+
+    public function getName(): Interpolation
+    {
+        return $this->name;
+    }
+
+    public function getArguments(): ArgumentInvocation
+    {
+        return $this->arguments;
+    }
+
+    public function getSpan(): FileSpan
+    {
+        return $this->span;
+    }
+
+    public function accepts(ExpressionVisitor $visitor)
+    {
+        return $visitor->visitInterpolatedFunctionExpression($this);
+    }
+}

--- a/src/Ast/Sass/Expression/ListExpression.php
+++ b/src/Ast/Sass/Expression/ListExpression.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass\Expression;
+
+use ScssPhp\ScssPhp\Ast\Sass\Expression;
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+use ScssPhp\ScssPhp\Value\ListSeparator;
+use ScssPhp\ScssPhp\Visitor\ExpressionVisitor;
+
+/**
+ * A list literal.
+ *
+ * @internal
+ */
+final class ListExpression implements Expression
+{
+    /**
+     * @var Expression[]
+     * @readonly
+     */
+    private $contents;
+
+    /**
+     * @var ListSeparator::*
+     * @readonly
+     */
+    private $separator;
+
+    /**
+     * @var FileSpan
+     * @readonly
+     */
+    private $span;
+
+    /**
+     * @var bool
+     * @readonly
+     */
+    private $brackets;
+
+    /**
+     * ListExpression constructor.
+     *
+     * @param Expression[] $contents
+     * @param ListSeparator::* $separator
+     */
+    public function __construct(array $contents, string $separator, FileSpan $span, bool $brackets = false)
+    {
+        $this->contents = $contents;
+        $this->separator = $separator;
+        $this->span = $span;
+        $this->brackets = $brackets;
+    }
+
+    /**
+     * @return Expression[]
+     */
+    public function getContents(): array
+    {
+        return $this->contents;
+    }
+
+    /**
+     * @return ListSeparator::*
+     */
+    public function getSeparator(): string
+    {
+        return $this->separator;
+    }
+
+    public function hasBrackets(): bool
+    {
+        return $this->brackets;
+    }
+
+    public function getSpan(): FileSpan
+    {
+        return $this->span;
+    }
+
+    public function accepts(ExpressionVisitor $visitor)
+    {
+        return $visitor->visitListExpression($this);
+    }
+}

--- a/src/Ast/Sass/Expression/MapExpression.php
+++ b/src/Ast/Sass/Expression/MapExpression.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass\Expression;
+
+use ScssPhp\ScssPhp\Ast\Sass\Expression;
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+use ScssPhp\ScssPhp\Visitor\ExpressionVisitor;
+
+/**
+ * A map literal.
+ *
+ * @internal
+ */
+final class MapExpression implements Expression
+{
+    /**
+     * @var list<array{Expression, Expression}>
+     * @readonly
+     */
+    private $pairs;
+
+    /**
+     * @var FileSpan
+     * @readonly
+     */
+    private $span;
+
+    /**
+     * @param list<array{Expression, Expression}> $pairs
+     */
+    public function __construct(array $pairs, FileSpan $span)
+    {
+        $this->pairs = $pairs;
+        $this->span = $span;
+    }
+
+    /**
+     * @return list<array{Expression, Expression}>
+     */
+    public function getPairs(): array
+    {
+        return $this->pairs;
+    }
+
+    public function getSpan(): FileSpan
+    {
+        return $this->span;
+    }
+
+    public function accepts(ExpressionVisitor $visitor)
+    {
+        return $visitor->visitMapExpression($this);
+    }
+}

--- a/src/Ast/Sass/Expression/NullExpression.php
+++ b/src/Ast/Sass/Expression/NullExpression.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass\Expression;
+
+use ScssPhp\ScssPhp\Ast\Sass\Expression;
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+use ScssPhp\ScssPhp\Visitor\ExpressionVisitor;
+
+/**
+ * A null literal.
+ *
+ * @internal
+ */
+final class NullExpression implements Expression
+{
+    /**
+     * @var FileSpan
+     * @readonly
+     */
+    private $span;
+
+    public function __construct(FileSpan $span)
+    {
+        $this->span = $span;
+    }
+
+    public function getSpan(): FileSpan
+    {
+        return $this->span;
+    }
+
+    public function accepts(ExpressionVisitor $visitor)
+    {
+        return $visitor->visitNullExpression($this);
+    }
+}

--- a/src/Ast/Sass/Expression/NumberExpression.php
+++ b/src/Ast/Sass/Expression/NumberExpression.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass\Expression;
+
+use ScssPhp\ScssPhp\Ast\Sass\Expression;
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+use ScssPhp\ScssPhp\Visitor\ExpressionVisitor;
+
+/**
+ * A number literal.
+ *
+ * @internal
+ */
+final class NumberExpression implements Expression
+{
+    /**
+     * @var float|int
+     * @readonly
+     */
+    private $value;
+
+    /**
+     * @var FileSpan
+     * @readonly
+     */
+    private $span;
+
+    /**
+     * @var string|null
+     * @readonly
+     */
+    private $unit;
+
+    /**
+     * @param int|float $value
+     */
+    public function __construct($value, FileSpan $span, ?string $unit = null)
+    {
+        $this->value = $value;
+        $this->span = $span;
+        $this->unit = $unit;
+    }
+
+    /**
+     * @return float|int
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    public function getSpan(): FileSpan
+    {
+        return $this->span;
+    }
+
+    public function getUnit(): ?string
+    {
+        return $this->unit;
+    }
+
+    public function accepts(ExpressionVisitor $visitor)
+    {
+        return $visitor->visitNumberExpression($this);
+    }
+}

--- a/src/Ast/Sass/Expression/ParenthesizedExpression.php
+++ b/src/Ast/Sass/Expression/ParenthesizedExpression.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass\Expression;
+
+use ScssPhp\ScssPhp\Ast\Sass\Expression;
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+use ScssPhp\ScssPhp\Visitor\ExpressionVisitor;
+
+/**
+ * An expression wrapped in parentheses.
+ *
+ * @internal
+ */
+final class ParenthesizedExpression implements Expression
+{
+    /**
+     * @var Expression
+     * @readonly
+     */
+    private $expression;
+
+    /**
+     * @var FileSpan
+     * @readonly
+     */
+    private $span;
+
+    public function __construct(Expression $expression, FileSpan $span)
+    {
+        $this->expression = $expression;
+        $this->span = $span;
+    }
+
+    public function getExpression(): Expression
+    {
+        return $this->expression;
+    }
+
+    public function getSpan(): FileSpan
+    {
+        return $this->span;
+    }
+
+    public function accepts(ExpressionVisitor $visitor)
+    {
+        return $visitor->visitParenthesizedExpression($this);
+    }
+}

--- a/src/Ast/Sass/Expression/SelectorExpression.php
+++ b/src/Ast/Sass/Expression/SelectorExpression.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass\Expression;
+
+use ScssPhp\ScssPhp\Ast\Sass\Expression;
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+use ScssPhp\ScssPhp\Visitor\ExpressionVisitor;
+
+/**
+ * A parent selector reference, `&`.
+ *
+ * @internal
+ */
+final class SelectorExpression implements Expression
+{
+    /**
+     * @var FileSpan
+     * @readonly
+     */
+    private $span;
+
+    public function __construct(FileSpan $span)
+    {
+        $this->span = $span;
+    }
+
+    public function getSpan(): FileSpan
+    {
+        return $this->span;
+    }
+
+    public function accepts(ExpressionVisitor $visitor)
+    {
+        return $visitor->visitSelectorExpression($this);
+    }
+}

--- a/src/Ast/Sass/Expression/StringExpression.php
+++ b/src/Ast/Sass/Expression/StringExpression.php
@@ -1,0 +1,161 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass\Expression;
+
+use ScssPhp\ScssPhp\Ast\Sass\Expression;
+use ScssPhp\ScssPhp\Ast\Sass\Interpolation;
+use ScssPhp\ScssPhp\Parser\InterpolationBuffer;
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+use ScssPhp\ScssPhp\Util\Character;
+use ScssPhp\ScssPhp\Visitor\ExpressionVisitor;
+
+/**
+ * A string literal.
+ *
+ * @internal
+ */
+final class StringExpression implements Expression
+{
+    /**
+     * @var Interpolation
+     * @readonly
+     */
+    private $text;
+
+    /**
+     * @var bool
+     * @readonly
+     */
+    private $quotes;
+
+    public function __construct(Interpolation $text, bool $quotes = false)
+    {
+        $this->text = $text;
+        $this->quotes = $quotes;
+    }
+
+    /**
+     * Returns a string expression with no interpolation.
+     */
+    public static function plain(string $text, FileSpan $span, bool $quotes = false): self
+    {
+        return new self(new Interpolation([$text], $span), $quotes);
+    }
+
+    public function getText(): Interpolation
+    {
+        return $this->text;
+    }
+
+    public function hasQuotes(): bool
+    {
+        return $this->quotes;
+    }
+
+    public function getSpan(): FileSpan
+    {
+        return $this->text->getSpan();
+    }
+
+    public function accepts(ExpressionVisitor $visitor)
+    {
+        return $visitor->visitStringExpression($this);
+    }
+
+    public function asInterpolation(bool $static = false, string $quote = null): Interpolation
+    {
+        if (!$this->quotes) {
+            return $this->text;
+        }
+
+        $quote = $quote ?? self::bestQuote($this->text->getContents());
+        $buffer = new InterpolationBuffer();
+
+        $buffer->write($quote);
+
+        foreach ($this->text->getContents() as $value) {
+            if ($value instanceof Expression) {
+                $buffer->add($value);
+            } else {
+                self::quoteInnerText($value, $quote, $buffer, $static);
+            }
+        }
+
+        $buffer->write($quote);
+
+        return $buffer->buildInterpolation($this->text->getSpan());
+    }
+
+    private static function quoteInnerText(string $value, string $quote, InterpolationBuffer $buffer, bool $static = false): void
+    {
+        $length = \strlen($value);
+
+        for ($i = 0; $i < $length; $i++) {
+            $char = $value[$i];
+
+            if (Character::isNewline($char)) {
+                $buffer->write('\\a');
+
+                if ($i !== $length - 1) {
+                    $next = $value[$i + 1];
+
+                    if (Character::isWhitespace($next) || Character::isHex($next)) {
+                        $buffer->write(' ');
+                    }
+                }
+            } else {
+                if ($char === $quote || $char === '\\' || ($static && $char === '#' && $i < $length - 1 && $value[$i + 1] === '{')) {
+                    $buffer->write('\\');
+                }
+
+                if (\ord($char) < 0x80) {
+                    $buffer->write($char);
+                } else {
+                    if (!preg_match('/./usA', $value, $m, 0, $i)) {
+                        throw new \UnexpectedValueException('Invalid UTF-8 char');
+                    }
+
+                    $buffer->write($m[0]);
+                    $i += \strlen($m[0]) - 1; // skip over the extra bytes that have been processed.
+                }
+            }
+        }
+
+    }
+
+    /**
+     * @param array<string|Expression> $parts
+     *
+     * @return string
+     */
+    private static function bestQuote(array $parts): string
+    {
+        $containsDoubleQuote = false;
+
+        foreach ($parts as $part) {
+            if (!\is_string($part)) {
+                continue;
+            }
+
+            if (false !== strpos($part, "'")) {
+                return '"';
+            }
+
+            if (false !== strpos($part, '"')) {
+                $containsDoubleQuote = true;
+            }
+        }
+
+        return $containsDoubleQuote ? "'": '"';
+    }
+}

--- a/src/Ast/Sass/Expression/UnaryOperationExpression.php
+++ b/src/Ast/Sass/Expression/UnaryOperationExpression.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass\Expression;
+
+use ScssPhp\ScssPhp\Ast\Sass\Expression;
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+use ScssPhp\ScssPhp\Visitor\ExpressionVisitor;
+
+/**
+ * A unary operator, as in `+$var` or `not fn()`.
+ *
+ * @internal
+ */
+class UnaryOperationExpression implements Expression
+{
+    /**
+     * @var UnaryOperator::*
+     * @readonly
+     */
+    private $operator;
+
+    /**
+     * @var Expression
+     * @readonly
+     */
+    private $operand;
+
+    /**
+     * @var FileSpan
+     * @readonly
+     */
+    private $span;
+
+    /**
+     * @param UnaryOperator::* $operator
+     */
+    public function __construct(string $operator, Expression $operand, FileSpan $span)
+    {
+        $this->operator = $operator;
+        $this->operand = $operand;
+        $this->span = $span;
+    }
+
+    /**
+     * @return UnaryOperator::*
+     */
+    public function getOperator()
+    {
+        return $this->operator;
+    }
+
+    public function getOperand(): Expression
+    {
+        return $this->operand;
+    }
+
+    public function getSpan(): FileSpan
+    {
+        return $this->span;
+    }
+
+    public function accepts(ExpressionVisitor $visitor)
+    {
+        return $visitor->visitUnaryOperationExpression($this);
+    }
+}

--- a/src/Ast/Sass/Expression/UnaryOperator.php
+++ b/src/Ast/Sass/Expression/UnaryOperator.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass\Expression;
+
+/**
+ * @internal
+ */
+final class UnaryOperator
+{
+    const PLUS = '+';
+    const MINUS = '-';
+    const DIVIDE = '/';
+    const NOT = 'not';
+}

--- a/src/Ast/Sass/Expression/ValueExpression.php
+++ b/src/Ast/Sass/Expression/ValueExpression.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass\Expression;
+
+use ScssPhp\ScssPhp\Ast\Sass\Expression;
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+use ScssPhp\ScssPhp\Value\Value;
+use ScssPhp\ScssPhp\Visitor\ExpressionVisitor;
+
+/**
+ * An expression that directly embeds a value.
+ *
+ * This is never constructed by the parser. It's only used when ASTs are
+ * constructed dynamically, as for the `call()` function.
+ *
+ * @internal
+ */
+final class ValueExpression implements Expression
+{
+    /**
+     * @var Value
+     * @readonly
+     */
+    private $value;
+
+    /**
+     * @var FileSpan
+     * @readonly
+     */
+    private $span;
+
+    public function __construct(Value $value, FileSpan $span)
+    {
+        $this->value = $value;
+        $this->span = $span;
+    }
+
+    public function getValue(): Value
+    {
+        return $this->value;
+    }
+
+    public function getSpan(): FileSpan
+    {
+        return $this->span;
+    }
+
+    public function accepts(ExpressionVisitor $visitor)
+    {
+        return $visitor->visitValueExpression($this);
+    }
+}

--- a/src/Ast/Sass/Expression/VariableExpression.php
+++ b/src/Ast/Sass/Expression/VariableExpression.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass\Expression;
+
+use ScssPhp\ScssPhp\Ast\Sass\Expression;
+use ScssPhp\ScssPhp\Ast\Sass\SassReference;
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+use ScssPhp\ScssPhp\Util\SpanUtil;
+use ScssPhp\ScssPhp\Visitor\ExpressionVisitor;
+
+/**
+ * A Sass variable.
+ *
+ * @internal
+ */
+final class VariableExpression implements Expression, SassReference
+{
+    /**
+     * The name of this variable, with underscores converted to hyphens.
+     *
+     * @var string
+     * @readonly
+     */
+    private $name;
+
+    /**
+     * The namespace of the variable being referenced, or `null` if it's
+     * referenced without a namespace.
+     *
+     * @var string|null
+     * @readonly
+     */
+    private $namespace;
+
+    /**
+     * @var FileSpan
+     * @readonly
+     */
+    private $span;
+
+    public function __construct(string $name, FileSpan $span, ?string $namespace = null)
+    {
+        $this->span = $span;
+        $this->name = $name;
+        $this->namespace = $namespace;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getNamespace(): ?string
+    {
+        return $this->namespace;
+    }
+
+    public function getSpan(): FileSpan
+    {
+        return $this->span;
+    }
+
+    public function getNameSpan(): FileSpan
+    {
+        if ($this->namespace === null) {
+            return $this->span;
+        }
+
+        return SpanUtil::withoutNamespace($this->span);
+    }
+
+    public function getNamespaceSpan(): ?FileSpan
+    {
+        if ($this->namespace === null) {
+            return null;
+        }
+
+        return SpanUtil::initialIdentifier($this->span);
+    }
+
+    public function accepts(ExpressionVisitor $visitor)
+    {
+        return $visitor->visitVariableExpression($this);
+    }
+}

--- a/src/Ast/Sass/Import.php
+++ b/src/Ast/Sass/Import.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass;
+
+/**
+ * An interface for different types of import.
+ *
+ * @internal
+ */
+interface Import extends SassNode
+{
+}

--- a/src/Ast/Sass/Import/DynamicImport.php
+++ b/src/Ast/Sass/Import/DynamicImport.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass\Import;
+
+use ScssPhp\ScssPhp\Ast\Sass\Import;
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+
+/**
+ * An import that will load a Sass file at runtime.
+ *
+ * @internal
+ */
+final class DynamicImport implements Import
+{
+    /**
+     * The URI of the file to import.
+     *
+     * If this is relative, it's relative to the containing file.
+     *
+     * @var string
+     * @readonly
+     */
+    private $urlString;
+
+    /**
+     * @var FileSpan
+     * @readonly
+     */
+    private $span;
+
+    public function __construct(string $urlString, FileSpan $span)
+    {
+        $this->urlString = $urlString;
+        $this->span = $span;
+    }
+
+    public function getUrlString(): string
+    {
+        return $this->urlString;
+    }
+
+    public function getSpan(): FileSpan
+    {
+        return $this->span;
+    }
+}

--- a/src/Ast/Sass/Import/StaticImport.php
+++ b/src/Ast/Sass/Import/StaticImport.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass\Import;
+
+use ScssPhp\ScssPhp\Ast\Sass\Import;
+use ScssPhp\ScssPhp\Ast\Sass\Interpolation;
+use ScssPhp\ScssPhp\Ast\Sass\SupportsCondition;
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+use ScssPhp\ScssPhp\Visitor\ExpressionVisitor;
+
+/**
+ * An import that produces a plain CSS `@import` rule.
+ *
+ * @internal
+ */
+final class StaticImport implements Import
+{
+    /**
+     * The URL for this import.
+     *
+     * This already contains quotes.
+     *
+     * @var Interpolation
+     * @readonly
+     */
+    private $url;
+
+    /**
+     * @var SupportsCondition|null
+     * @readonly
+     */
+    private $supports;
+
+    /**
+     * @var Interpolation|null
+     * @readonly
+     */
+    private $media;
+
+    /**
+     * @var FileSpan
+     * @readonly
+     */
+    private $span;
+
+    public function __construct(Interpolation $url, FileSpan $span, ?SupportsCondition $supports = null, ?Interpolation $media = null)
+    {
+        $this->url = $url;
+        $this->span = $span;
+        $this->supports = $supports;
+        $this->media = $media;
+    }
+
+    public function getUrl(): Interpolation
+    {
+        return $this->url;
+    }
+
+    public function getSupports(): ?SupportsCondition
+    {
+        return $this->supports;
+    }
+
+    public function getMedia(): ?Interpolation
+    {
+        return $this->media;
+    }
+
+    public function getSpan(): FileSpan
+    {
+        return $this->span;
+    }
+}

--- a/src/Ast/Sass/Interpolation.php
+++ b/src/Ast/Sass/Interpolation.php
@@ -1,0 +1,105 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass;
+
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+
+/**
+ * Plain text interpolated with Sass expressions.
+ *
+ * @internal
+ */
+final class Interpolation implements SassNode
+{
+    /**
+     * @var list<string|Expression>
+     * @readonly
+     */
+    private $contents;
+
+    /**
+     * @var FileSpan
+     * @readonly
+     */
+    private $span;
+
+    /**
+     * @param list<string|Expression> $contents
+     */
+    public function __construct(array $contents, FileSpan $span)
+    {
+        for ($i = 0; $i < \count($contents); $i++) {
+            if (!\is_string($contents[$i]) && !$contents[$i] instanceof Expression) {
+                throw new \TypeError('The contents of an Interpolation may only contain strings or Expression instances.');
+            }
+
+            if ($i != 0 && \is_string($contents[$i]) && \is_string($contents[$i - 1])) {
+                throw new \InvalidArgumentException('The contents of an Interpolation may not contain adjacent strings.');
+            }
+        }
+
+        $this->contents = $contents;
+        $this->span = $span;
+    }
+
+    /**
+     * @return list<string|Expression>
+     */
+    public function getContents(): array
+    {
+        return $this->contents;
+    }
+
+    public function getSpan(): FileSpan
+    {
+        return $this->span;
+    }
+
+    /**
+     * If this contains no interpolated expressions, returns its text contents.
+     *
+     * Otherwise, returns `null`.
+     *
+     * @psalm-mutation-free
+     */
+    public function getAsPlain(): ?string
+    {
+        if (\count($this->contents) === 0) {
+            return '';
+        }
+
+        if (\count($this->contents) > 1) {
+            return null;
+        }
+
+        if (\is_string($this->contents[0])) {
+            return $this->contents[0];
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns the plain text before the interpolation, or the empty string.
+     */
+    public function getInitialPlain(): string
+    {
+        $first = $this->contents[0] ?? null;
+
+        if (\is_string($first)) {
+            return $first;
+        }
+
+        return '';
+    }
+}

--- a/src/Ast/Sass/SassDeclaration.php
+++ b/src/Ast/Sass/SassDeclaration.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass;
+
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+
+/**
+ * A common interface for any node that declares a Sass member.
+ *
+ * @internal
+ */
+interface SassDeclaration extends SassNode
+{
+    /**
+     * The name of the declaration, with underscores converted to hyphens.
+     *
+     * This does not include the `$` for variables.
+     */
+    public function getName(): string;
+
+    /**
+     * The span containing this declaration's name.
+     *
+     * This includes the `$` for variables.
+     */
+    public function getNameSpan(): FileSpan;
+}

--- a/src/Ast/Sass/SassNode.php
+++ b/src/Ast/Sass/SassNode.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass;
+
+use ScssPhp\ScssPhp\Ast\AstNode;
+
+/**
+ * A node in the abstract syntax tree for an unevaluated Sass file.
+ *
+ * @internal
+ */
+interface SassNode extends AstNode
+{
+}

--- a/src/Ast/Sass/SassReference.php
+++ b/src/Ast/Sass/SassReference.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass;
+
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+
+/**
+ * A common interface for any node that references a Sass member.
+ *
+ * @internal
+ */
+interface SassReference extends SassNode
+{
+    /**
+     * The namespace of the member being referenced, or `null` if it's referenced
+     * without a namespace.
+     */
+    public function getNamespace(): ?string;
+
+    /**
+     * The name of the member being referenced, with underscores converted to
+     * hyphens.
+     *
+     * This does not include the `$` for variables.
+     */
+    public function getName(): string;
+
+    /**
+     * The span containing this reference's name.
+     *
+     * For variables, this should include the `$`.
+     */
+    public function getNameSpan(): FileSpan;
+
+    /**
+     * The span containing this reference's namespace, null if {@see getNamespace} is
+     * null.
+     */
+    public function getNamespaceSpan(): ?FileSpan;
+}

--- a/src/Ast/Sass/Statement.php
+++ b/src/Ast/Sass/Statement.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass;
+
+use ScssPhp\ScssPhp\Visitor\StatementVisitor;
+
+/**
+ * A statement in a Sass syntax tree.
+ *
+ * @internal
+ */
+interface Statement extends SassNode
+{
+    /**
+     * @template T
+     * @param StatementVisitor<T> $visitor
+     * @return T
+     */
+    public function accepts(StatementVisitor $visitor);
+}

--- a/src/Ast/Sass/Statement/AtRootRule.php
+++ b/src/Ast/Sass/Statement/AtRootRule.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass\Statement;
+
+use ScssPhp\ScssPhp\Ast\Sass\Interpolation;
+use ScssPhp\ScssPhp\Ast\Sass\Statement;
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+use ScssPhp\ScssPhp\Visitor\StatementVisitor;
+
+/**
+ * A `@at-root` rule.
+ *
+ * This moves it contents "up" the tree through parent nodes.
+ *
+ * @extends ParentStatement<Statement[]>
+ *
+ * @internal
+ */
+final class AtRootRule extends ParentStatement
+{
+    /**
+     * @var Interpolation|null
+     * @readonly
+     */
+    private $query;
+
+    /**
+     * @var FileSpan
+     * @readonly
+     */
+    private $span;
+
+    /**
+     * @param Statement[] $children
+     */
+    public function __construct(array $children, FileSpan $span, ?Interpolation $query = null)
+    {
+        $this->query = $query;
+        $this->span = $span;
+        parent::__construct($children);
+    }
+
+    /**
+     * The query specifying which statements this should move its contents through.
+     */
+    public function getQuery(): ?Interpolation
+    {
+        return $this->query;
+    }
+
+    public function getSpan(): FileSpan
+    {
+        return $this->span;
+    }
+
+    public function accepts(StatementVisitor $visitor)
+    {
+        return $visitor->visitAtRootRule($this);
+    }
+}

--- a/src/Ast/Sass/Statement/AtRule.php
+++ b/src/Ast/Sass/Statement/AtRule.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass\Statement;
+
+use ScssPhp\ScssPhp\Ast\Sass\Interpolation;
+use ScssPhp\ScssPhp\Ast\Sass\Statement;
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+use ScssPhp\ScssPhp\Visitor\StatementVisitor;
+
+/**
+ * An unknown at-rule.
+ *
+ * @extends ParentStatement<Statement[]|null>
+ *
+ * @internal
+ */
+final class AtRule extends ParentStatement
+{
+    /**
+     * @var Interpolation
+     * @readonly
+     */
+    private $name;
+
+    /**
+     * @var Interpolation|null
+     * @readonly
+     */
+    private $value;
+
+    /**
+     * @var FileSpan
+     * @readonly
+     */
+    private $span;
+
+    /**
+     * @param Statement[]|null $children
+     */
+    public function __construct(Interpolation $name, FileSpan $span, ?Interpolation $value = null, ?array $children = null)
+    {
+        $this->name = $name;
+        $this->value = $value;
+        $this->span = $span;
+        parent::__construct($children);
+    }
+
+    public function getName(): Interpolation
+    {
+        return $this->name;
+    }
+
+    public function getValue(): ?Interpolation
+    {
+        return $this->value;
+    }
+
+    public function getSpan(): FileSpan
+    {
+        return $this->span;
+    }
+
+    public function accepts(StatementVisitor $visitor)
+    {
+        return $visitor->visitAtRule($this);
+    }
+}

--- a/src/Ast/Sass/Statement/CallableDeclaration.php
+++ b/src/Ast/Sass/Statement/CallableDeclaration.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass\Statement;
+
+use ScssPhp\ScssPhp\Ast\Sass\ArgumentDeclaration;
+use ScssPhp\ScssPhp\Ast\Sass\Statement;
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+
+/**
+ * An abstract class for callables (functions or mixins) that are declared in
+ * user code.
+ *
+ * @extends ParentStatement<Statement[]>
+ *
+ * @internal
+ */
+abstract class CallableDeclaration extends ParentStatement
+{
+    /**
+     * @var string
+     * @readonly
+     */
+    private $name;
+
+    /**
+     * @var ArgumentDeclaration
+     * @readonly
+     */
+    private $arguments;
+
+    /**
+     * @var SilentComment|null
+     * @readonly
+     */
+    private $comment;
+
+    /**
+     * @var FileSpan
+     * @readonly
+     */
+    private $span;
+
+    /**
+     * @param Statement[] $children
+     */
+    public function __construct(string $name, ArgumentDeclaration $arguments, FileSpan $span, array $children, ?SilentComment $comment = null)
+    {
+        $this->name = $name;
+        $this->arguments = $arguments;
+        $this->comment = $comment;
+        $this->span = $span;
+        parent::__construct($children);
+    }
+
+    /**
+     * The name of this callable, with underscores converted to hyphens.
+     */
+    final public function getName(): string
+    {
+        return $this->name;
+    }
+
+    final public function getArguments(): ArgumentDeclaration
+    {
+        return $this->arguments;
+    }
+
+    /**
+     * @return SilentComment|null
+     */
+    final public function getComment(): ?SilentComment
+    {
+        return $this->comment;
+    }
+
+    final public function getSpan(): FileSpan
+    {
+        return $this->span;
+    }
+}

--- a/src/Ast/Sass/Statement/ContentBlock.php
+++ b/src/Ast/Sass/Statement/ContentBlock.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass\Statement;
+
+use ScssPhp\ScssPhp\Ast\Sass\ArgumentDeclaration;
+use ScssPhp\ScssPhp\Ast\Sass\Statement;
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+use ScssPhp\ScssPhp\Visitor\StatementVisitor;
+
+/**
+ * An anonymous block of code that's invoked for a {@see ContentRule}.
+ *
+ * @internal
+ */
+final class ContentBlock extends CallableDeclaration
+{
+    /**
+     * @param Statement[] $children
+     */
+    public function __construct(ArgumentDeclaration $arguments, array $children, FileSpan $span)
+    {
+        parent::__construct('@content', $arguments, $span, $children);
+    }
+
+    public function accepts(StatementVisitor $visitor)
+    {
+        return $visitor->visitContentBlock($this);
+    }
+}

--- a/src/Ast/Sass/Statement/ContentRule.php
+++ b/src/Ast/Sass/Statement/ContentRule.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass\Statement;
+
+use ScssPhp\ScssPhp\Ast\Sass\ArgumentInvocation;
+use ScssPhp\ScssPhp\Ast\Sass\Statement;
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+use ScssPhp\ScssPhp\Visitor\StatementVisitor;
+
+/**
+ * A `@content` rule.
+ *
+ * This is used in a mixin to include statement-level content passed by the
+ * caller.
+ *
+ * @internal
+ */
+final class ContentRule implements Statement
+{
+    /**
+     * The arguments pass to this `@content` rule.
+     *
+     * This will be an empty invocation if `@content` has no arguments.
+     *
+     * @var ArgumentInvocation
+     * @readonly
+     */
+    private $arguments;
+
+    /**
+     * @var FileSpan
+     * @readonly
+     */
+    private $span;
+
+    public function __construct(ArgumentInvocation $arguments, FileSpan $span)
+    {
+        $this->arguments = $arguments;
+        $this->span = $span;
+    }
+
+    public function getArguments(): ArgumentInvocation
+    {
+        return $this->arguments;
+    }
+
+    public function getSpan(): FileSpan
+    {
+        return $this->span;
+    }
+
+    public function accepts(StatementVisitor $visitor)
+    {
+        return $visitor->visitContentRule($this);
+    }
+}

--- a/src/Ast/Sass/Statement/DebugRule.php
+++ b/src/Ast/Sass/Statement/DebugRule.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass\Statement;
+
+use ScssPhp\ScssPhp\Ast\Sass\Expression;
+use ScssPhp\ScssPhp\Ast\Sass\Statement;
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+use ScssPhp\ScssPhp\Visitor\StatementVisitor;
+
+/**
+ * A `@debug` rule.
+ *
+ * This prints a Sass value for debugging purposes.
+ *
+ * @internal
+ */
+final class DebugRule implements Statement
+{
+    /**
+     * @var Expression
+     * @readonly
+     */
+    private $expression;
+
+    /**
+     * @var FileSpan
+     * @readonly
+     */
+    private $span;
+
+    public function __construct(Expression $expression, FileSpan $span)
+    {
+        $this->expression = $expression;
+        $this->span = $span;
+    }
+
+    public function getExpression(): Expression
+    {
+        return $this->expression;
+    }
+
+    public function getSpan(): FileSpan
+    {
+        return $this->span;
+    }
+
+    public function accepts(StatementVisitor $visitor)
+    {
+        return $visitor->visitDebugRule($this);
+    }
+}

--- a/src/Ast/Sass/Statement/Declaration.php
+++ b/src/Ast/Sass/Statement/Declaration.php
@@ -1,0 +1,123 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass\Statement;
+
+use ScssPhp\ScssPhp\Ast\Sass\Expression;
+use ScssPhp\ScssPhp\Ast\Sass\Expression\StringExpression;
+use ScssPhp\ScssPhp\Ast\Sass\Interpolation;
+use ScssPhp\ScssPhp\Ast\Sass\Statement;
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+use ScssPhp\ScssPhp\Visitor\StatementVisitor;
+
+/**
+ * A declaration (that is, a `name: value` pair).
+ *
+ * @extends ParentStatement<Statement[]|null>
+ *
+ * @internal
+ */
+final class Declaration extends ParentStatement
+{
+    /**
+     * @var Interpolation
+     * @readonly
+     */
+    private $name;
+
+    /**
+     * The value of this declaration.
+     *
+     * If {@see getChildren} is `null`, this is never `null`. Otherwise, it may or may
+     * not be `null`.
+     *
+     * @var Expression|null
+     * @readonly
+     */
+    private $value;
+
+    /**
+     * @var FileSpan
+     * @readonly
+     */
+    private $span;
+
+    /**
+     * @param Statement[]|null $children
+     */
+    private function __construct(Interpolation $name, ?Expression $value, FileSpan $span, ?array $children = null)
+    {
+        $this->name = $name;
+        $this->value = $value;
+        $this->span = $span;
+        parent::__construct($children);
+    }
+
+    public static function create(Interpolation $name, Expression $value, FileSpan $span): self
+    {
+        $declaration = new self($name, $value, $span);
+
+        if ($declaration->isCustomProperty() && !$value instanceof StringExpression) {
+            throw new \InvalidArgumentException(sprintf('Declarations whose names begin with "--" must have StringExpression values (got %s)', get_class($value)));
+        }
+
+        return $declaration;
+    }
+
+    /**
+     * @param Statement[] $children
+     */
+    public static function nested(Interpolation $name, array $children, FileSpan $span, ?Expression $value = null): self
+    {
+        $declaration = new self($name, $value, $span, $children);
+
+        if ($declaration->isCustomProperty() && !$value instanceof StringExpression) {
+            throw new \InvalidArgumentException('Declarations whose names begin with "--" may not be nested.');
+        }
+
+        return $declaration;
+    }
+
+    public function getName(): Interpolation
+    {
+        return $this->name;
+    }
+
+    public function getValue(): ?Expression
+    {
+        return $this->value;
+    }
+
+    /**
+     * Returns whether this is a CSS Custom Property declaration.
+     *
+     * Note that this can return `false` for declarations that will ultimately be
+     * serialized as custom properties if they aren't *parsed as* custom
+     * properties, such as `#{--foo}: ...`.
+     *
+     * If this is `true`, then `value` will be a {@see StringExpression}.
+     */
+    public function isCustomProperty(): bool
+    {
+        return 0 === strpos($this->name->getInitialPlain(), '--');
+    }
+
+    public function getSpan(): FileSpan
+    {
+        return $this->span;
+    }
+
+    public function accepts(StatementVisitor $visitor)
+    {
+        return $visitor->visitDeclaration($this);
+    }
+}

--- a/src/Ast/Sass/Statement/EachRule.php
+++ b/src/Ast/Sass/Statement/EachRule.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass\Statement;
+
+use ScssPhp\ScssPhp\Ast\Sass\Expression;
+use ScssPhp\ScssPhp\Ast\Sass\Statement;
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+use ScssPhp\ScssPhp\Visitor\StatementVisitor;
+
+/**
+ * An `@each` rule.
+ *
+ * This iterates over values in a list or map.
+ *
+ * @extends ParentStatement<Statement[]>
+ *
+ * @internal
+ */
+final class EachRule extends ParentStatement
+{
+    /**
+     * @var string[]
+     * @readonly
+     */
+    private $variables;
+
+    /**
+     * @var Expression
+     * @readonly
+     */
+    private $list;
+
+    /**
+     * @var FileSpan
+     * @readonly
+     */
+    private $span;
+
+    /**
+     * @param string[]    $variables
+     * @param Statement[] $children
+     */
+    public function __construct(array $variables, Expression $list, array $children, FileSpan $span)
+    {
+        $this->variables = $variables;
+        $this->list = $list;
+        $this->span = $span;
+        parent::__construct($children);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getVariables(): array
+    {
+        return $this->variables;
+    }
+
+    public function getList(): Expression
+    {
+        return $this->list;
+    }
+
+    public function getSpan(): FileSpan
+    {
+        return $this->span;
+    }
+
+    public function accepts(StatementVisitor $visitor)
+    {
+        return $visitor->visitEachRule($this);
+    }
+}

--- a/src/Ast/Sass/Statement/ElseClause.php
+++ b/src/Ast/Sass/Statement/ElseClause.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass\Statement;
+
+/**
+ * An `@else` clause in an `@if` rule.
+ *
+ * @internal
+ */
+final class ElseClause extends IfRuleClause
+{
+}

--- a/src/Ast/Sass/Statement/ErrorRule.php
+++ b/src/Ast/Sass/Statement/ErrorRule.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass\Statement;
+
+use ScssPhp\ScssPhp\Ast\Sass\Expression;
+use ScssPhp\ScssPhp\Ast\Sass\Statement;
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+use ScssPhp\ScssPhp\Visitor\StatementVisitor;
+
+/**
+ * A `@error` rule.
+ *
+ * This emits an error and stops execution.
+ *
+ * @internal
+ */
+final class ErrorRule implements Statement
+{
+    /**
+     * @var Expression
+     * @readonly
+     */
+    private $expression;
+
+    /**
+     * @var FileSpan
+     * @readonly
+     */
+    private $span;
+
+    public function __construct(Expression $expression, FileSpan $span)
+    {
+        $this->expression = $expression;
+        $this->span = $span;
+    }
+
+    public function getExpression(): Expression
+    {
+        return $this->expression;
+    }
+
+    public function getSpan(): FileSpan
+    {
+        return $this->span;
+    }
+
+    public function accepts(StatementVisitor $visitor)
+    {
+        return $visitor->visitErrorRule($this);
+    }
+}

--- a/src/Ast/Sass/Statement/ExtendRule.php
+++ b/src/Ast/Sass/Statement/ExtendRule.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass\Statement;
+
+use ScssPhp\ScssPhp\Ast\Sass\Interpolation;
+use ScssPhp\ScssPhp\Ast\Sass\Statement;
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+use ScssPhp\ScssPhp\Visitor\StatementVisitor;
+
+/**
+ * An `@extend` rule.
+ *
+ * This gives one selector all the styling of another.
+ *
+ * @internal
+ */
+final class ExtendRule implements Statement
+{
+    /**
+     * @var Interpolation
+     * @readonly
+     */
+    private $selector;
+
+    /**
+     * @var FileSpan
+     * @readonly
+     */
+    private $span;
+
+    /**
+     * @var bool
+     * @readonly
+     */
+    private $optional;
+
+    public function __construct(Interpolation $selector, FileSpan $span, bool $optional = false)
+    {
+        $this->selector = $selector;
+        $this->span = $span;
+        $this->optional = $optional;
+    }
+
+    public function getSelector(): Interpolation
+    {
+        return $this->selector;
+    }
+
+    /**
+     * Whether this is an optional extension.
+     *
+     * If an extension isn't optional, it will emit an error if it doesn't match
+     * any selectors.
+     */
+    public function isOptional(): bool
+    {
+        return $this->optional;
+    }
+
+    public function getSpan(): FileSpan
+    {
+        return $this->span;
+    }
+
+    public function accepts(StatementVisitor $visitor)
+    {
+        return $visitor->visitExtendRule($this);
+    }
+}

--- a/src/Ast/Sass/Statement/ForRule.php
+++ b/src/Ast/Sass/Statement/ForRule.php
@@ -1,0 +1,106 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass\Statement;
+
+use ScssPhp\ScssPhp\Ast\Sass\Expression;
+use ScssPhp\ScssPhp\Ast\Sass\Statement;
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+use ScssPhp\ScssPhp\Visitor\StatementVisitor;
+
+/**
+ * A `@for` rule.
+ *
+ * This iterates a set number of times.
+ *
+ * @extends ParentStatement<Statement[]>
+ *
+ * @internal
+ */
+final class ForRule extends ParentStatement
+{
+    /**
+     * @var string
+     * @readonly
+     */
+    private $variable;
+
+    /**
+     * @var Expression
+     * @readonly
+     */
+    private $from;
+
+    /**
+     * @var Expression
+     * @readonly
+     */
+    private $to;
+
+    /**
+     * @var bool
+     * @readonly
+     */
+    private $exclusive;
+
+    /**
+     * @var FileSpan
+     * @readonly
+     */
+    private $span;
+
+    /**
+     * @param Statement[] $children
+     */
+    public function __construct(string $variable, Expression $from, Expression $to, array $children, FileSpan $span, bool $exclusive = false)
+    {
+        $this->variable = $variable;
+        $this->from = $from;
+        $this->to = $to;
+        $this->exclusive = $exclusive;
+        $this->span = $span;
+        parent::__construct($children);
+    }
+
+    public function getVariable(): string
+    {
+        return $this->variable;
+    }
+
+    public function getFrom(): Expression
+    {
+        return $this->from;
+    }
+
+    public function getTo(): Expression
+    {
+        return $this->to;
+    }
+
+    /**
+     * Whether {@see getTo} is exclusive.
+     */
+    public function isExclusive(): bool
+    {
+        return $this->exclusive;
+    }
+
+    public function getSpan(): FileSpan
+    {
+        return $this->span;
+    }
+
+    public function accepts(StatementVisitor $visitor)
+    {
+        return $visitor->visitForRule($this);
+    }
+}

--- a/src/Ast/Sass/Statement/FunctionRule.php
+++ b/src/Ast/Sass/Statement/FunctionRule.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass\Statement;
+
+use ScssPhp\ScssPhp\Ast\Sass\SassDeclaration;
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+use ScssPhp\ScssPhp\Util\SpanUtil;
+use ScssPhp\ScssPhp\Visitor\StatementVisitor;
+
+/**
+ * A function declaration.
+ *
+ * This declares a function that's invoked using normal CSS function syntax.
+ *
+ * @internal
+ */
+final class FunctionRule extends CallableDeclaration implements SassDeclaration
+{
+    public function getNameSpan(): FileSpan
+    {
+        return SpanUtil::initialIdentifier(SpanUtil::withoutInitialAtRule($this->getSpan()));
+    }
+
+    public function accepts(StatementVisitor $visitor)
+    {
+        return $visitor->visitFunctionRule($this);
+    }
+}

--- a/src/Ast/Sass/Statement/HasContentVisitor.php
+++ b/src/Ast/Sass/Statement/HasContentVisitor.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass\Statement;
+
+use ScssPhp\ScssPhp\Ast\Sass\ArgumentInvocation;
+use ScssPhp\ScssPhp\Ast\Sass\Interpolation;
+use ScssPhp\ScssPhp\Ast\Sass\SupportsCondition;
+use ScssPhp\ScssPhp\Visitor\StatementSearchVisitor;
+
+/**
+ * A visitor for determining whether a {@see MixinRule} recursively contains a
+ * {@see ContentRule}.
+ *
+ * @internal
+ *
+ * @extends StatementSearchVisitor<bool>
+ */
+class HasContentVisitor extends StatementSearchVisitor
+{
+    public function visitContentRule(ContentRule $node): bool
+    {
+        return true;
+    }
+
+    protected function visitArgumentInvocation(ArgumentInvocation $invocation): ?bool
+    {
+        return null;
+    }
+
+    protected function visitSupportsCondition(SupportsCondition $condition): ?bool
+    {
+        return null;
+    }
+
+    protected function visitInterpolation(Interpolation $interpolation): ?bool
+    {
+        return null;
+    }
+}

--- a/src/Ast/Sass/Statement/IfClause.php
+++ b/src/Ast/Sass/Statement/IfClause.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass\Statement;
+
+use ScssPhp\ScssPhp\Ast\Sass\Expression;
+use ScssPhp\ScssPhp\Ast\Sass\Statement;
+
+/**
+ * An `@if` or `@else if` clause in an `@if` rule.
+ *
+ * @internal
+ */
+final class IfClause extends IfRuleClause
+{
+    /**
+     * @var Expression
+     * @readonly
+     */
+    private $expression;
+
+    /**
+     * @param Statement[] $children
+     */
+    public function __construct(Expression $expression, array $children)
+    {
+        $this->expression = $expression;
+        parent::__construct($children);
+    }
+
+    public function getExpression(): Expression
+    {
+        return $this->expression;
+    }
+}

--- a/src/Ast/Sass/Statement/IfRule.php
+++ b/src/Ast/Sass/Statement/IfRule.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass\Statement;
+
+use ScssPhp\ScssPhp\Ast\Sass\Statement;
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+use ScssPhp\ScssPhp\Visitor\StatementVisitor;
+
+/**
+ * An `@if` rule.
+ *
+ * This conditionally executes a block of code.
+ *
+ * @internal
+ */
+final class IfRule implements Statement
+{
+    /**
+     * @var IfClause[]
+     * @readonly
+     */
+    private $clauses;
+
+    /**
+     * @var ElseClause|null
+     * @readonly
+     */
+    private $lastClause;
+
+    /**
+     * @var FileSpan
+     * @readonly
+     */
+    private $span;
+
+    /**
+     * @param IfClause[] $clauses
+     */
+    public function __construct(array $clauses, FileSpan $span, ?ElseClause $lastClause = null)
+    {
+        $this->clauses = $clauses;
+        $this->span = $span;
+        $this->lastClause = $lastClause;
+    }
+
+    /**
+     * The `@if` and `@else if` clauses.
+     *
+     * The first clause whose expression evaluates to `true` will have its
+     * statements executed. If no expression evaluates to `true`, `lastClause`
+     * will be executed if it's not `null`.
+     *
+     * @return IfClause[]
+     */
+    public function getClauses(): array
+    {
+        return $this->clauses;
+    }
+
+    /**
+     * The final, unconditional `@else` clause.
+     *
+     * This is `null` if there is no unconditional `@else`.
+     *
+     * @return ElseClause|null
+     */
+    public function getLastClause(): ?ElseClause
+    {
+        return $this->lastClause;
+    }
+
+    public function getSpan(): FileSpan
+    {
+        return $this->span;
+    }
+
+    public function accepts(StatementVisitor $visitor)
+    {
+        return $visitor->visitIfRule($this);
+    }
+}

--- a/src/Ast/Sass/Statement/IfRuleClause.php
+++ b/src/Ast/Sass/Statement/IfRuleClause.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass\Statement;
+
+use ScssPhp\ScssPhp\Ast\Sass\Import\DynamicImport;
+use ScssPhp\ScssPhp\Ast\Sass\Statement;
+
+/**
+ * The superclass of `@if` and `@else` clauses.
+ *
+ * @internal
+ */
+abstract class IfRuleClause
+{
+    /**
+     * @var Statement[]
+     * @readonly
+     */
+    private $children;
+
+    /**
+     * @var bool
+     * @readonly
+     */
+    private $declarations = false;
+
+    /**
+     * @param Statement[] $children
+     */
+    public function __construct(array $children)
+    {
+        $this->children = $children;
+
+        foreach ($children as $child) {
+            if ($child instanceof VariableDeclaration || $child instanceof FunctionRule || $child instanceof MixinRule) {
+                $this->declarations = true;
+                break;
+            }
+
+            if ($child instanceof ImportRule) {
+                foreach ($child->getImports() as $import) {
+                    if ($import instanceof DynamicImport) {
+                        $this->declarations = true;
+                        break 2;
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * @return Statement[]
+     */
+    final public function getChildren(): array
+    {
+        return $this->children;
+    }
+
+    final public function hasDeclarations(): bool
+    {
+        return $this->declarations;
+    }
+}

--- a/src/Ast/Sass/Statement/ImportRule.php
+++ b/src/Ast/Sass/Statement/ImportRule.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass\Statement;
+
+use ScssPhp\ScssPhp\Ast\Sass\Import;
+use ScssPhp\ScssPhp\Ast\Sass\Statement;
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+use ScssPhp\ScssPhp\Visitor\StatementVisitor;
+
+/**
+ * An `@import` rule.
+ *
+ * @internal
+ */
+final class ImportRule implements Statement
+{
+    /**
+     * @var Import[]
+     * @readonly
+     */
+    private $imports;
+
+    /**
+     * @var FileSpan
+     * @readonly
+     */
+    private $span;
+
+    /**
+     * @param Import[] $imports
+     */
+    public function __construct(array $imports, FileSpan $span)
+    {
+        $this->imports = $imports;
+        $this->span = $span;
+    }
+
+    /**
+     * @return Import[]
+     */
+    public function getImports(): array
+    {
+        return $this->imports;
+    }
+
+    public function getSpan(): FileSpan
+    {
+        return $this->span;
+    }
+
+    public function accepts(StatementVisitor $visitor)
+    {
+        return $visitor->visitImportRule($this);
+    }
+}

--- a/src/Ast/Sass/Statement/IncludeRule.php
+++ b/src/Ast/Sass/Statement/IncludeRule.php
@@ -1,0 +1,122 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass\Statement;
+
+use ScssPhp\ScssPhp\Ast\Sass\ArgumentInvocation;
+use ScssPhp\ScssPhp\Ast\Sass\CallableInvocation;
+use ScssPhp\ScssPhp\Ast\Sass\SassReference;
+use ScssPhp\ScssPhp\Ast\Sass\Statement;
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+use ScssPhp\ScssPhp\Util\SpanUtil;
+use ScssPhp\ScssPhp\Visitor\StatementVisitor;
+
+/**
+ * A mixin invocation.
+ *
+ * @internal
+ */
+final class IncludeRule implements Statement, CallableInvocation, SassReference
+{
+    /**
+     * @var string|null
+     * @readonly
+     */
+    private $namespace;
+
+    /**
+     * @var string
+     * @readonly
+     */
+    private $name;
+
+    /**
+     * @var ArgumentInvocation
+     * @readonly
+     */
+    private $arguments;
+
+    /**
+     * @var ContentBlock|null
+     * @readonly
+     */
+    private $content;
+
+    /**
+     * @var FileSpan
+     * @readonly
+     */
+    private $span;
+
+    public function __construct(string $name, ArgumentInvocation $arguments, FileSpan $span, ?string $namespace = null,?ContentBlock $content = null)
+    {
+        $this->name = $name;
+        $this->arguments = $arguments;
+        $this->span = $span;
+        $this->namespace = $namespace;
+        $this->content = $content;
+    }
+
+    public function getNamespace(): ?string
+    {
+        return $this->namespace;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getArguments(): ArgumentInvocation
+    {
+        return $this->arguments;
+    }
+
+    public function getContent(): ?ContentBlock
+    {
+        return $this->content;
+    }
+
+    public function getSpan(): FileSpan
+    {
+        return $this->span;
+    }
+
+    public function getNameSpan(): FileSpan
+    {
+        $startSpan = $this->span->getText()[0] === '+' ? SpanUtil::trimLeft($this->span->subspan(1)) : SpanUtil::withoutInitialAtRule($this->span);
+
+        if ($this->namespace !== null) {
+            $startSpan = SpanUtil::withoutNamespace($startSpan);
+        }
+
+        return SpanUtil::initialIdentifier($startSpan);
+    }
+
+    public function getNamespaceSpan(): ?FileSpan
+    {
+        if ($this->namespace === null) {
+            return null;
+        }
+
+        $startSpan = $this->span->getText()[0] === '+'
+            ? SpanUtil::trimLeft($this->span->subspan(1))
+            : SpanUtil::withoutInitialAtRule($this->span);
+
+        return SpanUtil::initialIdentifier($startSpan);
+    }
+
+    public function accepts(StatementVisitor $visitor)
+    {
+        return $visitor->visitIncludeRule($this);
+    }
+}

--- a/src/Ast/Sass/Statement/LoudComment.php
+++ b/src/Ast/Sass/Statement/LoudComment.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass\Statement;
+
+use ScssPhp\ScssPhp\Ast\Sass\Interpolation;
+use ScssPhp\ScssPhp\Ast\Sass\Statement;
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+use ScssPhp\ScssPhp\Visitor\StatementVisitor;
+
+/**
+ * A loud CSS-style comment.
+ *
+ * @internal
+ */
+final class LoudComment implements Statement
+{
+    /**
+     * @var Interpolation
+     * @readonly
+     */
+    private $text;
+
+    public function __construct(Interpolation $text)
+    {
+        $this->text = $text;
+    }
+
+    public function getText(): Interpolation
+    {
+        return $this->text;
+    }
+
+    public function getSpan(): FileSpan
+    {
+        return $this->text->getSpan();
+    }
+
+    public function accepts(StatementVisitor $visitor)
+    {
+        return $visitor->visitLoudComment($this);
+    }
+}

--- a/src/Ast/Sass/Statement/MediaRule.php
+++ b/src/Ast/Sass/Statement/MediaRule.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass\Statement;
+
+use ScssPhp\ScssPhp\Ast\Sass\Interpolation;
+use ScssPhp\ScssPhp\Ast\Sass\Statement;
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+use ScssPhp\ScssPhp\Visitor\StatementVisitor;
+
+/**
+ * A `@media` rule.
+ *
+ * @extends ParentStatement<Statement[]>
+ *
+ * @internal
+ */
+final class MediaRule extends ParentStatement
+{
+    /**
+     * @var Interpolation
+     * @readonly
+     */
+    private $query;
+
+    /**
+     * @var FileSpan
+     * @readonly
+     */
+    private $span;
+
+    /**
+     * @param Statement[] $children
+     */
+    public function __construct(Interpolation $query, array $children, FileSpan $span)
+    {
+        $this->query = $query;
+        $this->span = $span;
+        parent::__construct($children);
+    }
+
+    /**
+     * The query that determines on which platforms the styles will be in effect.
+     *
+     * This is only parsed after the interpolation has been resolved.
+     */
+    public function getQuery(): Interpolation
+    {
+        return $this->query;
+    }
+
+    public function getSpan(): FileSpan
+    {
+        return $this->span;
+    }
+
+    public function accepts(StatementVisitor $visitor)
+    {
+        return $visitor->visitMediaRule($this);
+    }
+}

--- a/src/Ast/Sass/Statement/MixinRule.php
+++ b/src/Ast/Sass/Statement/MixinRule.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass\Statement;
+
+use ScssPhp\ScssPhp\Ast\Sass\ArgumentDeclaration;
+use ScssPhp\ScssPhp\Ast\Sass\SassDeclaration;
+use ScssPhp\ScssPhp\Ast\Sass\Statement;
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+use ScssPhp\ScssPhp\Util\SpanUtil;
+use ScssPhp\ScssPhp\Visitor\StatementVisitor;
+
+/**
+ * A mixin declaration.
+ *
+ * This declares a mixin that's invoked using `@include`.
+ *
+ * @internal
+ */
+final class MixinRule extends CallableDeclaration implements SassDeclaration
+{
+    /**
+     * Whether the mixin contains a `@content` rule.
+     *
+     * @var bool
+     * @readonly
+     */
+    private $content;
+
+    /**
+     * @param Statement[] $children
+     */
+    public function __construct(string $name, ArgumentDeclaration $arguments, FileSpan $span, array $children, ?SilentComment $comment = null)
+    {
+        parent::__construct($name, $arguments, $span, $children, $comment);
+    }
+
+    public function hasContent(): bool
+    {
+        if (!isset($this->content)) {
+            $this->content = (new HasContentVisitor())->visitMixinRule($this) === true;
+        }
+
+        return $this->content;
+    }
+
+    public function getNameSpan(): FileSpan
+    {
+        $startSpan = $this->getSpan()->getText()[0] === '='
+            ? SpanUtil::trimLeft($this->getSpan()->subspan(1))
+            : SpanUtil::withoutInitialAtRule($this->getSpan());
+
+        return SpanUtil::initialIdentifier($startSpan);
+    }
+
+    public function accepts(StatementVisitor $visitor)
+    {
+        return $visitor->visitMixinRule($this);
+    }
+}

--- a/src/Ast/Sass/Statement/ParentStatement.php
+++ b/src/Ast/Sass/Statement/ParentStatement.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass\Statement;
+
+use ScssPhp\ScssPhp\Ast\Sass\Import\DynamicImport;
+use ScssPhp\ScssPhp\Ast\Sass\Statement;
+
+/**
+ * A {@see Statement} that can have child statements.
+ *
+ * This has a generic parameter so that its subclasses can choose whether or
+ * not their children lists are nullable.
+ *
+ * @template T
+ * @psalm-template T of (Statement[]|null)
+ *
+ * @internal
+ */
+abstract class ParentStatement implements Statement
+{
+    /**
+     * @var T
+     * @readonly
+     */
+    private $children;
+
+    /**
+     * @var bool
+     * @readonly
+     */
+    private $declarations;
+
+    /**
+     * @param T $children
+     */
+    public function __construct(?array $children)
+    {
+        $this->children = $children;
+
+        if ($children === null) {
+            $this->declarations = false;
+            return;
+        }
+
+        foreach ($children as $child) {
+            if ($child instanceof VariableDeclaration || $child instanceof FunctionRule || $child instanceof MixinRule) {
+                $this->declarations = true;
+                return;
+            }
+
+            if ($child instanceof ImportRule) {
+                foreach ($child->getImports() as $import) {
+                    if ($import instanceof DynamicImport) {
+                        $this->declarations = true;
+                        return;
+                    }
+                }
+            }
+        }
+
+        $this->declarations = false;
+    }
+
+    /**
+     * @return T
+     */
+    final public function getChildren()
+    {
+        return $this->children;
+    }
+
+    final public function hasDeclarations(): bool
+    {
+        return $this->declarations;
+    }
+}

--- a/src/Ast/Sass/Statement/ReturnRule.php
+++ b/src/Ast/Sass/Statement/ReturnRule.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass\Statement;
+
+use ScssPhp\ScssPhp\Ast\Sass\Expression;
+use ScssPhp\ScssPhp\Ast\Sass\Statement;
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+use ScssPhp\ScssPhp\Visitor\StatementVisitor;
+
+/**
+ * A `@return` rule.
+ *
+ * This exits from the current function body with a return value.
+ *
+ * @internal
+ */
+final class ReturnRule implements Statement
+{
+    /**
+     * @var Expression
+     * @readonly
+     */
+    private $expression;
+
+    /**
+     * @var FileSpan
+     * @readonly
+     */
+    private $span;
+
+    public function __construct(Expression $expression, FileSpan $span)
+    {
+        $this->expression = $expression;
+        $this->span = $span;
+    }
+
+    public function getExpression(): Expression
+    {
+        return $this->expression;
+    }
+
+    public function getSpan(): FileSpan
+    {
+        return $this->span;
+    }
+
+    public function accepts(StatementVisitor $visitor)
+    {
+        return $visitor->visitReturnRule($this);
+    }
+}

--- a/src/Ast/Sass/Statement/SilentComment.php
+++ b/src/Ast/Sass/Statement/SilentComment.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass\Statement;
+
+use ScssPhp\ScssPhp\Ast\Sass\Statement;
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+use ScssPhp\ScssPhp\Visitor\StatementVisitor;
+
+/**
+ * A silent Sass-style comment.
+ *
+ * @internal
+ */
+final class SilentComment implements Statement
+{
+    /**
+     * @var string
+     * @readonly
+     */
+    private $text;
+
+    /**
+     * @var FileSpan
+     * @readonly
+     */
+    private $span;
+
+    public function __construct(string $text, FileSpan $span)
+    {
+        $this->text = $text;
+        $this->span = $span;
+    }
+
+    public function getText(): string
+    {
+        return $this->text;
+    }
+
+    public function getSpan(): FileSpan
+    {
+        return $this->span;
+    }
+
+    public function accepts(StatementVisitor $visitor)
+    {
+        return $visitor->visitSilentComment($this);
+    }
+}

--- a/src/Ast/Sass/Statement/StyleRule.php
+++ b/src/Ast/Sass/Statement/StyleRule.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass\Statement;
+
+use ScssPhp\ScssPhp\Ast\Sass\Interpolation;
+use ScssPhp\ScssPhp\Ast\Sass\Statement;
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+use ScssPhp\ScssPhp\Visitor\StatementVisitor;
+
+/**
+ * A style rule.
+ *
+ * This applies style declarations to elements that match a given selector.
+ *
+ * @extends ParentStatement<Statement[]>
+ *
+ * @internal
+ */
+final class StyleRule extends ParentStatement
+{
+    /**
+     * @var Interpolation
+     * @readonly
+     */
+    private $selector;
+
+    /**
+     * @var FileSpan
+     * @readonly
+     */
+    private $span;
+
+    /**
+     * @param Statement[] $children
+     */
+    public function __construct(Interpolation $selector, array $children, FileSpan $span)
+    {
+        $this->selector = $selector;
+        $this->span = $span;
+        parent::__construct($children);
+    }
+
+    /**
+     * The selector to which the declaration will be applied.
+     *
+     * This is only parsed after the interpolation has been resolved.
+     */
+    public function getSelector(): Interpolation
+    {
+        return $this->selector;
+    }
+
+    public function getSpan(): FileSpan
+    {
+        return $this->span;
+    }
+
+    public function accepts(StatementVisitor $visitor)
+    {
+        return $visitor->visitStyleRule($this);
+    }
+}

--- a/src/Ast/Sass/Statement/Stylesheet.php
+++ b/src/Ast/Sass/Statement/Stylesheet.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass\Statement;
+
+use ScssPhp\ScssPhp\Ast\Sass\Statement;
+use ScssPhp\ScssPhp\Ast\Sass\SupportsCondition;
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+use ScssPhp\ScssPhp\Visitor\StatementVisitor;
+
+/**
+ * A Sass stylesheet.
+ *
+ * This is the root Sass node. It contains top-level statements.
+ *
+ * @extends ParentStatement<Statement[]>
+ *
+ * @internal
+ */
+final class Stylesheet extends ParentStatement
+{
+    /**
+     * @var bool
+     * @readonly
+     */
+    private $plainCss;
+
+    /**
+     * @var FileSpan
+     * @readonly
+     */
+    private $span;
+
+    /**
+     * @param Statement[] $children
+     */
+    public function __construct(array $children, FileSpan $span, bool $plainCss = false)
+    {
+        $this->span = $span;
+        $this->plainCss = $plainCss;
+        parent::__construct($children);
+    }
+
+    public function isPlainCss(): bool
+    {
+        return $this->plainCss;
+    }
+
+    public function getSpan(): FileSpan
+    {
+        return $this->span;
+    }
+
+    public function accepts(StatementVisitor $visitor)
+    {
+        return $visitor->visitStylesheet($this);
+    }
+}

--- a/src/Ast/Sass/Statement/Stylesheet.php
+++ b/src/Ast/Sass/Statement/Stylesheet.php
@@ -13,8 +13,13 @@
 namespace ScssPhp\ScssPhp\Ast\Sass\Statement;
 
 use ScssPhp\ScssPhp\Ast\Sass\Statement;
-use ScssPhp\ScssPhp\Ast\Sass\SupportsCondition;
+use ScssPhp\ScssPhp\Exception\SassFormatException;
+use ScssPhp\ScssPhp\Logger\LoggerInterface;
+use ScssPhp\ScssPhp\Parser\CssParser;
+use ScssPhp\ScssPhp\Parser\ScssParser;
 use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+use ScssPhp\ScssPhp\SourceSpan\SourceFile;
+use ScssPhp\ScssPhp\Syntax;
 use ScssPhp\ScssPhp\Visitor\StatementVisitor;
 
 /**
@@ -63,5 +68,54 @@ final class Stylesheet extends ParentStatement
     public function accepts(StatementVisitor $visitor)
     {
         return $visitor->visitStylesheet($this);
+    }
+
+    /**
+     * @param Syntax::* $syntax
+     *
+     * @throws SassFormatException when parsing fails
+     */
+    public static function parse(string $contents, string $syntax, ?LoggerInterface $logger = null, ?string $sourceUrl = null): self
+    {
+        switch ($syntax) {
+            case Syntax::SASS:
+                return self::parseSass($contents, $logger, $sourceUrl);
+
+            case Syntax::SCSS:
+                return self::parseScss($contents, $logger, $sourceUrl);
+
+            case Syntax::CSS:
+                return self::parseCss($contents, $logger, $sourceUrl);
+
+            default:
+                throw new \InvalidArgumentException("Unknown syntax $syntax.");
+        }
+    }
+
+    /**
+     * @throws SassFormatException when parsing fails
+     */
+    public static function parseSass(string $contents, ?LoggerInterface $logger = null, ?string $sourceUrl = null): self
+    {
+        $file = new SourceFile($contents, $sourceUrl);
+        $span = $file->span(0, 0);
+
+        throw new SassFormatException('The Sass indented syntax is not implemented.', $span);
+    }
+
+    /**
+     * @throws SassFormatException when parsing fails
+     */
+    public static function parseScss(string $contents, ?LoggerInterface $logger = null, ?string $sourceUrl = null): self
+    {
+        return (new ScssParser($contents, $logger, $sourceUrl))->parse();
+    }
+
+    /**
+     * @throws SassFormatException when parsing fails
+     */
+    public static function parseCss(string $contents, ?LoggerInterface $logger = null, ?string $sourceUrl = null): self
+    {
+        return (new CssParser($contents, $logger, $sourceUrl))->parse();
     }
 }

--- a/src/Ast/Sass/Statement/SupportsRule.php
+++ b/src/Ast/Sass/Statement/SupportsRule.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass\Statement;
+
+use ScssPhp\ScssPhp\Ast\Sass\Statement;
+use ScssPhp\ScssPhp\Ast\Sass\SupportsCondition;
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+use ScssPhp\ScssPhp\Visitor\StatementVisitor;
+
+/**
+ * A `@supports` rule.
+ *
+ * @extends ParentStatement<Statement[]>
+ *
+ * @internal
+ */
+final class SupportsRule extends ParentStatement
+{
+    /**
+     * @var SupportsCondition
+     * @readonly
+     */
+    private $condition;
+
+    /**
+     * @var FileSpan
+     * @readonly
+     */
+    private $span;
+
+    /**
+     * @param Statement[] $children
+     */
+    public function __construct(SupportsCondition $condition, array $children, FileSpan $span)
+    {
+        $this->condition = $condition;
+        $this->span = $span;
+        parent::__construct($children);
+    }
+
+    public function getCondition(): SupportsCondition
+    {
+        return $this->condition;
+    }
+
+    public function getSpan(): FileSpan
+    {
+        return $this->span;
+    }
+
+    public function accepts(StatementVisitor $visitor)
+    {
+        return $visitor->visitSupportsRule($this);
+    }
+}

--- a/src/Ast/Sass/Statement/VariableDeclaration.php
+++ b/src/Ast/Sass/Statement/VariableDeclaration.php
@@ -1,0 +1,150 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass\Statement;
+
+use ScssPhp\ScssPhp\Ast\Sass\Expression;
+use ScssPhp\ScssPhp\Ast\Sass\SassDeclaration;
+use ScssPhp\ScssPhp\Ast\Sass\Statement;
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+use ScssPhp\ScssPhp\Util\SpanUtil;
+use ScssPhp\ScssPhp\Visitor\StatementVisitor;
+
+/**
+ * A variable declaration.
+ *
+ * This defines or sets a variable.
+ *
+ * @internal
+ */
+final class VariableDeclaration implements Statement, SassDeclaration
+{
+    /**
+     * @var string|null
+     * @readonly
+     */
+    private $namespace;
+
+    /**
+     * @var string
+     * @readonly
+     */
+    private $name;
+
+    /**
+     * @var SilentComment|null
+     * @readonly
+     */
+    private $comment;
+
+    /**
+     * @var Expression
+     * @readonly
+     */
+    private $expression;
+
+    /**
+     * @var bool
+     * @readonly
+     */
+    private $guarded;
+
+    /**
+     * @var bool
+     * @readonly
+     */
+    private $global;
+
+    /**
+     * @var FileSpan
+     * @readonly
+     */
+    private $span;
+
+    public function __construct(string $name, Expression $expression, FileSpan $span, ?string $namespace = null, bool $guarded = false, bool $global = false, ?SilentComment $comment = null)
+    {
+        $this->name = $name;
+        $this->expression = $expression;
+        $this->span = $span;
+        $this->namespace = $namespace;
+        $this->guarded = $guarded;
+        $this->global = $global;
+        $this->comment = $comment;
+
+        if ($namespace !== null && $global) {
+            throw new \InvalidArgumentException("Other modules' members can't be defined with !global.");
+        }
+    }
+
+    public function getNamespace(): ?string
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * The name of the variable, with underscores converted to hyphens.
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getComment(): ?SilentComment
+    {
+        return $this->comment;
+    }
+
+    public function getExpression(): Expression
+    {
+        return $this->expression;
+    }
+
+    public function isGuarded(): bool
+    {
+        return $this->guarded;
+    }
+
+    public function isGlobal(): bool
+    {
+        return $this->global;
+    }
+
+    public function getSpan(): FileSpan
+    {
+        return $this->span;
+    }
+
+    public function getNameSpan(): FileSpan
+    {
+        $span = $this->span;
+
+        if ($this->namespace !== null) {
+            $span = SpanUtil::withoutNamespace($span);
+        }
+
+        return SpanUtil::initialIdentifier($span, 1);
+    }
+
+    public function getNamespaceSpan(): ?FileSpan
+    {
+        if ($this->namespace === null) {
+            return null;
+        }
+
+        return SpanUtil::initialIdentifier($this->span);
+    }
+
+    public function accepts(StatementVisitor $visitor)
+    {
+        return $visitor->visitVariableDeclaration($this);
+    }
+}

--- a/src/Ast/Sass/Statement/WarnRule.php
+++ b/src/Ast/Sass/Statement/WarnRule.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass\Statement;
+
+use ScssPhp\ScssPhp\Ast\Sass\Expression;
+use ScssPhp\ScssPhp\Ast\Sass\Statement;
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+use ScssPhp\ScssPhp\Visitor\StatementVisitor;
+
+/**
+ * A `@warn` rule.
+ *
+ * This prints a Sass value—usually a string—to warn the user of something.
+ *
+ * @internal
+ */
+final class WarnRule implements Statement
+{
+    /**
+     * @var Expression
+     * @readonly
+     */
+    private $expression;
+
+    /**
+     * @var FileSpan
+     * @readonly
+     */
+    private $span;
+
+    public function __construct(Expression $expression, FileSpan $span)
+    {
+        $this->expression = $expression;
+        $this->span = $span;
+    }
+
+    public function getExpression(): Expression
+    {
+        return $this->expression;
+    }
+
+    public function getSpan(): FileSpan
+    {
+        return $this->span;
+    }
+
+    public function accepts(StatementVisitor $visitor)
+    {
+        return $visitor->visitWarnRule($this);
+    }
+}

--- a/src/Ast/Sass/Statement/WhileRule.php
+++ b/src/Ast/Sass/Statement/WhileRule.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass\Statement;
+
+use ScssPhp\ScssPhp\Ast\Sass\Expression;
+use ScssPhp\ScssPhp\Ast\Sass\Statement;
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+use ScssPhp\ScssPhp\Visitor\StatementVisitor;
+
+/**
+ * A `@while` rule.
+ *
+ * This repeatedly executes a block of code as long as a statement evaluates to
+ * `true`.
+ *
+ * @extends ParentStatement<Statement[]>
+ *
+ * @internal
+ */
+final class WhileRule extends ParentStatement
+{
+    /**
+     * @var Expression
+     * @readonly
+     */
+    private $condition;
+
+    /**
+     * @var FileSpan
+     * @readonly
+     */
+    private $span;
+
+    /**
+     * @param Statement[] $children
+     */
+    public function __construct(Expression $condition, array $children, FileSpan $span)
+    {
+        $this->condition = $condition;
+        $this->span = $span;
+        parent::__construct($children);
+    }
+
+    public function getCondition(): Expression
+    {
+        return $this->condition;
+    }
+
+    public function getSpan(): FileSpan
+    {
+        return $this->span;
+    }
+
+    public function accepts(StatementVisitor $visitor)
+    {
+        return $visitor->visitWhileRule($this);
+    }
+}

--- a/src/Ast/Sass/SupportsCondition.php
+++ b/src/Ast/Sass/SupportsCondition.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass;
+
+/**
+ * An interface for defining the condition a `@supports` rule selects.
+ *
+ * @internal
+ */
+interface SupportsCondition extends SassNode
+{
+}

--- a/src/Ast/Sass/SupportsCondition/SupportsAnything.php
+++ b/src/Ast/Sass/SupportsCondition/SupportsAnything.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass\SupportsCondition;
+
+use ScssPhp\ScssPhp\Ast\Sass\Interpolation;
+use ScssPhp\ScssPhp\Ast\Sass\SupportsCondition;
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+
+/**
+ * A supports condition that represents the forwards-compatible
+ * `<general-enclosed>` production.
+ *
+ * @internal
+ */
+final class SupportsAnything implements SupportsCondition
+{
+    /**
+     * The contents of the condition.
+     *
+     * @var Interpolation
+     * @readonly
+     */
+    private $contents;
+
+    /**
+     * @var FileSpan
+     * @readonly
+     */
+    private $span;
+
+    public function __construct(Interpolation $contents, FileSpan $span)
+    {
+        $this->contents = $contents;
+        $this->span = $span;
+    }
+
+    public function getContents(): Interpolation
+    {
+        return $this->contents;
+    }
+
+    public function getSpan(): FileSpan
+    {
+        return $this->span;
+    }
+}

--- a/src/Ast/Sass/SupportsCondition/SupportsDeclaration.php
+++ b/src/Ast/Sass/SupportsCondition/SupportsDeclaration.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass\SupportsCondition;
+
+use ScssPhp\ScssPhp\Ast\Sass\Expression;
+use ScssPhp\ScssPhp\Ast\Sass\SupportsCondition;
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+
+/**
+ * A condition that selects for browsers where a given declaration is
+ * supported.
+ *
+ * @internal
+ */
+final class SupportsDeclaration implements SupportsCondition
+{
+    /**
+     * The name of the declaration being tested.
+     *
+     * @var Expression
+     * @readonly
+     */
+    private $name;
+
+    /**
+     * The value of the declaration being tested.
+     *
+     * @var Expression
+     * @readonly
+     */
+    private $value;
+
+    /**
+     * @var FileSpan
+     * @readonly
+     */
+    private $span;
+
+    public function __construct(Expression $name, Expression $value, FileSpan $span)
+    {
+        $this->name = $name;
+        $this->value = $value;
+        $this->span = $span;
+    }
+
+    public function getName(): Expression
+    {
+        return $this->name;
+    }
+
+    public function getValue(): Expression
+    {
+        return $this->value;
+    }
+
+    public function getSpan(): FileSpan
+    {
+        return $this->span;
+    }
+}

--- a/src/Ast/Sass/SupportsCondition/SupportsFunction.php
+++ b/src/Ast/Sass/SupportsCondition/SupportsFunction.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass\SupportsCondition;
+
+use ScssPhp\ScssPhp\Ast\Sass\Interpolation;
+use ScssPhp\ScssPhp\Ast\Sass\SupportsCondition;
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+
+/**
+ * A function-syntax condition.
+ *
+ * @internal
+ */
+final class SupportsFunction implements SupportsCondition
+{
+    /**
+     * The name of the function.
+     *
+     * @var Interpolation
+     * @readonly
+     */
+    private $name;
+
+    /**
+     * The arguments of the function.
+     *
+     * @var Interpolation
+     * @readonly
+     */
+    private $arguments;
+
+    /**
+     * @var FileSpan
+     * @readonly
+     */
+    private $span;
+
+    public function __construct(Interpolation $name, Interpolation $arguments, FileSpan $span)
+    {
+        $this->name = $name;
+        $this->arguments = $arguments;
+        $this->span = $span;
+    }
+
+    public function getName(): Interpolation
+    {
+        return $this->name;
+    }
+
+    public function getArguments(): Interpolation
+    {
+        return $this->arguments;
+    }
+
+    public function getSpan(): FileSpan
+    {
+        return $this->span;
+    }
+}

--- a/src/Ast/Sass/SupportsCondition/SupportsInterpolation.php
+++ b/src/Ast/Sass/SupportsCondition/SupportsInterpolation.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass\SupportsCondition;
+
+use ScssPhp\ScssPhp\Ast\Sass\Expression;
+use ScssPhp\ScssPhp\Ast\Sass\SupportsCondition;
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+
+/**
+ * An interpolated condition.
+ *
+ * @internal
+ */
+final class SupportsInterpolation implements SupportsCondition
+{
+    /**
+     * The expression in the interpolation.
+     *
+     * @var Expression
+     * @readonly
+     */
+    private $expression;
+
+    /**
+     * @var FileSpan
+     * @readonly
+     */
+    private $span;
+
+    public function __construct(Expression $expression, FileSpan $span)
+    {
+        $this->expression = $expression;
+        $this->span = $span;
+    }
+
+    public function getExpression(): Expression
+    {
+        return $this->expression;
+    }
+
+    public function getSpan(): FileSpan
+    {
+        return $this->span;
+    }
+}

--- a/src/Ast/Sass/SupportsCondition/SupportsNegation.php
+++ b/src/Ast/Sass/SupportsCondition/SupportsNegation.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass\SupportsCondition;
+
+use ScssPhp\ScssPhp\Ast\Sass\SupportsCondition;
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+
+/**
+ * A negated condition.
+ *
+ * @internal
+ */
+final class SupportsNegation implements SupportsCondition
+{
+    /**
+     * The condition that's been negated.
+     *
+     * @var SupportsCondition
+     * @readonly
+     */
+    private $condition;
+
+    /**
+     * @var FileSpan
+     * @readonly
+     */
+    private $span;
+
+    public function __construct(SupportsCondition $condition, FileSpan $span)
+    {
+        $this->condition = $condition;
+        $this->span = $span;
+    }
+
+    public function getCondition(): SupportsCondition
+    {
+        return $this->condition;
+    }
+
+    public function getSpan(): FileSpan
+    {
+        return $this->span;
+    }
+}

--- a/src/Ast/Sass/SupportsCondition/SupportsOperation.php
+++ b/src/Ast/Sass/SupportsCondition/SupportsOperation.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass\SupportsCondition;
+
+use ScssPhp\ScssPhp\Ast\Sass\SupportsCondition;
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+
+/**
+ * An operation defining the relationship between two conditions.
+ *
+ * @internal
+ */
+final class SupportsOperation implements SupportsCondition
+{
+    /**
+     * The left-hand operand.
+     *
+     * @var SupportsCondition
+     * @readonly
+     */
+    private $left;
+
+    /**
+     * The right-hand operand.
+     *
+     * @var SupportsCondition
+     * @readonly
+     */
+    private $right;
+
+    /**
+     * @var string
+     * @readonly
+     */
+    private $operator;
+
+    /**
+     * @var FileSpan
+     * @readonly
+     */
+    private $span;
+
+    public function __construct(SupportsCondition $left, SupportsCondition $right, string $operator, FileSpan $span)
+    {
+        $this->left = $left;
+        $this->right = $right;
+        $this->operator = $operator;
+        $this->span = $span;
+    }
+
+    public function getLeft(): SupportsCondition
+    {
+        return $this->left;
+    }
+
+    public function getRight(): SupportsCondition
+    {
+        return $this->right;
+    }
+
+    public function getOperator(): string
+    {
+        return $this->operator;
+    }
+
+    public function getSpan(): FileSpan
+    {
+        return $this->span;
+    }
+}

--- a/src/Colors.php
+++ b/src/Colors.php
@@ -12,6 +12,8 @@
 
 namespace ScssPhp\ScssPhp;
 
+use ScssPhp\ScssPhp\Value\SassColor;
+
 /**
  * CSS Colors
  *
@@ -179,6 +181,17 @@ final class Colors
         'rebeccapurple' => '102,51,153',
         'transparent' => '0,0,0,0',
     ];
+
+    public static function colorNameToColor(string $colorName): ?SassColor
+    {
+        $rgba = self::colorNameToRGBa($colorName);
+
+        if ($rgba === null) {
+            return null;
+        }
+
+        return SassColor::rgb($rgba[0], $rgba[1], $rgba[2], $rgba[3] ?? null);
+    }
 
     /**
      * Convert named color in a [r,g,b[,a]] array

--- a/src/Exception/SassFormatException.php
+++ b/src/Exception/SassFormatException.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Exception;
+
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+
+/**
+ * @internal
+ */
+final class SassFormatException extends \Exception implements SassException
+{
+    /**
+     * @var string
+     * @readonly
+     */
+    private $originalMessage;
+
+    /**
+     * @var FileSpan
+     * @readonly
+     */
+    private $span;
+
+    public function __construct(string $message, FileSpan $span, \Throwable $previous = null)
+    {
+        $this->originalMessage = $message;
+        $this->span = $span;
+
+        parent::__construct($span->message($message), 0, $previous);
+    }
+
+    /**
+     * Gets the original message without the location info in it.
+     */
+    public function getOriginalMessage(): string
+    {
+        return $this->originalMessage;
+    }
+
+    public function getSpan(): FileSpan
+    {
+        return $this->span;
+    }
+}

--- a/src/Parser/CssParser.php
+++ b/src/Parser/CssParser.php
@@ -1,0 +1,165 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Parser;
+
+use ScssPhp\ScssPhp\Ast\Sass\ArgumentInvocation;
+use ScssPhp\ScssPhp\Ast\Sass\Expression;
+use ScssPhp\ScssPhp\Ast\Sass\Expression\InterpolatedFunctionExpression;
+use ScssPhp\ScssPhp\Ast\Sass\Expression\StringExpression;
+use ScssPhp\ScssPhp\Ast\Sass\Import\StaticImport;
+use ScssPhp\ScssPhp\Ast\Sass\Interpolation;
+use ScssPhp\ScssPhp\Ast\Sass\Statement;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\ImportRule;
+use ScssPhp\ScssPhp\Compiler;
+
+/**
+ * A parser for imported CSS files.
+ *
+ * @internal
+ */
+final class CssParser extends ScssParser
+{
+    /**
+     * Sass global functions which are shadowing a CSS function are allowed in CSS files.
+     */
+    private const CSS_ALLOWED_FUNCTIONS = [
+        'rgb' => true, 'rgba' => true, 'hsl' => true, 'hsla' => true, 'grayscale' => true,
+        'invert' => true, 'alpha' => true, 'opacity' => true, 'saturate' => true,
+    ];
+
+    protected function isPlainCss(): bool
+    {
+        return true;
+    }
+
+    protected function silentComment(): void
+    {
+        $start = $this->scanner->getPosition();
+        parent::silentComment();
+        $this->error("Silent comments aren't allowed in plain CSS.", $this->scanner->spanFrom($start));
+    }
+
+    protected function atRule(callable $child, bool $root = false): Statement
+    {
+        $start = $this->scanner->getPosition();
+
+        $this->scanner->expectChar('@');
+        $name = $this->interpolatedIdentifier();
+        $this->whitespace();
+
+        switch ($name->getAsPlain()) {
+            case 'at-root':
+            case 'content':
+            case 'debug':
+            case 'each':
+            case 'error':
+            case 'extend':
+            case 'for':
+            case 'function':
+            case 'if':
+            case 'include':
+            case 'mixin':
+            case 'return':
+            case 'warn':
+            case 'while':
+                $this->almostAnyValue();
+                $this->error("This at-rule isn't allowed in plain CSS.", $this->scanner->spanFrom($start));
+
+            case 'import':
+                return $this->cssImportRule($start);
+
+            case 'media':
+                return $this->mediaRule($start);
+
+            case '-moz-document':
+                return $this->mozDocumentRule($start, $name);
+
+            case 'supports':
+                return $this->supportsRule($start);
+
+            default:
+                return $this->unknownAtRule($start, $name);
+
+        }
+    }
+
+    private function cssImportRule(int $start): ImportRule
+    {
+        $urlStart = $this->scanner->getPosition();
+        $next = $this->scanner->peekChar();
+
+        if ($next === 'u' || $next === 'U') {
+            $url = $this->dynamicUrl();
+        } else {
+            $url = new StringExpression($this->interpolatedString()->asInterpolation(true));
+        }
+        $urlSpan = $this->scanner->spanFrom($urlStart);
+
+        $this->whitespace();
+        list($supports, $media) = $this->tryImportQueries();
+        $this->expectStatementSeparator('@import rule');
+
+        return new ImportRule([
+            new StaticImport(new Interpolation([$url], $urlSpan), $this->scanner->spanFrom($start), $supports, $media)
+        ], $this->scanner->spanFrom($start));
+    }
+
+    protected function identifierLike(): Expression
+    {
+        $start = $this->scanner->getPosition();
+        $identifier = $this->interpolatedIdentifier();
+        $plain = $identifier->getAsPlain();
+        assert($plain !== null); // CSS doesn't allow non-plain identifiers
+
+        $specialFunction = $this->trySpecialFunction(strtolower($plain), $start);
+
+        if ($specialFunction !== null) {
+            return $specialFunction;
+        }
+
+        $beforeArguments = $this->scanner->getPosition();
+        if (!$this->scanner->scanChar('(')) {
+            return new StringExpression($identifier);
+        }
+
+        $arguments = [];
+
+        if (!$this->scanner->scanChar(')')) {
+            do {
+                $this->whitespace();
+                $arguments[] = $this->expression(null, true);
+                $this->whitespace();
+            } while ($this->scanner->scanChar(','));
+            $this->scanner->expectChar(')');
+        }
+
+        if ($plain === 'if' || (!isset(self::CSS_ALLOWED_FUNCTIONS[$plain]) && Compiler::isNativeFunction($plain))) {
+            $this->error("This function isn't allowed in plain CSS.", $this->scanner->spanFrom($start));
+        }
+
+        return new InterpolatedFunctionExpression(
+            // Create a fake interpolation to force the function to be interpreted
+            // as plain CSS, rather than calling a user-defined function.
+            new Interpolation([new StringExpression($identifier)], $identifier->getSpan()),
+            new ArgumentInvocation($arguments, [], $this->scanner->spanFrom($beforeArguments)),
+            $this->scanner->spanFrom($start)
+        );
+    }
+
+    protected function namespacedExpression(string $namespace, int $start): Expression
+    {
+        $expression = parent::namespacedExpression($namespace, $start);
+
+        $this->error("Module namespaces aren't allowed in plain CSS.", $expression->getSpan());
+    }
+}

--- a/src/Parser/FormatException.php
+++ b/src/Parser/FormatException.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Parser;
+
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+
+/**
+ * @internal
+ */
+final class FormatException extends \Exception
+{
+    /**
+     * @var FileSpan
+     * @readonly
+     */
+    private $span;
+
+    public function __construct(string $message, FileSpan $span)
+    {
+        $this->span = $span;
+        parent::__construct($message);
+    }
+
+    public function getSpan(): FileSpan
+    {
+        return $this->span;
+    }
+}

--- a/src/Parser/InterpolationBuffer.php
+++ b/src/Parser/InterpolationBuffer.php
@@ -1,0 +1,109 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Parser;
+
+use ScssPhp\ScssPhp\Ast\Sass\Expression;
+use ScssPhp\ScssPhp\Ast\Sass\Interpolation;
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+
+/**
+ * A buffer that iteratively builds up an {@see Interpolation}.
+ *
+ * @internal
+ */
+final class InterpolationBuffer
+{
+    /**
+     * @var string
+     */
+    private $text = '';
+
+    /**
+     * @var list<string|Expression>
+     */
+    private $contents = [];
+
+    /**
+     * Returns the substring of the buffer string after the last interpolation.
+     */
+    public function getTrailingString(): string
+    {
+        return $this->text;
+    }
+
+    public function isEmpty(): bool
+    {
+        return $this->text === '' && \count($this->contents) === 0;
+    }
+
+    public function write(string $string): void
+    {
+        $this->text .= $string;
+    }
+
+    public function add(Expression $expression): void
+    {
+        $this->flushText();
+        $this->contents[] = $expression;
+    }
+
+    public function addInterpolation(Interpolation $interpolation): void
+    {
+        $contents = $interpolation->getContents();
+
+        if (empty($contents)) {
+            return;
+        }
+
+        if (is_string($contents[0])) {
+            $this->text .= $contents[0];
+
+            array_shift($contents);
+        }
+
+        $this->flushText();
+
+        foreach ($contents as $content) {
+            $this->contents[] = $content;
+        }
+
+        if (\is_string($this->contents[\count($this->contents) - 1])) {
+            $this->text = $this->contents[\count($this->contents) - 1];
+            array_pop($this->contents);
+        }
+    }
+
+    public function buildInterpolation(FileSpan $span): Interpolation
+    {
+        $contents = $this->contents;
+
+        if ($this->text !== '') {
+            $contents[] = $this->text;
+        }
+
+        return new Interpolation($contents, $span);
+    }
+
+    /**
+     * Flushes {@see self::$text} to {@see self::$contents} if necessary.
+     */
+    private function flushText(): void
+    {
+        if ($this->text === '') {
+            return;
+        }
+
+        $this->contents[] = $this->text;
+        $this->text = '';
+    }
+}

--- a/src/Parser/Parser.php
+++ b/src/Parser/Parser.php
@@ -1,0 +1,878 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Parser;
+
+use ScssPhp\ScssPhp\Exception\SassFormatException;
+use ScssPhp\ScssPhp\Logger\LoggerInterface;
+use ScssPhp\ScssPhp\Logger\QuietLogger;
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+use ScssPhp\ScssPhp\Util;
+use ScssPhp\ScssPhp\Util\Character;
+use ScssPhp\ScssPhp\Util\ParserUtil;
+
+/**
+ * @internal
+ */
+class Parser
+{
+    /**
+     * @var StringScanner
+     * @readonly
+     */
+    protected $scanner;
+
+    /**
+     * @var LoggerInterface
+     * @readonly
+     */
+    protected $logger;
+
+    /**
+     * @var string|null
+     * @readonly
+     */
+    protected $sourceUrl;
+
+    public function __construct(string $contents, ?LoggerInterface $logger = null, ?string $sourceUrl = null)
+    {
+        $this->scanner = new StringScanner($contents);
+        $this->logger = $logger ?: new QuietLogger();
+        $this->sourceUrl = $sourceUrl;
+    }
+
+    /**
+     * Consumes whitespace, including any comments.
+     */
+    protected function whitespace(): void
+    {
+        do {
+            $this->whitespaceWithoutComments();
+        } while ($this->scanComment());
+    }
+
+    /**
+     * Consumes whitespace, but not comments.
+     */
+    protected function whitespaceWithoutComments(): void
+    {
+        while (!$this->scanner->isDone() && Character::isWhitespace($this->scanner->peekChar())) {
+            $this->scanner->readChar();
+        }
+    }
+
+    /**
+     * Consumes spaces and tabs.
+     */
+    protected function spaces(): void
+    {
+        while (!$this->scanner->isDone() && Character::isSpaceOrTab($this->scanner->peekChar())) {
+            $this->scanner->readChar();
+        }
+    }
+
+    /**
+     * Consumes and ignores a comment if possible.
+     *
+     * Returns whether the comment was consumed.
+     */
+    protected function scanComment(): bool
+    {
+        if ($this->scanner->peekChar() !== '/') {
+            return false;
+        }
+
+        $next = $this->scanner->peekChar(1);
+
+        if ($next === '/') {
+            $this->silentComment();
+
+            return true;
+        }
+
+        if ($next === '*') {
+            $this->loudComment();
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Consumes and ignores a silent (Sass-style) comment.
+     */
+    protected function silentComment(): void
+    {
+        $this->scanner->expect('//');
+
+        while (!$this->scanner->isDone() && !Character::isNewline($this->scanner->peekChar())) {
+            $this->scanner->readChar();
+        }
+    }
+
+    /**
+     * Consumes and ignores a loud (CSS-style) comment.
+     */
+    protected function loudComment(): void
+    {
+        $this->scanner->expect('/*');
+
+        while (true) {
+            $next = $this->scanner->readChar();
+
+            if ($next !== '*') {
+                continue;
+            }
+
+            do {
+                $next = $this->scanner->readChar();
+            } while ($next === '*');
+
+            if ($next === '/') {
+                break;
+            }
+        }
+    }
+
+    /**
+     * Consumes a plain CSS identifier.
+     *
+     * If $normalize is `true`, this converts underscores into hyphens.
+     *
+     * If $unit is `true`, this doesn't parse a `-` followed by a digit. This
+     * ensures that `1px-2px` parses as subtraction rather than the unit
+     * `px-2px`.
+     */
+    protected function identifier(bool $normalize = false, bool $unit = false): string
+    {
+        $text = '';
+
+        if ($this->scanner->scanChar('-')) {
+            $text .= '-';
+
+
+            if ($this->scanner->scanChar('-')) {
+                $text .= '-';
+                $text .= $this->consumeIdentifierBody($normalize, $unit);
+
+                return $text;
+            }
+        }
+
+        $first = $this->scanner->peekChar();
+
+        if ($first === null) {
+            $this->scanner->error('Expected identifier.');
+        }
+
+        if ($normalize && $first === '_') {
+            $this->scanner->readChar();
+            $text .= '-';
+        } elseif (Character::isNameStart($first)) {
+            $text .= $this->scanner->readUtf8Char();
+        } elseif ($first === '\\') {
+            $text .= $this->escape(true);
+        } else {
+            $this->scanner->error('Expected identifier.');
+        }
+
+        $text .= $this->consumeIdentifierBody($normalize, $unit);
+
+        return $text;
+    }
+
+    /**
+     * Consumes a chunk of a plain CSS identifier after the name start.
+     */
+    public function identifierBody(): string
+    {
+        $text = $this->consumeIdentifierBody();
+
+        if ($text === '') {
+            $this->scanner->error('Expected identifier body.');
+        }
+
+        return $text;
+    }
+
+    private function consumeIdentifierBody(bool $normalize = false, bool $unit = false): string
+    {
+        $text = '';
+
+        while (true) {
+            $next = $this->scanner->peekChar();
+
+            if ($next === null) {
+                break;
+            }
+
+            if ($unit && $next === '-') {
+                $second = $this->scanner->peekChar(1);
+
+                if ($second !== null && ($second === '.' || Character::isDigit($second))) {
+                    break;
+                }
+
+                $text .= $this->scanner->readChar();
+            } elseif ($normalize && $next === '_') {
+                $this->scanner->readChar();
+                $text .= '-';
+            } elseif (Character::isName($next)) {
+                $text .= $this->scanner->readUtf8Char();
+            } elseif ($next === '\\') {
+                $text .= $this->escape();
+            } else {
+                break;
+            }
+        }
+
+        return $text;
+    }
+
+    /**
+     * Consumes a plain CSS string.
+     *
+     * This returns the parsed contents of the string—that is, it doesn't include
+     * quotes and its escapes are resolved.
+     */
+    protected function string(): string
+    {
+        $quote = $this->scanner->readChar();
+
+        if ($quote !== '"' && $quote !== "'") {
+            $this->scanner->error('Expected string.');
+        }
+
+        $buffer = '';
+
+        while (true) {
+            $next = $this->scanner->peekChar();
+
+            if ($next === $quote) {
+                $this->scanner->readChar();
+                break;
+            }
+
+            if ($next === null || Character::isNewline($next)) {
+                $this->scanner->error("Expected $quote.");
+            }
+
+            if ($next === '\\') {
+                $second = $this->scanner->peekChar(1);
+
+                if ($second !== null && Character::isNewline($second)) {
+                    $this->scanner->readChar();
+                    $this->scanner->readChar();
+                } else {
+                    $buffer .= $this->escapeCharacter();
+                }
+            } else {
+                $buffer .= $this->scanner->readUtf8Char();
+            }
+        }
+
+        return $buffer;
+    }
+
+    /**
+     * Consumes and returns a natural number (that is, a non-negative integer).
+     *
+     * Doesn't support scientific notation.
+     */
+    protected function naturalNumber(): int
+    {
+        $first = $this->scanner->readChar();
+
+        if (!Character::isDigit($first)) {
+            $this->scanner->error('Expected digit.', $this->scanner->getPosition() - 1);
+        }
+
+        $number = $first;
+
+        $next = $this->scanner->peekChar();
+
+        while ($next !== null && Character::isDigit($next)) {
+            $number .= $this->scanner->readChar();
+            $next = $this->scanner->peekChar();
+        }
+
+        return intval($number);
+    }
+
+    /**
+     * Consumes tokens until it reaches a top-level `";"`, `")"`, `"]"`,
+     * or `"}"` and returns their contents as a string.
+     *
+     * If $allowEmpty is `false` (the default), this requires at least one token.
+     */
+    protected function declarationValue(bool $allowEmpty = false): string
+    {
+        $buffer = '';
+        $brackets = [];
+        $wroteNewline = false;
+
+        while (true) {
+            $next = $this->scanner->peekChar();
+
+            if ($next === null) {
+                break;
+            }
+
+            switch ($next) {
+                case '\\':
+                    $buffer .= $this->escape(true);
+                    $wroteNewline = false;
+                    break;
+
+                case '"':
+                case "'":
+                    $buffer .= $this->rawText([$this, 'string']);
+                    $wroteNewline = false;
+                    break;
+
+                case '/':
+                    if ($this->scanner->peekChar(1) === '*') {
+                        $buffer .= $this->rawText([$this, 'loudComment']);
+                    } else {
+                        $buffer .= $this->scanner->readChar();
+                    }
+                    $wroteNewline = false;
+                    break;
+
+                case ' ':
+                case "\t":
+                    $second = $this->scanner->peekChar(1);
+                    if ($wroteNewline || $second === null || !Character::isWhitespace($second)) {
+                        $buffer .= ' ';
+                    }
+                    $this->scanner->readChar();
+                    break;
+
+                case "\n":
+                case "\r":
+                case "\f":
+                    $prev = $this->scanner->peekChar(-1);
+                    if ($prev === null || !Character::isNewline($prev)) {
+                        $buffer .= "\n";
+                    }
+                    $this->scanner->readChar();
+                    $wroteNewline = true;
+                    break;
+
+                case '(':
+                case '{':
+                case '[':
+                    $buffer .= $next;
+                    $brackets[] = Character::opposite($this->scanner->readChar());
+                    $wroteNewline = false;
+                    break;
+
+                case ')':
+                case '}':
+                case ']':
+                    if (empty($brackets)) {
+                        break 2;
+                    }
+
+                    $buffer .= $next;
+                    $this->scanner->expectChar(array_pop($brackets));
+                    $wroteNewline = false;
+                    break;
+
+                case ';':
+                    if (empty($brackets)) {
+                        break 2;
+                    }
+
+                    $buffer .= $this->scanner->readChar();
+                    break;
+
+                case 'u':
+                case 'U':
+                    $url = $this->tryUrl();
+
+                    if ($url !== null) {
+                        $buffer .= $url;
+                    } else {
+                        $buffer .= $this->scanner->readChar();
+                    }
+
+                    $wroteNewline = false;
+                    break;
+
+                default:
+                    if ($this->lookingAtIdentifier()) {
+                        $buffer .= $this->identifier();
+                    } else {
+                        $buffer .= $this->scanner->readUtf8Char();
+                    }
+                    $wroteNewline = false;
+                    break;
+            }
+        }
+
+        if (!empty($brackets)) {
+            $this->scanner->expectChar(array_pop($brackets));
+        }
+
+        if (!$allowEmpty && $buffer === '') {
+            $this->scanner->error('Expected token.');
+        }
+
+        return $buffer;
+    }
+
+    /**
+     * Consumes a `url()` token if possible, and returns `null` otherwise.
+     */
+    protected function tryUrl(): ?string
+    {
+        $start = $this->scanner->getPosition();
+
+        if (!$this->scanIdentifier('url')) {
+            return null;
+        }
+
+        if (!$this->scanner->scanChar('(')) {
+            $this->scanner->setPosition($start);
+
+            return null;
+        }
+
+        $this->whitespace();
+
+        $buffer = 'url(';
+
+        while (true) {
+            $next = $this->scanner->peekChar();
+
+            if ($next === null) {
+                break;
+            }
+
+            $nextCharCode = \ord($next);
+
+            if ($next === '\\') {
+                $buffer .= $this->escape();
+            } elseif ($next === '%' || $next === '&' || $next === '#' || ($nextCharCode >= \ord('*') && $nextCharCode <= \ord('~')) || $nextCharCode >= 0x80) {
+                $buffer .= $this->scanner->readUtf8Char();
+            } elseif (Character::isWhitespace($next)) {
+                $this->whitespace();
+
+                if ($this->scanner->peekChar() !== ')') {
+                    break;
+                }
+            } elseif ($next === ')') {
+                $buffer .= $this->scanner->readChar();
+
+                return $buffer;
+            } else {
+                break;
+            }
+        }
+
+        $this->scanner->setPosition($start);
+
+        return null;
+    }
+
+    /**
+     * Consumes a Sass variable name, and returns its name without the dollar sign.
+     */
+    protected function variableName(): string
+    {
+        $this->scanner->expectChar('$');
+
+        return $this->identifier(true);
+    }
+
+    /**
+     * Consumes an escape sequence and returns the text that defines it.
+     *
+     * If $identifierStart is true, this normalizes the escape sequence as
+     * though it were at the beginning of an identifier.
+     */
+    protected function escape(bool $identifierStart = false): string
+    {
+        $start = $this->scanner->getPosition();
+
+        $this->scanner->expectChar('\\');
+
+        $first = $this->scanner->peekChar();
+
+        if ($first === null) {
+            $this->scanner->error('Expected escape sequence.');
+        }
+
+        if (Character::isNewline($first)) {
+            $this->scanner->error('Expected escape sequence.');
+        }
+
+        if (Character::isHex($first)) {
+            $value = 0;
+            for ($i = 0; $i < 6; $i++) {
+                $next = $this->scanner->peekChar();
+
+                if ($next === null || !Character::isHex($next)) {
+                    break;
+                }
+
+                $value *= 16;
+                $value += hexdec($this->scanner->readChar());
+                assert(\is_int($value));
+            }
+
+            $this->scanCharIf([Character::class, 'isWhitespace']);
+            $valueText = Util::mbChr($value);
+        } else {
+            $valueText = $this->scanner->readUtf8Char();
+            $value = Util::mbOrd($valueText);
+        }
+
+        if ($identifierStart ? Character::isNameStart($valueText) : Character::isName($valueText)) {
+            if ($value > 0x10ffff) {
+                $this->scanner->error('Invalid Unicode code point.', $start);
+            }
+
+            return $valueText;
+        }
+
+        if ($value < 0x1f || $valueText === "\x7f" || ($identifierStart && Character::isDigit($valueText))) {
+            return '\\' . bin2hex($valueText) . ' ';
+        }
+
+        return '\\' . $valueText;
+    }
+
+    /**
+     * Consumes an escape sequence and returns the character it represents.
+     */
+    protected function escapeCharacter(): string
+    {
+        return ParserUtil::consumeEscapedCharacter($this->scanner);
+    }
+
+    /**
+     * @param callable(string): bool $condition
+     */
+    protected function scanCharIf(callable $condition): bool
+    {
+        $next = $this->scanner->peekChar();
+
+        if ($next === null || !$condition($next)) {
+            return false;
+        }
+
+        $this->scanner->readChar();
+
+        return true;
+    }
+
+    /**
+     * Consumes the next character or escape sequence if it matches $character.
+     *
+     * Matching will be case-insensitive unless $caseSensitive is true.
+     * When matching case-insensitively, $character must be passed in lowercase.
+     *
+     * This only supports ASCII identifier characters.
+     */
+    protected function scanIdentChar(string $character, bool $caseSensitive = false): bool
+    {
+        $matches = function (string $actual) use ($character, $caseSensitive): bool {
+            if ($caseSensitive) {
+                return $actual === $character;
+            }
+
+            return \strtolower($actual) === $character;
+        };
+
+        $next = $this->scanner->peekChar();
+
+        if ($next !== null && $matches($next)) {
+            $this->scanner->readChar();
+
+            return true;
+        }
+
+        if ($next === '\\') {
+            $start = $this->scanner->getPosition();
+
+            if ($matches($this->escapeCharacter())) {
+                return true;
+            }
+
+            $this->scanner->setPosition($start);
+        }
+
+        return false;
+    }
+
+    /**
+     * Consumes the next character or escape sequence and asserts it matches $char.
+     *
+     * Matching will be case-insensitive unless $caseSensitive is true.
+     * When matching case-insensitively, $char must be passed in lowercase.
+     *
+     * This only supports ASCII identifier characters.
+     */
+    protected function expectIdentChar(string $char, bool $caseSensitive = false): void
+    {
+        if ($this->scanIdentChar($char, $caseSensitive)) {
+            return;
+        }
+
+        $this->scanner->error("Expected \"$char\"");
+    }
+
+    /**
+     * Returns whether the scanner is immediately before a number.
+     *
+     * This follows [the CSS algorithm][].
+     *
+     * [the CSS algorithm]: https://drafts.csswg.org/css-syntax-3/#starts-with-a-number
+     */
+    protected function lookingAtNumber(): bool
+    {
+        $first = $this->scanner->peekChar();
+
+        if ($first === null) {
+            return false;
+        }
+
+        if (Character::isDigit($first)) {
+            return true;
+        }
+
+        if ($first === '.') {
+            $second = $this->scanner->peekChar(1);
+
+            return $second !== null && Character::isDigit($second);
+        }
+
+        if ($first === '+' || $first === '-') {
+            $second = $this->scanner->peekChar(1);
+
+            if ($second === null) {
+                return false;
+            }
+
+            if (Character::isDigit($second)) {
+                return true;
+            }
+
+            if ($second !== '.') {
+                return false;
+            }
+
+            $third = $this->scanner->peekChar(2);
+
+            return $third !== null && Character::isDigit($third);
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns whether the scanner is immediately before a plain CSS identifier.
+     *
+     * If $forward is passed, this looks that many characters forward instead.
+     *
+     * This is based on [the CSS algorithm][], but it assumes all backslashes
+     * start escapes.
+     *
+     * [the CSS algorithm]: https://drafts.csswg.org/css-syntax-3/#would-start-an-identifier
+     */
+    protected function lookingAtIdentifier(int $forward = 0): bool
+    {
+        $first = $this->scanner->peekChar($forward);
+
+        if ($first === null) {
+            return false;
+        }
+
+        if ($first === '\\' || Character::isNameStart($first)) {
+            return true;
+        }
+
+        if ($first !== '-') {
+            return false;
+        }
+
+        $second = $this->scanner->peekChar($forward + 1);
+
+        if ($second === null) {
+            return false;
+        }
+
+        return $second === '\\' || $second === '-' || Character::isNameStart($second);
+    }
+
+    /**
+     * Returns whether the scanner is immediately before a sequence of characters
+     * that could be part of a plain CSS identifier body.
+     */
+    protected function lookingAtIdentifierBody(): bool
+    {
+        $next = $this->scanner->peekChar();
+
+        return $next !== null && ($next === '\\' || Character::isName($next));
+    }
+
+    /**
+     * Consumes an identifier if its name exactly matches $text.
+     *
+     * When matching case-insensitively, $text must be passed in lowercase.
+     *
+     * This only supports ASCII identifiers.
+     */
+    protected function scanIdentifier(string $text, bool $caseSensitive = false): bool
+    {
+        if (!$this->lookingAtIdentifier()) {
+            return false;
+        }
+
+        $start = $this->scanner->getPosition();
+
+        for ($i = 0; $i < \strlen($text); $i++) {
+            if ($this->scanIdentChar($text[$i], $caseSensitive)) {
+                continue;
+            }
+
+            $this->scanner->setPosition($start);
+
+            return false;
+        }
+
+        if (!$this->lookingAtIdentifierBody()) {
+            return true;
+        }
+
+        $this->scanner->setPosition($start);
+
+        return false;
+    }
+
+    /**
+     * Consumes an identifier asserts that its name exactly matches $text.
+     *
+     * When matching case-insensitively, $text must be passed in lowercase.
+     *
+     * This only supports ASCII identifiers.
+     */
+    protected function expectIdentifier(string $text, ?string $name = null, bool $caseSensitive = false): void
+    {
+        $name = $name ?? "\"$text\"";
+
+        $start = $this->scanner->getPosition();
+
+        for ($i = 0; $i < \strlen($text); $i++) {
+            if ($this->scanIdentChar($text[$i], $caseSensitive)) {
+                continue;
+            }
+
+            $this->scanner->error("Expected $name.", $start);
+        }
+
+        if (!$this->lookingAtIdentifierBody()) {
+            return;
+        }
+
+        $this->scanner->error("Expected $name.", $start);
+    }
+
+    /**
+     * Runs $consumer and returns the source text that it consumes.
+     *
+     * @param callable(): void $consumer
+     */
+    protected function rawText(callable $consumer): string
+    {
+        $start = $this->scanner->getPosition();
+        $consumer();
+
+        return $this->scanner->substring($start);
+    }
+
+    /**
+     * Prints a warning to standard error, associated with $span.
+     */
+    protected function warn(string $message, FileSpan $span): void
+    {
+        $this->logger->warn($span->message($message));
+    }
+
+    /**
+     * Throws an error associated with $position.
+     *
+     * @throws FormatException
+     *
+     * @return never-returns
+     */
+    protected function error(string $message, FileSpan $span): void
+    {
+        throw new FormatException($message, $span);
+    }
+
+    protected function wrapException(FormatException $error): SassFormatException
+    {
+        $span = $error->getSpan();
+
+        if ($span->getLength() === 0 && 0 === stripos($error->getMessage(), 'expected')) {
+            $startPosition = $this->firstNewlineBefore($span->getStart()->getOffset());
+
+            if ($startPosition !== $span->getStart()->getOffset()) {
+                $span = $span->getFile()->span($startPosition, $startPosition);
+            }
+        }
+
+        return new SassFormatException($error->getMessage(), $span, $error);
+    }
+
+    /**
+     * If [position] is separated from the previous non-whitespace character in
+     * `$scanner->getString()` by one or more newlines, returns the offset of the last
+     * separating newline.
+     *
+     * Otherwise returns $position.
+     *
+     * This helps avoid missing token errors pointing at the next closing bracket
+     * rather than the line where the problem actually occurred.
+     *
+     * @param int $position
+     *
+     * @return int
+     */
+    private function firstNewlineBefore(int $position): int
+    {
+        $index = $position - 1;
+        $lastNewline = null;
+        $string = $this->scanner->getString();
+
+        while ($index >= 0) {
+            $char = $string[$index];
+
+            if (!Character::isWhitespace($char)) {
+                return $lastNewline ?? $position;
+            }
+
+            if (Character::isNewline($char)) {
+                $lastNewline = $index;
+            }
+            $index--;
+        }
+
+        // If the document *only* contains whitespace before $position, always
+        // return $position.
+
+        return $position;
+    }
+}

--- a/src/Parser/ScssParser.php
+++ b/src/Parser/ScssParser.php
@@ -1,0 +1,287 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Parser;
+
+use ScssPhp\ScssPhp\Ast\Sass\Interpolation;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\LoudComment;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\SilentComment;
+use ScssPhp\ScssPhp\Util\Character;
+
+/**
+ * A parser for the CSS-compatible syntax.
+ *
+ * @internal
+ */
+class ScssParser extends StylesheetParser
+{
+    protected function isIndented(): bool
+    {
+        return false;
+    }
+
+    protected function getCurrentIndentation(): int
+    {
+        return 0;
+    }
+
+    protected function styleRuleSelector(): Interpolation
+    {
+        return $this->almostAnyValue();
+    }
+
+    protected function expectStatementSeparator(?string $name = null): void
+    {
+        $this->whitespaceWithoutComments();
+
+        if ($this->scanner->isDone()) {
+            return;
+        }
+
+        $next = $this->scanner->peekChar();
+
+        if ($next === ';' || $next === '}') {
+            return;
+        }
+
+        $this->scanner->expectChar(';');
+    }
+
+    protected function atEndOfStatement(): bool
+    {
+        $next = $this->scanner->peekChar();
+
+        return $next === null || $next === ';' || $next === '}' || $next === '{';
+    }
+
+    protected function lookingAtChildren(): bool
+    {
+        return $this->scanner->peekChar() === '{';
+    }
+
+    protected function scanElse(int $ifIndentation): bool
+    {
+        $start = $this->scanner->getPosition();
+        $this->whitespace();
+        $beforeAt = $this->scanner->getPosition();
+
+        if ($this->scanner->scanChar('@')) {
+            if ($this->scanIdentifier('else', true)) {
+                return true;
+            }
+
+            if ($this->scanIdentifier('elseif', true)) {
+                $span = $this->scanner->spanFrom($beforeAt);
+                $line = $span->getStart()->getLine() + 1;
+                $column = $span->getStart()->getColumn() + 1;
+                $sourceUrl = $this->sourceUrl;
+
+                $message = "@elseif is deprecated and will not be supported in future Sass versions.\nUse \"@else if\" instead.";
+                $message .= "\n    on line $line, column $column";
+
+                if ($sourceUrl !== null) {
+                    $message .= " of $sourceUrl";
+                }
+
+                $this->logger->warn($message, true);
+
+                $this->scanner->setPosition($this->scanner->getPosition() - 2);
+
+                return true;
+            }
+        }
+
+        $this->scanner->setPosition($start);
+
+        return false;
+    }
+
+    protected function children(callable $child): array
+    {
+        $this->scanner->expectChar('{');
+        $this->whitespaceWithoutComments();
+        $children = [];
+
+        while (true) {
+            switch ($this->scanner->peekChar()) {
+                case '$':
+                    $children[] = $this->variableDeclarationWithoutNamespace();
+                    break;
+
+                case '/':
+                    switch ($this->scanner->peekChar(1)) {
+                        case '/':
+                            $children[] = $this->silentCommentStatement();
+                            $this->whitespaceWithoutComments();
+                            break;
+
+                        case '*':
+                            $children[] = $this->loudCommentStatement();
+                            $this->whitespaceWithoutComments();
+                            break;
+
+                        default:
+                            $children[] = $child();
+                            break;
+                    }
+                    break;
+
+                case ';':
+                    $this->scanner->readChar();
+                    $this->whitespaceWithoutComments();
+                    break;
+
+                case '}':
+                    $this->scanner->expectChar('}');
+
+                    return $children;
+
+                default:
+                    $children[] = $child();
+                    break;
+            }
+        }
+    }
+
+    protected function statements(callable $statement): array
+    {
+        $statements = [];
+        $this->whitespaceWithoutComments();
+
+        while (!$this->scanner->isDone()) {
+            switch ($this->scanner->peekChar()) {
+                case '$':
+                    $statements[] = $this->variableDeclarationWithoutNamespace();
+                    break;
+
+                case '/':
+                    switch ($this->scanner->peekChar(1)) {
+                        case '/':
+                            $statements[] = $this->silentCommentStatement();
+                            $this->whitespaceWithoutComments();
+                            break;
+
+                        case '*':
+                            $statements[] = $this->loudCommentStatement();
+                            $this->whitespaceWithoutComments();
+                            break;
+
+                        default:
+                            $child = $statement();
+
+                            if ($child !== null) {
+                                $statements[] = $child;
+                            }
+                            break;
+                    }
+                    break;
+
+                case ';':
+                    $this->scanner->readChar();
+                    $this->whitespaceWithoutComments();
+                    break;
+
+                default:
+                    $child = $statement();
+
+                    if ($child !== null) {
+                        $statements[] = $child;
+                    }
+                    break;
+            }
+        }
+
+        return $statements;
+    }
+
+    /**
+     * Consumes a statement-level silent comment block.
+     */
+    private function silentCommentStatement(): SilentComment
+    {
+        $start = $this->scanner->getPosition();
+
+        $this->scanner->expect('//');
+
+        do {
+            while (!$this->scanner->isDone() && !Character::isNewline($this->scanner->readChar())) {
+                // Ignore the content of the comment
+            }
+
+            if ($this->scanner->isDone()) {
+                break;
+            }
+
+            $this->whitespaceWithoutComments();
+        } while ($this->scanner->scan('//'));
+
+        if ($this->isPlainCss()) {
+            $this->error('Silent comments aren\'t allowed in plain CSS.', $this->scanner->spanFrom($start));
+        }
+
+        $this->lastSilentComment = new SilentComment($this->scanner->substring($start), $this->scanner->spanFrom($start));
+
+        return $this->lastSilentComment;
+    }
+
+    /**
+     * Consumes a statement-level loud comment block.
+     */
+    private function loudCommentStatement(): LoudComment
+    {
+        $start = $this->scanner->getPosition();
+
+        $this->scanner->expect('/*');
+
+        $buffer = new InterpolationBuffer();
+        $buffer->write('/*');
+
+        while (true) {
+            switch ($this->scanner->peekChar()) {
+                case '#':
+                    if ($this->scanner->peekChar(1) === '{') {
+                        $buffer->add($this->singleInterpolation());
+                    } else {
+                        $buffer->write($this->scanner->readChar());
+                    }
+                    break;
+
+                case '*':
+                    $buffer->write($this->scanner->readChar());
+
+                    if ($this->scanner->peekChar() !== '/') {
+                        break;
+                    }
+
+                    $buffer->write($this->scanner->readChar());
+
+                    return new LoudComment($buffer->buildInterpolation($this->scanner->spanFrom($start)));
+
+                case "\r":
+                    $this->scanner->readChar();
+
+                    if ($this->scanner->peekChar() !== "\n") {
+                        $buffer->write("\n");
+                    }
+                    break;
+
+                case "\f":
+                    $this->scanner->readChar();
+                    $buffer->write("\n");
+                    break;
+
+                default:
+                    $buffer->write($this->scanner->readUtf8Char());
+            }
+        }
+    }
+}

--- a/src/Parser/StringScanner.php
+++ b/src/Parser/StringScanner.php
@@ -1,0 +1,336 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Parser;
+
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+use ScssPhp\ScssPhp\SourceSpan\SourceFile;
+
+/**
+ * A port of Dart's string_scanner package to be used by the parser.
+ *
+ * The scanner only supports UTF-8 strings.
+ *
+ * Differences with Dart:
+ * - reading a character is reading a byte, not an UTF-16 code unit (as PHP strings are not UTF-16). The
+ *   {@see readUtf8Char} method can be used to consume an UTF-8 char.
+ * - characters are represented as a single-char string, not as an integer with their UTF-16 char code
+ * - offsets are based on bytes, not on UTF-16 code units. In practice, parsing Sass generally needs
+ *   to peak following chars only when already knowing that the current char is an ASCII one, which
+ *   makes this safe. When this assumption does not hold anymore, a different logic should be used
+ * - as strings and regexp cannot be used interchangeably in PHP (in Dart, regexps are a different
+ *   object, and both String and Regexp are implementing a Pattern interface for matching), the scanner
+ *   exposes supports only strings in scan() and expect(). Should we need support for regexps, a
+ *   separate method will be added.
+ *
+ * @internal
+ */
+final class StringScanner
+{
+    /**
+     * @var string
+     * @readonly
+     */
+    private $string;
+
+    /**
+     * @var int
+     */
+    private $position = 0;
+
+    /**
+     * @var SourceFile
+     * @readonly
+     */
+    private $sourceFile;
+
+    public function __construct(string $content, ?string $sourceUrl = null)
+    {
+        $this->string = $content;
+        $this->sourceFile = new SourceFile($content, $sourceUrl);
+    }
+
+    public function getString(): string
+    {
+        return $this->string;
+    }
+
+    public function getPosition(): int
+    {
+        return $this->position;
+    }
+
+    public function setPosition(int $position): void
+    {
+        $this->position = $position;
+    }
+
+    public function spanFrom(int $start, ?int $end = null): FileSpan
+    {
+        $end = $end ?? $this->position;
+
+        return $this->sourceFile->span($start, $end);
+    }
+
+    /**
+     * Returns an empty span at the current location.
+     */
+    public function getEmptySpan(): FileSpan
+    {
+        return $this->sourceFile->span($this->position, $this->position);
+    }
+
+    public function isDone(): bool
+    {
+        return $this->position === \strlen($this->string);
+    }
+
+    /**
+     * @throws FormatException if the end of the string is reached
+     */
+    public function readChar(): string
+    {
+        if ($this->position === \strlen($this->string)) {
+            $this->fail('more input');
+        }
+
+        return $this->string[$this->position++];
+    }
+
+    /**
+     * @throws FormatException if the end of the string is reached
+     */
+    public function readUtf8Char(): string
+    {
+        if ($this->position === \strlen($this->string)) {
+            $this->fail('more input');
+        }
+
+        if (\ord($this->string[$this->position]) < 0x80) {
+            return $this->string[$this->position++];
+        }
+
+        if (!preg_match('/./usA', $this->string, $m, 0, $this->position)) {
+            $this->fail('utf-8 char');
+        }
+
+        $this->position += \strlen($m[0]);
+
+        return $m[0];
+    }
+
+    /**
+     * Consumes the next character in the string if it the provided character.
+     *
+     * @param string $char
+     *
+     * @return bool Whether the character was consumed.
+     */
+    public function scanChar(string $char): bool
+    {
+        if ($this->position === \strlen($this->string)) {
+            return false;
+        }
+
+        if ($this->string[$this->position] !== $char) {
+            return false;
+        }
+
+        ++$this->position;
+
+        return true;
+    }
+
+    /**
+     * Consumes the provided string if it appears at the current position.
+     *
+     * @param string $string
+     *
+     * @return bool Whether the string was consumed.
+     */
+    public function scan(string $string): bool
+    {
+        if (!$this->matches($string)) {
+            return false;
+        }
+
+        $this->position += \strlen($string);
+
+        return true;
+    }
+
+    /**
+     * Returns whether or not the provided string appears at the current position.
+     *
+     * This doesn't move the scan pointer forward.
+     */
+    public function matches(string $string): bool
+    {
+        if ($this->position - 1 + \strlen($string) >= \strlen($this->string)) {
+            return false;
+        }
+
+        return substr($this->string, $this->position, \strlen($string)) === $string;
+    }
+
+    /**
+     * If the next character in the string is $character, consumes it.
+     *
+     * If $character could not be consumed, throws an exception
+     * describing the position of the failure. $name is used in this error as
+     * the expected name of the character being matched; if it's `null`, the
+     * character itself is used instead.
+     *
+     * @param string      $character
+     * @param string|null $name
+     *
+     * @return void
+     *
+     * @throws FormatException
+     */
+    public function expectChar(string $character, ?string $name = null): void
+    {
+        if ($this->scanChar($character)) {
+            return;
+        }
+
+        if ($name === null) {
+            $name = '"' . $character . '"';
+        }
+
+        $this->fail($name);
+    }
+
+    /**
+     * @param string $string
+     *
+     * @return void
+     *
+     * @throws FormatException
+     */
+    public function expect(string $string): void
+    {
+        if ($this->scan($string)) {
+            return;
+        }
+
+        $this->fail('"' . $string . '"');
+    }
+
+    /**
+     * @throws FormatException
+     */
+    public function expectDone(): void
+    {
+        if ($this->isDone()) {
+            return;
+        }
+
+        $this->fail('no more input');
+    }
+
+    /**
+     * Returns the character at the given offset of the current position.
+     *
+     * The offset can be negative to peek already seen characters.
+     * Returns null if the offset goes out of range.
+     * This does not affect the position or the last match.
+     *
+     * @param int $offset
+     *
+     * @return string|null
+     */
+    public function peekChar(int $offset = 0): ?string
+    {
+        $pos = $this->position + $offset;
+
+        if ($pos < 0 || $pos >= \strlen($this->string)) {
+            return null;
+        }
+
+        return $this->string[$pos];
+    }
+
+    /**
+     * Returns the substring of the string between $start and $end (excluded).
+     *
+     * $end defaults to the current position.
+     *
+     * @param int      $start
+     * @param int|null $end
+     *
+     * @return string
+     */
+    public function substring(int $start, ?int $end = null): string
+    {
+        if ($end === null) {
+            $end = $this->position;
+        }
+
+        if ($end < $start) {
+            return '';
+        }
+
+        return substr($this->string, $start, $end - $start);
+    }
+
+    /**
+     * The scanner's current (zero-based) line number.
+     *
+     * @return int
+     */
+    public function getLine(): int
+    {
+        return $this->sourceFile->getLine($this->position);
+    }
+
+    /**
+     * The scanner's current (zero-based) column number.
+     *
+     * @return int
+     */
+    public function getColumn(): int
+    {
+        return $this->sourceFile->getColumn($this->position);
+    }
+
+    /**
+     * @param string   $message
+     * @param int|null $position
+     * @param int|null $length
+     *
+     * @throws FormatException
+     *
+     * @return never-returns
+     */
+    public function error(string $message, ?int $position = null, ?int $length = null)
+    {
+        $position = $position ?? $this->position;
+        $length = $length ?? 0;
+
+        $span = $this->sourceFile->span($position, $position + $length);
+
+        throw new FormatException($message, $span);
+    }
+
+    /**
+     * @param string $message
+     *
+     * @throws FormatException
+     *
+     * @return never-returns
+     */
+    private function fail(string $message)
+    {
+        $this->error("expected $message.");
+    }
+}

--- a/src/Parser/StylesheetParser.php
+++ b/src/Parser/StylesheetParser.php
@@ -1,0 +1,4276 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Parser;
+
+use ScssPhp\ScssPhp\Ast\Sass\Argument;
+use ScssPhp\ScssPhp\Ast\Sass\ArgumentDeclaration;
+use ScssPhp\ScssPhp\Ast\Sass\ArgumentInvocation;
+use ScssPhp\ScssPhp\Ast\Sass\Expression;
+use ScssPhp\ScssPhp\Ast\Sass\Expression\BinaryOperationExpression;
+use ScssPhp\ScssPhp\Ast\Sass\Expression\BinaryOperator;
+use ScssPhp\ScssPhp\Ast\Sass\Expression\BooleanExpression;
+use ScssPhp\ScssPhp\Ast\Sass\Expression\CalculationExpression;
+use ScssPhp\ScssPhp\Ast\Sass\Expression\ColorExpression;
+use ScssPhp\ScssPhp\Ast\Sass\Expression\FunctionExpression;
+use ScssPhp\ScssPhp\Ast\Sass\Expression\IfExpression;
+use ScssPhp\ScssPhp\Ast\Sass\Expression\InterpolatedFunctionExpression;
+use ScssPhp\ScssPhp\Ast\Sass\Expression\ListExpression;
+use ScssPhp\ScssPhp\Ast\Sass\Expression\MapExpression;
+use ScssPhp\ScssPhp\Ast\Sass\Expression\NullExpression;
+use ScssPhp\ScssPhp\Ast\Sass\Expression\NumberExpression;
+use ScssPhp\ScssPhp\Ast\Sass\Expression\ParenthesizedExpression;
+use ScssPhp\ScssPhp\Ast\Sass\Expression\SelectorExpression;
+use ScssPhp\ScssPhp\Ast\Sass\Expression\StringExpression;
+use ScssPhp\ScssPhp\Ast\Sass\Expression\UnaryOperationExpression;
+use ScssPhp\ScssPhp\Ast\Sass\Expression\UnaryOperator;
+use ScssPhp\ScssPhp\Ast\Sass\Expression\VariableExpression;
+use ScssPhp\ScssPhp\Ast\Sass\Import;
+use ScssPhp\ScssPhp\Ast\Sass\Import\DynamicImport;
+use ScssPhp\ScssPhp\Ast\Sass\Import\StaticImport;
+use ScssPhp\ScssPhp\Ast\Sass\Interpolation;
+use ScssPhp\ScssPhp\Ast\Sass\Statement;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\AtRootRule;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\AtRule;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\ContentBlock;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\ContentRule;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\DebugRule;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\Declaration;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\EachRule;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\ElseClause;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\ErrorRule;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\ExtendRule;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\ForRule;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\FunctionRule;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\IfClause;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\IfRule;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\ImportRule;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\IncludeRule;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\MediaRule;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\MixinRule;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\ReturnRule;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\SilentComment;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\StyleRule;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\Stylesheet;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\SupportsRule;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\VariableDeclaration;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\WarnRule;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\WhileRule;
+use ScssPhp\ScssPhp\Ast\Sass\SupportsCondition;
+use ScssPhp\ScssPhp\Ast\Sass\SupportsCondition\SupportsAnything;
+use ScssPhp\ScssPhp\Ast\Sass\SupportsCondition\SupportsDeclaration;
+use ScssPhp\ScssPhp\Ast\Sass\SupportsCondition\SupportsFunction;
+use ScssPhp\ScssPhp\Ast\Sass\SupportsCondition\SupportsInterpolation;
+use ScssPhp\ScssPhp\Ast\Sass\SupportsCondition\SupportsNegation;
+use ScssPhp\ScssPhp\Ast\Sass\SupportsCondition\SupportsOperation;
+use ScssPhp\ScssPhp\Colors;
+use ScssPhp\ScssPhp\Exception\SassFormatException;
+use ScssPhp\ScssPhp\Logger\LoggerInterface;
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+use ScssPhp\ScssPhp\Util;
+use ScssPhp\ScssPhp\Util\Character;
+use ScssPhp\ScssPhp\Util\StringUtil;
+use ScssPhp\ScssPhp\Value\ListSeparator;
+use ScssPhp\ScssPhp\Value\SassColor;
+
+/**
+ * @internal
+ */
+abstract class StylesheetParser extends Parser
+{
+    /**
+     * The silent comment this parser encountered previously.
+     *
+     * @var SilentComment|null
+     */
+    protected $lastSilentComment;
+
+    /**
+     * Whether we've consumed a rule other than `@charset`, `@forward`, or `@use`.
+     *
+     * @var bool
+     */
+    private $isUseAllowed = true;
+
+    /**
+     * Whether the parser is currently parsing the contents of a mixin declaration.
+     *
+     * @var bool
+     */
+    private $inMixin = false;
+
+    /**
+     * Whether the parser is currently parsing a content block passed to a mixin.
+     *
+     * @var bool
+     */
+    private $inContentBlock = false;
+
+    /**
+     * Whether the parser is currently parsing a control directive such as `@if`
+     * or `@each`.
+     *
+     * @var bool
+     */
+    private $inControlDirective = false;
+
+    /**
+     * Whether the parser is currently parsing an unknown rule.
+     *
+     * @var bool
+     */
+    private $inUnknownAtRule = false;
+
+    /**
+     * Whether the parser is currently parsing a style rule.
+     *
+     * @var bool
+     */
+    private $inStyleRule = false;
+
+    /**
+     * Whether the parser is currently within a parenthesized expression.
+     *
+     * @var bool
+     */
+    private $inParentheses = false;
+
+    /**
+     * A map from all variable names that are assigned with `!global` in the
+     * current stylesheet to the nodes where they're defined.
+     *
+     * These are collected at parse time because they affect the variables
+     * exposed by the module generated for this stylesheet, *even if they aren't
+     * evaluated*. This allows us to ensure that the stylesheet always exposes
+     * the same set of variable names no matter how it's evaluated.
+     *
+     * @var array<string, VariableDeclaration>
+     */
+    private $globalVariables = [];
+
+    /**
+     * @var \Closure
+     * @readonly
+     */
+    private $statementCallable;
+
+    /**
+     * @var \Closure
+     * @readonly
+     */
+    private $declarationChildCallable;
+
+    /**
+     * @var \Closure
+     * @readonly
+     */
+    private $functionChildCallable;
+
+    public function __construct(string $contents, ?LoggerInterface $logger = null, ?string $sourceUrl = null)
+    {
+        parent::__construct($contents, $logger, $sourceUrl);
+
+        // Store callables for some private methods, to ensure they pass callable typehints when passed
+        // to parent methods expecting a callable, due to the semantic of PHP array callables.
+        $this->statementCallable = \Closure::fromCallable([$this, 'statement']);
+        $this->declarationChildCallable = \Closure::fromCallable([$this, 'declarationChild']);
+        $this->functionChildCallable = \Closure::fromCallable([$this, 'functionChild']);
+    }
+
+    /**
+     * @throws SassFormatException when parsing fails
+     */
+    public function parse(): Stylesheet
+    {
+        try {
+            $start = $this->scanner->getPosition();
+
+            // Allow a byte-order mark at the beginning of the document.
+            $this->scanner->scan("\u{FEFF}");
+
+            $statements = $this->statements(function () {
+                // Handle this specially so that {@see atRule} always returns a non-nullable Statement.
+                if ($this->scanner->scan('@charset')) {
+                    $this->whitespace();
+                    $this->string();
+
+                    return null;
+                }
+
+                return $this->statement(true);
+            });
+
+            $this->scanner->expectDone();
+
+            // Ensure that all global variable assignments produce a variable in this
+            // stylesheet, even if they aren't evaluated. See sass/language#50.
+            foreach ($this->globalVariables as $declaration) {
+                $statements[] = new VariableDeclaration($declaration->getName(), new NullExpression($declaration->getExpression()->getSpan()), $declaration->getSpan(), null, true);
+            }
+
+            return new Stylesheet($statements, $this->scanner->spanFrom($start), $this->isPlainCss());
+        } catch (FormatException $e) {
+            throw $this->wrapException($e);
+        }
+    }
+
+    /**
+     * Consumes a statement that's allowed at the top level of the stylesheet or
+     * within nested style and at rules.
+     *
+     * If $root is `true`, this parses at-rules that are allowed only at the
+     * root of the stylesheet.
+     */
+    private function statement(bool $root = false): Statement
+    {
+        switch ($this->scanner->peekChar()) {
+            case '@':
+                return $this->atRule($this->statementCallable, $root);
+
+            case '+':
+                if (!$this->isIndented()) {
+                    return $this->styleRule();
+                }
+
+                throw new \BadMethodCallException('The parsing of the indented syntax is not implemented.');
+
+            case '=':
+                if (!$this->isIndented()) {
+                    return $this->styleRule();
+                }
+
+                throw new \BadMethodCallException('The parsing of the indented syntax is not implemented.');
+
+            case '}':
+                $this->scanner->error('unmatched "}".');
+
+            default:
+                if ($this->inStyleRule || $this->inUnknownAtRule || $this->inMixin || $this->inContentBlock) {
+                    return $this->declarationOrStyleRule();
+                }
+
+                return $this->variableDeclarationOrStyleRule();
+        }
+    }
+
+    /**
+     * Consumes a namespaced variable declaration.
+     *
+     * @throws FormatException
+     */
+    private function variableDeclarationWithNamespace(): VariableDeclaration
+    {
+        $start = $this->scanner->getPosition();
+        $namespace = $this->identifier();
+        $this->scanner->expectChar('.');
+
+        return $this->variableDeclarationWithoutNamespace($namespace, $start);
+    }
+
+    /**
+     * Consumes a variable declaration.
+     */
+    protected function variableDeclarationWithoutNamespace(?string $namespace = null, ?int $start = null): VariableDeclaration
+    {
+        $precedingComment = $this->lastSilentComment;
+        $this->lastSilentComment = null;
+        $start = $start ?? $this->scanner->getPosition();
+
+        $name = $this->variableName();
+
+        if ($namespace !== null) {
+            $this->assertPublic($name, function () use ($start) {
+                return $this->scanner->spanFrom($start);
+            });
+        }
+
+        $this->whitespace();
+        $this->scanner->expectChar(':');
+        $this->whitespace();
+
+        $value = $this->expression();
+
+        $guarded = false;
+        $global = false;
+        $flagStart = $this->scanner->getPosition();
+
+        while ($this->scanner->scanChar('!')) {
+            $flag = $this->identifier();
+            if ($flag === 'default') {
+                $guarded = true;
+            } elseif ($flag === 'global') {
+                if ($namespace !== null) {
+                    $this->error("!global isn't allowed for variables in other modules.", $this->scanner->spanFrom($flagStart));
+                }
+
+                $global = true;
+            } else {
+                $this->error('Invalid flag name.', $this->scanner->spanFrom($flagStart));
+            }
+
+            $this->whitespace();
+            $flagStart = $this->scanner->getPosition();
+        }
+
+        $this->expectStatementSeparator('variable declaration');
+
+        // TODO remove this when implementing modules
+        if ($namespace !== null) {
+            $this->error('Sass modules are not implemented yet.', $this->scanner->spanFrom($start));
+        }
+
+        $declaration = new VariableDeclaration($name, $value, $this->scanner->spanFrom($start), $namespace, $guarded, $global, $precedingComment);
+
+        if ($global && !isset($this->globalVariables[$name])) {
+            $this->globalVariables[$name] = $declaration;
+        }
+
+        return $declaration;
+    }
+
+    private function variableDeclarationOrStyleRule(): Statement
+    {
+        if ($this->isPlainCss()) {
+            return $this->styleRule();
+        }
+
+        if (!$this->lookingAtIdentifier()) {
+            return $this->styleRule();
+        }
+
+        $start = $this->scanner->getPosition();
+        $variableOrInterpolation = $this->variableDeclarationOrInterpolation();
+
+        if ($variableOrInterpolation instanceof VariableDeclaration) {
+            return $variableOrInterpolation;
+        }
+
+        $buffer = new InterpolationBuffer();
+        $buffer->addInterpolation($variableOrInterpolation);
+
+        return $this->styleRule($buffer, $start);
+    }
+
+    /**
+     * Consumes a {@see VariableDeclaration}, a {@see Declaration}, or a {@see StyleRule}.
+     *
+     * @throws FormatException
+     */
+    private function declarationOrStyleRule(): Statement
+    {
+        if ($this->isPlainCss() && $this->inStyleRule && !$this->inUnknownAtRule) {
+            return $this->propertyOrVariableDeclaration();
+        }
+
+        $start = $this->scanner->getPosition();
+
+        $declarationBuffer = $this->declarationOrBuffer();
+
+        if ($declarationBuffer instanceof Statement) {
+            return $declarationBuffer;
+        }
+
+        return $this->styleRule($declarationBuffer, $start);
+    }
+
+    /**
+     * Tries to parse a variable or property declaration, and returns the value
+     * parsed so far if it fails.
+     *
+     * This can return either an {@see InterpolationBuffer}, indicating that it
+     * couldn't consume a declaration and that selector parsing should be
+     * attempted; or it can return a {@see Declaration} or a {@see VariableDeclaration},
+     * indicating that it successfully consumed a declaration.
+     *
+     * @return Statement|InterpolationBuffer
+     */
+    private function declarationOrBuffer()
+    {
+        $start = $this->scanner->getPosition();
+        $nameBuffer = new InterpolationBuffer();
+        $first = $this->scanner->peekChar();
+        $startsWithPunctuation = false;
+
+        // Allow the "*prop: val", ":prop: val", "#prop: val", and ".prop: val"
+        // hacks.
+        if ($first === ':' || $first === '*' || $first === '.' || ($first === '#' && $this->scanner->peekChar(1) !== '{')) {
+            $startsWithPunctuation = true;
+            $nameBuffer->write($this->scanner->readChar());
+            $nameBuffer->write($this->rawText([$this, 'whitespace']));
+        }
+
+        if (!$this->lookingAtInterpolatedIdentifier()) {
+            return $nameBuffer;
+        }
+
+        $variableOrInterpolation = $startsWithPunctuation ? $this->interpolatedIdentifier() : $this->variableDeclarationOrInterpolation();
+
+        if ($variableOrInterpolation instanceof VariableDeclaration) {
+            return $variableOrInterpolation;
+        }
+
+        $nameBuffer->addInterpolation($variableOrInterpolation);
+
+        $this->isUseAllowed = false;
+
+        if ($this->scanner->matches('/*')) {
+            $nameBuffer->write($this->rawText([$this, 'loudComment']));
+        }
+
+        $midBuffer = $this->rawText([$this, 'whitespace']);
+        $beforeColon = $this->scanner->getPosition();
+
+        if (!$this->scanner->scanChar(':')) {
+            if ($midBuffer !== '') {
+                $nameBuffer->write(' ');
+            }
+
+            return $nameBuffer;
+        }
+
+        $midBuffer .= ':';
+
+        // Parse custom properties as declarations no matter what.
+        $name = $nameBuffer->buildInterpolation($this->scanner->spanFrom($start, $beforeColon));
+
+        if (0 === strpos($name->getInitialPlain(), '--')) {
+            $value = new StringExpression($this->interpolatedDeclarationValue());
+            $this->expectStatementSeparator('custom property');
+
+            return Declaration::create($name, $value, $this->scanner->spanFrom($start));
+        }
+
+        if ($this->scanner->scanChar(':')) {
+            $nameBuffer->write($midBuffer);
+            $nameBuffer->write(':');
+
+            return $nameBuffer;
+        }
+
+        if ($this->isIndented() && $this->lookingAtInterpolatedIdentifier()) {
+            $nameBuffer->write($midBuffer);
+
+            return $nameBuffer;
+        }
+
+        $postColonWhitespace = $this->rawText([$this, 'whitespace']);
+
+        if ($this->lookingAtChildren()) {
+            return $this->withChildren($this->declarationChildCallable, $start, function (array $children, FileSpan $span) use ($name) {
+                return Declaration::nested($name, $children, $span);
+            });
+        }
+
+        $midBuffer .= $postColonWhitespace;
+        $couldBeSelector = $postColonWhitespace === '' && $this->lookingAtInterpolatedIdentifier();
+
+        $beforeDeclaration = $this->scanner->getPosition();
+
+        try {
+            $value = $this->lookingAtChildren()
+                ? new StringExpression(new Interpolation([], $this->scanner->getEmptySpan()), true)
+                : $this->expression();
+
+            if ($this->lookingAtChildren()) {
+                // Properties that are ambiguous with selectors can't have additional
+                // properties nested beneath them, so we force an error. This will be
+                // caught below and cause the text to be reparsed as a selector.
+                if ($couldBeSelector) {
+                    $this->expectStatementSeparator();
+                }
+            } elseif (!$this->atEndOfStatement()) {
+                // Force an exception if there isn't a valid end-of-property character
+                // but don't consume that character. This will also cause the text to be
+                // reparsed.
+                $this->expectStatementSeparator();
+            }
+
+        } catch (FormatException $e) {
+            if (!$couldBeSelector) {
+                throw $e;
+            }
+
+            // If the value would be followed by a semicolon, it's definitely supposed
+            // to be a property, not a selector.
+            $this->scanner->setPosition($beforeDeclaration);
+
+            $additional = $this->almostAnyValue();
+
+            if (!$this->isIndented() && $this->scanner->peekChar() === ';') {
+                throw $e;
+            }
+
+            $nameBuffer->write($midBuffer);
+            $nameBuffer->addInterpolation($additional);
+
+            return $nameBuffer;
+        }
+
+        if ($this->lookingAtChildren()) {
+            return $this->withChildren($this->declarationChildCallable, $start, function (array $children, FileSpan $span) use ($name, $value) {
+                return Declaration::nested($name, $children, $span, $value);
+            });
+        }
+
+        $this->expectStatementSeparator();
+
+        return Declaration::create($name, $value, $this->scanner->spanFrom($start));
+    }
+
+    /**
+     * Tries to parse a namespaced {@see VariableDeclaration}, and returns the value
+     * parsed so far if it fails.
+     *
+     * This can return either an {@see Interpolation}, indicating that it couldn't
+     * consume a variable declaration and that property declaration or selector
+     * parsing should be attempted; or it can return a {@see VariableDeclaration},
+     * indicating that it successfully consumed a variable declaration.
+     *
+     * @return Interpolation|VariableDeclaration
+     */
+    private function variableDeclarationOrInterpolation()
+    {
+        if (!$this->lookingAtIdentifier()) {
+            return $this->interpolatedIdentifier();
+        }
+
+        $start = $this->scanner->getPosition();
+        $identifier = $this->identifier();
+
+        if ($this->scanner->matches('.$')) {
+            $this->scanner->readChar();
+
+            return $this->variableDeclarationWithoutNamespace($identifier, $start);
+        }
+
+        $buffer = new InterpolationBuffer();
+        $buffer->write($identifier);
+
+        // Parse the rest of an interpolated identifier if one exists, so callers
+        // don't have to.
+        if ($this->lookingAtInterpolatedIdentifierBody()) {
+            $buffer->addInterpolation($this->interpolatedIdentifier());
+        }
+
+        return $buffer->buildInterpolation($this->scanner->spanFrom($start));
+    }
+
+    /**
+     * Consumes a StyleRule
+     */
+    private function styleRule(?InterpolationBuffer $buffer = null, ?int $start = null): StyleRule
+    {
+        $start = $start ?? $this->scanner->getPosition();
+        $interpolation = $this->styleRuleSelector();
+
+        if ($buffer !== null) {
+            $buffer->addInterpolation($interpolation);
+            $interpolation = $buffer->buildInterpolation($this->scanner->spanFrom($start));
+        }
+
+        if (!$interpolation->getContents()) {
+            $this->scanner->error('expected "}".');
+        }
+
+        $wasInStyleRule = $this->inStyleRule;
+        $this->inStyleRule = true;
+
+        return $this->withChildren($this->statementCallable, $start, function (array $children) use ($wasInStyleRule, $start, $interpolation) {
+            $this->inStyleRule = $wasInStyleRule;
+
+            return new StyleRule($interpolation, $children, $this->scanner->spanFrom($start));
+        });
+    }
+
+    /**
+     * Consumes either a property declaration or a namespaced variable declaration.
+     *
+     * This is only used in contexts where declarations are allowed but style
+     * rules are not, such as nested declarations. Otherwise,
+     * {@see declarationOrStyleRule} is used instead.
+     *
+     * If $parseCustomProperties is `true`, properties that begin with `--` will
+     * be parsed using custom property parsing rules.
+     */
+    private function propertyOrVariableDeclaration(bool $parseCustomProperties = true): Statement
+    {
+        $start = $this->scanner->getPosition();
+
+        // Allow the "*prop: val", ":prop: val", "#prop: val", and ".prop: val"
+        // hacks.
+        $first = $this->scanner->peekChar();
+        if ($first === ':' || $first === '*' || $first === '.' || ($first === '#' && $this->scanner->peekChar(1) !== '{')) {
+            $nameBuffer = new InterpolationBuffer();
+            $nameBuffer->write($this->scanner->readChar());
+            $nameBuffer->write($this->rawText([$this, 'whitespace']));
+            $nameBuffer->addInterpolation($this->interpolatedIdentifier());
+            $name = $nameBuffer->buildInterpolation($this->scanner->spanFrom($start));
+        } elseif (!$this->isPlainCss()) {
+            $variableOrInterpolation = $this->variableDeclarationOrInterpolation();
+
+            if ($variableOrInterpolation instanceof VariableDeclaration) {
+                return $variableOrInterpolation;
+            }
+
+            $name = $variableOrInterpolation;
+        } else {
+            $name = $this->interpolatedIdentifier();
+        }
+
+        $this->whitespace();
+        $this->scanner->expectChar(':');
+
+        if ($parseCustomProperties && 0 === strpos($name->getInitialPlain(), '--')) {
+            $value = new StringExpression($this->interpolatedDeclarationValue());
+            $this->expectStatementSeparator('custom property');
+
+            return Declaration::create($name, $value, $this->scanner->spanFrom($start));
+        }
+
+        $this->whitespace();
+
+        if ($this->lookingAtChildren()) {
+            if ($this->isPlainCss()) {
+                $this->scanner->error("Nested declarations aren't allowed in plain CSS.");
+            }
+
+            return $this->withChildren($this->declarationChildCallable, $start, function (array $children, FileSpan $span) use ($name) {
+                return Declaration::nested($name, $children, $span);
+            });
+        }
+
+        $value = $this->expression();
+
+        if ($this->lookingAtChildren()) {
+            if ($this->isPlainCss()) {
+                $this->scanner->error("Nested declarations aren't allowed in plain CSS.");
+            }
+
+            return $this->withChildren($this->declarationChildCallable, $start, function (array $children, FileSpan $span) use ($name, $value) {
+                return Declaration::nested($name, $children, $span, $value);
+            });
+        }
+
+        $this->expectStatementSeparator();
+
+        return Declaration::create($name, $value, $this->scanner->spanFrom($start));
+    }
+
+    /**
+     * Consumes a statement that's allowed within a declaration.
+     */
+    private function declarationChild(): Statement
+    {
+        if ($this->scanner->peekChar() === '@') {
+            return $this->declarationAtRule();
+        }
+
+        return $this->propertyOrVariableDeclaration(false);
+    }
+
+    /**
+     * Consumes an at-rule.
+     *
+     * This consumes at-rules that are allowed at all levels of the document; the
+     * $child parameter is called to consume any at-rules that are specifically
+     * allowed in the caller's context.
+     *
+     * If $root is `true`, this parses at-rules that are allowed only at the
+     * root of the stylesheet.
+     *
+     * @param callable(): Statement $child
+     */
+    protected function atRule(callable $child, bool $root = false): Statement
+    {
+        $start = $this->scanner->getPosition();
+        $this->scanner->expectChar('@', '@-rule');
+        $name = $this->interpolatedIdentifier();
+        $this->whitespace();
+
+        $wasUseAllowed = $this->isUseAllowed;
+        $this->isUseAllowed = false;
+
+        switch ($name->getAsPlain()) {
+            case 'at-root':
+                return $this->atRootRule($start);
+            case 'content':
+                return $this->contentRule($start);
+            case 'debug':
+                return $this->debugRule($start);
+            case 'each':
+                return $this->eachRule($start, $child);
+            case 'else':
+                $this->disallowedAtRule($start);
+            case 'error':
+                return $this->errorRule($start);
+            case 'extend':
+                return $this->extendRule($start);
+            case 'for':
+                return $this->forRule($start, $child);
+            case 'forward':
+                $this->isUseAllowed = $wasUseAllowed;
+
+                if (!$root) {
+                    $this->disallowedAtRule($start);
+                }
+
+                // TODO remove this when implementing modules
+                $this->error('Sass modules are not implemented yet.', $this->scanner->spanFrom($start));
+            case 'function':
+                return $this->functionRule($start);
+            case 'if':
+                return $this->ifRule($start, $child);
+            case 'import':
+                return $this->importRule($start);
+            case 'include':
+                return $this->includeRule($start);
+            case 'media':
+                return $this->mediaRule($start);
+            case 'mixin':
+                return $this->mixinRule($start);
+            case '-moz-document':
+                return $this->mozDocumentRule($start, $name);
+            case 'return':
+                $this->disallowedAtRule($start);
+            case 'supports':
+                return $this->supportsRule($start);
+            case 'use':
+                $this->isUseAllowed = $wasUseAllowed;
+
+                if (!$root) {
+                    $this->disallowedAtRule($start);
+                }
+
+                // TODO remove this when implementing modules
+                $this->error('Sass modules are not implemented yet.', $this->scanner->spanFrom($start));
+            case 'warn':
+                return $this->warnRule($start);
+            case 'while':
+                return $this->whileRule($start, $child);
+            default:
+                return $this->unknownAtRule($start, $name);
+        }
+    }
+
+    /**
+     * Consumes an at-rule allowed within a property declaration.
+     */
+    private function declarationAtRule(): Statement
+    {
+        $start = $this->scanner->getPosition();
+        $name = $this->plainAtRuleName();
+
+        switch ($name) {
+            case 'content':
+                return $this->contentRule($start);
+            case 'debug':
+                return $this->debugRule($start);
+            case 'each':
+                return $this->eachRule($start, $this->declarationChildCallable);
+            case 'else':
+                $this->disallowedAtRule($start);
+            case 'error':
+                return $this->errorRule($start);
+            case 'for':
+                return $this->forRule($start, $this->declarationChildCallable);
+            case 'if':
+                return $this->ifRule($start, $this->declarationChildCallable);
+            case 'include':
+                return $this->includeRule($start);
+            case 'warn':
+                return $this->warnRule($start);
+            case 'while':
+                return $this->whileRule($start, $this->declarationChildCallable);
+            default:
+                $this->disallowedAtRule($start);
+        }
+    }
+
+    /**
+     * Consumes a statement allowed within a function.
+     */
+    private function functionChild(): Statement
+    {
+        if ($this->scanner->peekChar() !== '@') {
+            $start = $this->scanner->getPosition();
+
+            try {
+                return $this->variableDeclarationWithNamespace();
+            } catch (FormatException $variableDeclarationError) {
+                // TODO remove this when implementing modules
+                if ($variableDeclarationError->getMessage() === 'Sass modules are not implemented yet.') {
+                    throw $variableDeclarationError;
+                }
+
+                $this->scanner->setPosition($start);
+
+                // If a variable declaration failed to parse, it's possible the user
+                // thought they could write a style rule or property declaration in a
+                // function. If so, throw a more helpful error message.
+                try {
+                    $statement = $this->declarationOrStyleRule();
+                } catch (FormatException $e) {
+                    throw $variableDeclarationError;
+                }
+
+                $this->error('@function rules may not contain ' . ($statement instanceof StyleRule ? 'style rules.' : 'declarations.'), $statement->getSpan());
+            }
+        }
+
+        $start = $this->scanner->getPosition();
+
+        switch ($this->plainAtRuleName()) {
+            case 'debug':
+                return $this->debugRule($start);
+            case 'each':
+                return $this->eachRule($start, $this->functionChildCallable);
+            case 'else':
+                $this->disallowedAtRule($start);
+            case 'error':
+                return $this->errorRule($start);
+            case 'for':
+                return $this->forRule($start, $this->functionChildCallable);
+            case 'if':
+                return $this->ifRule($start, $this->functionChildCallable);
+            case 'return':
+                return $this->returnRule($start);
+            case 'warn':
+                return $this->warnRule($start);
+            case 'while':
+                return $this->whileRule($start, $this->functionChildCallable);
+            default:
+                $this->disallowedAtRule($start);
+        }
+    }
+
+    /**
+     * Consumes an at-rule's name, with interpolation disallowed.
+     */
+    private function plainAtRuleName(): string
+    {
+        $this->scanner->expectChar('@', '@-rule');
+
+        $name = $this->identifier();
+        $this->whitespace();
+
+        return $name;
+    }
+
+    /**
+     * Consumes an `@at-root` rule.
+     *
+     * $start should point before the `@`.
+     */
+    private function atRootRule(int $start): AtRootRule
+    {
+        if ($this->scanner->peekChar() === '(') {
+            $query = $this->atRootQuery();
+            $this->whitespace();
+
+            return $this->withChildren($this->statementCallable, $start, function (array $children, FileSpan $span) use ($query) {
+                return new AtRootRule($children, $span, $query);
+            });
+        }
+
+        if ($this->lookingAtChildren()) {
+            return $this->withChildren($this->statementCallable, $start, function (array $children, FileSpan $span) {
+                return new AtRootRule($children, $span);
+            });
+        }
+
+        $child = $this->styleRule();
+
+        return new AtRootRule([$child], $this->scanner->spanFrom($start));
+    }
+
+    /**
+     * Consumes a query expression of the form `(foo: bar)`.
+     */
+    private function atRootQuery(): Interpolation
+    {
+        if ($this->scanner->peekChar() === '#') {
+            $interpolation = $this->singleInterpolation();
+
+            return new Interpolation([$interpolation], $interpolation->getSpan());
+        }
+
+        $start = $this->scanner->getPosition();
+        $buffer = new InterpolationBuffer();
+        $this->scanner->expectChar('(');
+        $buffer->write('(');
+        $this->whitespace();
+
+        $buffer->add($this->expression());
+
+        if ($this->scanner->scanChar(':')) {
+            $this->whitespace();
+            $buffer->write(': ');
+            $buffer->add($this->expression());
+        }
+
+        $this->scanner->expectChar(')');
+        $this->whitespace();
+        $buffer->write(')');
+
+        return $buffer->buildInterpolation($this->scanner->spanFrom($start));
+    }
+
+    /**
+     * Consumes a `@content` rule.
+     *
+     * $start should point before the `@`.
+     */
+    private function contentRule(int $start): ContentRule
+    {
+        if (!$this->inMixin) {
+            $this->error('@content is only allowed within mixin declarations.', $this->scanner->spanFrom($start));
+        }
+
+        $this->whitespace();
+
+        $arguments = $this->scanner->peekChar() === '(' ? $this->argumentInvocation(true) : ArgumentInvocation::createEmpty($this->scanner->getEmptySpan());
+
+        $this->expectStatementSeparator('@content rule');
+
+        return new ContentRule($arguments, $this->scanner->spanFrom($start));
+    }
+
+    /**
+     * Consumes a `@debug` rule.
+     *
+     * $start should point before the `@`.
+     */
+    private function debugRule(int $start): DebugRule
+    {
+        $value = $this->expression();
+        $this->expectStatementSeparator('@debug rule');
+
+        return new DebugRule($value, $this->scanner->spanFrom($start));
+    }
+
+    /**
+     * Consumes a `@each` rule.
+     *
+     * $start should point before the `@`. $child is called to consume any
+     * children that are specifically allowed in the caller's context.
+     *
+     * @param callable(): Statement $child
+     */
+    private function eachRule(int $start, callable $child): EachRule
+    {
+        $wasInControlDirective = $this->inControlDirective;
+        $this->inControlDirective = true;
+
+        $variables = [$this->variableName()];
+        $this->whitespace();
+
+        while ($this->scanner->scanChar(',')) {
+            $this->whitespace();
+            $variables[] = $this->variableName();
+            $this->whitespace();
+        }
+
+        $this->expectIdentifier('in');
+        $this->whitespace();
+
+        $list = $this->expression();
+
+        return $this->withChildren($child, $start, function (array $children, FileSpan $span) use ($variables, $wasInControlDirective, $list) {
+            $this->inControlDirective = $wasInControlDirective;
+
+            return new EachRule($variables, $list, $children, $span);
+        });
+    }
+
+    /**
+     * Consumes a `@error` rule.
+     *
+     * $start should point before the `@`.
+     */
+    private function errorRule(int $start): ErrorRule
+    {
+        $value = $this->expression();
+        $this->expectStatementSeparator('@error rule');
+
+        return new ErrorRule($value, $this->scanner->spanFrom($start));
+    }
+
+    /**
+     * Consumes a `@extend` rule.
+     *
+     * $start should point before the `@`.
+     */
+    private function extendRule(int $start): ExtendRule
+    {
+        if (!$this->inStyleRule && !$this->inMixin && !$this->inContentBlock) {
+            $this->error('@extend may only be used within style rules.', $this->scanner->spanFrom($start));
+        }
+
+        $value = $this->almostAnyValue();
+        $optional = $this->scanner->scanChar('!');
+
+        if ($optional) {
+            $this->expectIdentifier('optional');
+        }
+
+        $this->expectStatementSeparator('@extend rule');
+
+        return new ExtendRule($value, $this->scanner->spanFrom($start), $optional);
+    }
+
+    /**
+     * Consumes a function declaration.
+     *
+     * $start should point before the `@`.
+     */
+    private function functionRule(int $start): FunctionRule
+    {
+        $precedingComment = $this->lastSilentComment;
+        $this->lastSilentComment = null;
+
+        $name = $this->identifier(true);
+        $this->whitespace();
+        $arguments = $this->argumentDeclaration();
+
+        if ($this->inMixin || $this->inContentBlock) {
+            $this->error('Mixins may not contain function declarations.', $this->scanner->spanFrom($start));
+        }
+
+        if ($this->inControlDirective) {
+            $this->error('Functions may not be declared in control directives.', $this->scanner->spanFrom($start));
+        }
+
+        switch (Util::unvendor($name)) {
+            case 'calc':
+            case 'element':
+            case 'expression':
+            case 'url':
+            case 'and':
+            case 'or':
+            case 'not':
+            case 'clamp':
+                $this->error('Invalid function name.', $this->scanner->spanFrom($start));
+        }
+
+        $this->whitespace();
+
+        return $this->withChildren($this->functionChildCallable, $start, function (array $children, FileSpan $span) use ($name, $precedingComment, $arguments) {
+            return new FunctionRule($name, $arguments, $span, $children, $precedingComment);
+        });
+    }
+
+    /**
+     * Consumes a `@for` rule.
+     *
+     * $start should point before the `@`. $child is called to consume any
+     * children that are specifically allowed in the caller's context.
+     *
+     * @param callable(): Statement $child
+     */
+    private function forRule(int $start, callable $child): ForRule
+    {
+        $wasInControlDirective = $this->inControlDirective;
+        $this->inControlDirective = true;
+
+        $variable = $this->variableName();
+        $this->whitespace();
+
+        $this->expectIdentifier('from');
+        $this->whitespace();
+
+        $exclusive = null;
+        $from = $this->expression(function () use (&$exclusive) {
+            if (!$this->lookingAtIdentifier()) {
+                return false;
+            }
+
+            if ($this->scanIdentifier('to')) {
+                $exclusive = true;
+
+                return true;
+            }
+
+            if ($this->scanIdentifier('through')) {
+                $exclusive = false;
+
+                return true;
+            }
+
+            return false;
+        });
+
+        if ($exclusive === null) {
+            $this->scanner->error('Expected "to" or "through".');
+        }
+
+        $this->whitespace();
+        $to = $this->expression();
+
+        return $this->withChildren($child, $start, function (array $children, FileSpan $span) use ($variable, $from, $to, $exclusive, $wasInControlDirective) {
+            $this->inControlDirective = $wasInControlDirective;
+
+            return new ForRule($variable, $from, $to, $children, $span, $exclusive);
+        });
+    }
+
+    /**
+     * Consumes a `@if` rule.
+     *
+     * $start should point before the `@`. $child is called to consume any
+     * children that are specifically allowed in the caller's context.
+     *
+     * @param callable(): Statement $child
+     */
+    private function ifRule(int $start, callable $child): IfRule
+    {
+        $ifIndentation = $this->getCurrentIndentation();
+        $wasInControlDirective = $this->inControlDirective;
+        $this->inControlDirective = true;
+
+        $condition = $this->expression();
+        $children = $this->children($child);
+        $this->whitespaceWithoutComments();
+
+        $clauses = [new IfClause($condition, $children)];
+        $lastClause = null;
+
+        while ($this->scanElse($ifIndentation)) {
+            $this->whitespace();
+
+            if ($this->scanIdentifier('if')) {
+                $this->whitespace();
+                $clauses[] = new IfClause($this->expression(), $this->children($child));
+            } else {
+                $lastClause = new ElseClause($this->children($child));
+                break;
+            }
+        }
+
+        $this->inControlDirective = $wasInControlDirective;
+        $span = $this->scanner->spanFrom($start);
+        $this->whitespaceWithoutComments();
+
+        return new IfRule($clauses, $span, $lastClause);
+    }
+
+    /**
+     * Consumes an `@import` rule.
+     *
+     * $start should point before the `@`.
+     */
+    private function importRule(int $start): ImportRule
+    {
+        $imports = [];
+
+        do {
+            $this->whitespace();
+            $argument = $this->importArgument();
+
+            if (($this->inControlDirective || $this->inMixin) && $argument instanceof DynamicImport) {
+                $this->disallowedAtRule($start);
+            }
+
+            $imports[] = $argument;
+            $this->whitespace();
+        } while ($this->scanner->scanChar(','));
+
+        $this->expectStatementSeparator('@import rule');
+
+        return new ImportRule($imports, $this->scanner->spanFrom($start));
+    }
+
+    /**
+     * Consumes an argument to an `@import` rule.
+     */
+    protected function importArgument(): Import
+    {
+        $start = $this->scanner->getPosition();
+        $next = $this->scanner->peekChar();
+
+        if ($next === 'u' || $next === 'U') {
+            $url = $this->dynamicUrl();
+            $this->whitespace();
+            list($supports, $media) = $this->tryImportQueries();
+
+            return new StaticImport(new Interpolation([$url], $this->scanner->spanFrom($start)), $this->scanner->spanFrom($start), $supports, $media);
+        }
+
+        $url = $this->string();
+        $urlSpan = $this->scanner->spanFrom($start);
+        $this->whitespace();
+        list($supports, $media) = $this->tryImportQueries();
+
+        if ($this->isPlainImportUrl($url) || $supports !== null || $media !== null) {
+
+            return new StaticImport(new Interpolation([$urlSpan->getText()], $urlSpan), $this->scanner->spanFrom($start), $supports, $media);
+        }
+
+        // TODO catch the exception of parseImportUrl once it validates the URI format
+
+        return new DynamicImport($this->parseImportUrl($url), $urlSpan);
+    }
+
+    /**
+     * Parses $url as an import URL.
+     */
+    protected function parseImportUrl(string $url): string
+    {
+        // TODO implement URI parsing to enforce well-formed URI for imports ?
+        return $url;
+    }
+
+    /**
+     * Returns whether $url indicates that an `@import` is a plain CSS import.
+     */
+    protected function isPlainImportUrl(string $url): bool
+    {
+        if (\strlen($url) < 5) {
+            return false;
+        }
+
+        if (substr($url, -4) === '.css') {
+            return true;
+        }
+
+        if ($url[0] === '/') {
+            return $url[1] === '/';
+        }
+
+        if ($url[0] !== 'h') {
+            return false;
+        }
+
+        return 0 === strpos($url, 'http://') || 0 === strpos($url, 'https://');
+    }
+
+    /**
+     * Consumes a supports condition and/or a media query after an `@import`.
+     *
+     * @return array{SupportsCondition|null, Interpolation|null}
+     */
+    protected function tryImportQueries(): array
+    {
+        $supports = null;
+
+        if ($this->scanIdentifier('supports')) {
+            $this->scanner->expectChar('(');
+            $start = $this->scanner->getPosition();
+
+            if ($this->scanIdentifier('not')) {
+                $this->whitespace();
+                $supports = new SupportsNegation($this->supportsConditionInParens(), $this->scanner->spanFrom($start));
+            } elseif ($this->scanner->peekChar() === '(') {
+                $supports = $this->supportsCondition();
+            } else {
+                $name = $this->expression();
+                $this->scanner->expectChar(':');
+                $this->whitespace();
+                $value = $this->expression();
+                $supports = new SupportsDeclaration($name, $value, $this->scanner->spanFrom($start));
+            }
+
+            $this->scanner->expectChar(')');
+            $this->whitespace();
+        }
+
+        $media = $this->lookingAtInterpolatedIdentifier() || $this->scanner->peekChar() === '(' ? $this->mediaQueryList() : null;
+
+        return [$supports, $media];
+    }
+
+    /**
+     * Consumes a `@include` rule.
+     *
+     * $start should point before the `@`.
+     */
+    private function includeRule(int $start): IncludeRule
+    {
+        $namespace = null;
+        $name = $this->identifier();
+
+        if ($this->scanner->scanChar('.')) {
+            $namespace = $name;
+            $name = $this->publicIdentifier();
+        } else {
+            $name = str_replace('_', '-', $name);
+        }
+
+        $this->whitespace();
+
+        $arguments = $this->scanner->peekChar() === '(' ? $this->argumentInvocation(true) : ArgumentInvocation::createEmpty($this->scanner->getEmptySpan());
+        $this->whitespace();
+
+        $contentArguments = null;
+        if ($this->scanIdentifier('using')) {
+            $this->whitespace();
+            $contentArguments = $this->argumentDeclaration();
+            $this->whitespace();
+        }
+
+        $content = null;
+        if ($contentArguments !== null || $this->lookingAtChildren()) {
+            $contentArguments = $contentArguments ?? ArgumentDeclaration::createEmpty($this->scanner->getEmptySpan());
+            $wasInContentBlock = $this->inContentBlock;
+            $this->inContentBlock = true;
+
+            $content = $this->withChildren($this->statementCallable, $start, function (array $children, FileSpan $span) use ($contentArguments) {
+                return new ContentBlock($contentArguments, $children, $span);
+            });
+
+            $this->inContentBlock = $wasInContentBlock;
+        } else {
+            $this->expectStatementSeparator();
+        }
+
+        $span = $this->scanner->spanFrom($start, $start)->expand(($content ?? $arguments)->getSpan());
+
+        // TODO remove this when implementing modules
+        if ($namespace !== null) {
+            $this->error('Sass modules are not implemented yet.', $this->scanner->spanFrom($start));
+        }
+
+        return new IncludeRule($name, $arguments, $span, $namespace, $content);
+    }
+
+    /**
+     * Consumes a `@media` rule.
+     *
+     * $start should point before the `@`.
+     */
+    protected function mediaRule(int $start): MediaRule
+    {
+        $query = $this->mediaQueryList();
+
+        return $this->withChildren($this->statementCallable, $start, function (array $children, FileSpan $span) use ($query) {
+            return new MediaRule($query, $children, $span);
+        });
+    }
+
+    /**
+     * Consumes a mixin declaration.
+     *
+     * $start should point before the `@`.
+     */
+    private function mixinRule(int $start): MixinRule
+    {
+        $precedingComment = $this->lastSilentComment;
+        $this->lastSilentComment = null;
+
+        $name = $this->identifier(true);
+        $this->whitespace();
+
+        $arguments = $this->scanner->peekChar() === '(' ? $this->argumentDeclaration() : ArgumentDeclaration::createEmpty($this->scanner->getEmptySpan());
+
+        if ($this->inMixin || $this->inContentBlock) {
+            $this->error('Mixins may not contain mixin declarations.', $this->scanner->spanFrom($start));
+        }
+
+        if ($this->inControlDirective) {
+            $this->error('Mixins may not be declared in control directives.', $this->scanner->spanFrom($start));
+        }
+
+        $this->whitespace();
+        $this->inMixin = true;
+
+        return $this->withChildren($this->statementCallable, $start, function (array $children, FileSpan $span) use ($name, $arguments, $precedingComment) {
+            $this->inMixin = false;
+
+            return new MixinRule($name, $arguments, $span, $children, $precedingComment);
+        });
+    }
+
+    /**
+     * Consumes a `@moz-document` rule.
+     *
+     * Gecko's `@-moz-document` diverges from [the specification][] allows the
+     * `url-prefix` and `domain` functions to omit quotation marks, contrary to
+     * the standard.
+     *
+     * [the specification]: https://www.w3.org/TR/css3-conditional/
+     */
+    protected function mozDocumentRule(int $start, Interpolation $name): AtRule
+    {
+        $valueStart = $this->scanner->getPosition();
+        $buffer = new InterpolationBuffer();
+        $needsDeprecationWarning = false;
+
+        while (true) {
+            if ($this->scanner->peekChar() === '#') {
+                $buffer->add($this->singleInterpolation());
+                $needsDeprecationWarning = true;
+            } else {
+                $identifierStart = $this->scanner->getPosition();
+                $identifier = $this->identifier();
+
+                switch ($identifier) {
+                    case 'url':
+                    case 'url-prefix':
+                    case 'domain':
+                        $contents = $this->tryUrlContents($identifierStart, $identifier);
+
+                        if ($contents !== null) {
+                            $buffer->addInterpolation($contents);
+                        } else {
+                            $this->scanner->expectChar('(');
+                            $this->whitespace();
+                            $argument = $this->interpolatedString();
+                            $this->scanner->expectChar(')');
+
+                            $buffer->write($identifier);
+                            $buffer->write('(');
+                            $buffer->addInterpolation($argument->asInterpolation());
+                            $buffer->write(')');
+                        }
+
+                        // A url-prefix with no argument, or with an empty string as an
+                        // argument, is not (yet) deprecated.
+                        $trailing = $buffer->getTrailingString();
+                        if (!StringUtil::endsWith($trailing, 'url-prefix()') && !StringUtil::endsWith($trailing, "url-prefix('')") && !StringUtil::endsWith($trailing, 'url-prefix("")')) {
+                            $needsDeprecationWarning = true;
+                        }
+                        break;
+
+                    case 'regexp':
+                        $buffer->write('regexp(');
+                        $this->scanner->expectChar('(');
+                        $buffer->addInterpolation($this->interpolatedString()->asInterpolation());
+                        $this->scanner->expectChar(')');
+                        $buffer->write(')');
+                        $needsDeprecationWarning = true;
+                        break;
+
+                    default:
+                        $this->error('Invalid function name.', $this->scanner->spanFrom($identifierStart));
+                }
+            }
+
+            $this->whitespace();
+
+            if (!$this->scanner->scanChar(',')) {
+                break;
+            }
+
+            $buffer->write(',');
+            $buffer->write($this->rawText([$this, 'whitespace']));
+        }
+
+        $value = $buffer->buildInterpolation($this->scanner->spanFrom($valueStart));
+
+        return $this->withChildren($this->statementCallable, $start, function (array $children, FileSpan $span) use ($name, $value, $needsDeprecationWarning) {
+            if ($needsDeprecationWarning) {
+                $this->logger->warn($span->message("@-moz-document is deprecated and support will be removed in Dart Sass 2.0.0.\n\nFor details, see http://bit.ly/MozDocument."), true);
+            }
+
+            return new AtRule($name, $span, $value, $children);
+        });
+    }
+
+    /**
+     * Consumes a `@return` rule.
+     *
+     * $start should point before the `@`.
+     */
+    private function returnRule(int $start): ReturnRule
+    {
+        $value = $this->expression();
+        $this->expectStatementSeparator('@return rule');
+
+        return new ReturnRule($value, $this->scanner->spanFrom($start));
+    }
+
+    /**
+     * Consumes a `@supports` rule.
+     *
+     * $start should point before the `@`.
+     */
+    protected function supportsRule(int $start): SupportsRule
+    {
+        $condition = $this->supportsCondition();
+        $this->whitespace();
+
+        return $this->withChildren($this->statementCallable, $start, function (array $children, FileSpan $span) use ($condition) {
+            return new SupportsRule($condition, $children, $span);
+        });
+    }
+
+    /**
+     * Consumes a `@warn` rule.
+     *
+     * $start should point before the `@`.
+     */
+    private function warnRule(int $start): WarnRule
+    {
+        $value = $this->expression();
+        $this->expectStatementSeparator('@warn rule');
+
+        return new WarnRule($value, $this->scanner->spanFrom($start));
+    }
+
+    /**
+     * Consumes a `@while` rule.
+     *
+     * $start should point before the `@`. $child is called to consume any
+     * children that are specifically allowed in the caller's context.
+     *
+     * @param callable(): Statement $child
+     */
+    private function whileRule(int $start, callable $child): WhileRule
+    {
+        $wasInControlDirective = $this->inControlDirective;
+        $this->inControlDirective = true;
+
+        $condition = $this->expression();
+
+        return $this->withChildren($child, $start, function (array $children, FileSpan $span) use ($condition, $wasInControlDirective) {
+            $this->inControlDirective = $wasInControlDirective;
+
+            return new WhileRule($condition, $children, $span);
+        });
+    }
+
+    /**
+     * Consumes an at-rule that's not explicitly supported by Sass.
+     *
+     * $start should point before the `@`. $name is the name of the at-rule.
+     */
+    protected function unknownAtRule(int $start, Interpolation $name): AtRule
+    {
+        $wasInUnknownAtRule = $this->inUnknownAtRule;
+        $this->inUnknownAtRule = true;
+
+        $value = null;
+        $next = $this->scanner->peekChar();
+        if ($next !== '!' && !$this->atEndOfStatement()) {
+            $value = $this->almostAnyValue();
+        }
+
+        if ($this->lookingAtChildren()) {
+            $rule = $this->withChildren($this->statementCallable, $start, function (array $children, FileSpan $span) use ($name, $value) {
+                return new AtRule($name, $span, $value, $children);
+            });
+        } else {
+            $this->expectStatementSeparator();
+            $rule = new AtRule($name, $this->scanner->spanFrom($start), $value);
+        }
+
+        $this->inUnknownAtRule = $wasInUnknownAtRule;
+
+        return $rule;
+    }
+
+    /**
+     * Throws an exception indicating that the at-rule starting at $start is
+     * not allowed in the current context.
+     *
+     * @return never-return
+     */
+    private function disallowedAtRule(int $start)
+    {
+        $this->almostAnyValue();
+        $this->error('This at-rule is not allowed here.', $this->scanner->spanFrom($start));
+    }
+
+    /**
+     * Consumes an argument declaration.
+     */
+    private function argumentDeclaration(): ArgumentDeclaration
+    {
+        $start = $this->scanner->getPosition();
+        $this->scanner->expectChar('(');
+        $this->whitespace();
+
+        $arguments = [];
+        $named = [];
+        $restArgument = null;
+
+        while ($this->scanner->peekChar() === '$') {
+            $variableStart = $this->scanner->getPosition();
+            $name = $this->variableName();
+            $this->whitespace();
+
+            $defaultValue = null;
+
+            if ($this->scanner->scanChar(':')) {
+                $this->whitespace();
+                $defaultValue = $this->expressionUntilComma();
+            } elseif ($this->scanner->scanChar('.')) {
+                $this->scanner->expectChar('.');
+                $this->scanner->expectChar('.');
+                $this->whitespace();
+                $restArgument = $name;
+                break;
+            }
+
+            $argument = new Argument($name, $this->scanner->spanFrom($variableStart), $defaultValue);
+            $arguments[] = $argument;
+
+            if (isset($named[$name])) {
+                $this->error('Duplicate argument.', $argument->getSpan());
+            }
+            $named[$name] = true;
+
+            if (!$this->scanner->scanChar(',')) {
+                break;
+            }
+            $this->whitespace();
+        }
+
+        $this->scanner->expectChar(')');
+
+        return new ArgumentDeclaration($arguments, $this->scanner->spanFrom($start), $restArgument);
+    }
+
+    /**
+     * Consumes an argument invocation.
+     *
+     * If $mixin is `true`, this is parsed as a mixin invocation. Mixin
+     * invocations don't allow the Microsoft-style `=` operator at the top level,
+     * but function invocations do.
+     */
+    private function argumentInvocation(bool $mixin = false): ArgumentInvocation
+    {
+        $start = $this->scanner->getPosition();
+        $this->scanner->expectChar('(');
+        $this->whitespace();
+
+        $positional = [];
+        $named = [];
+        $rest = null;
+        $keywordRest = null;
+
+        while ($this->lookingAtExpression()) {
+            $expression = $this->expressionUntilComma(!$mixin);
+            $this->whitespace();
+
+            if ($expression instanceof VariableExpression && $this->scanner->scanChar(':')) {
+                $this->whitespace();
+
+                if (isset($named[$expression->getName()])) {
+                    $this->error('Duplicate argument.', $expression->getSpan());
+                }
+
+                $named[$expression->getName()] = $this->expressionUntilComma(!$mixin);
+            } elseif ($this->scanner->scanChar('.')) {
+                $this->scanner->expectChar('.');
+                $this->scanner->expectChar('.');
+
+                if ($rest === null) {
+                    $rest = $expression;
+                } else {
+                    $keywordRest = $expression;
+                    $this->whitespace();
+                    break;
+                }
+            } elseif ($named) {
+                $this->error('Positional arguments must come before keyword arguments.', $expression->getSpan());
+            } else {
+                $positional[] = $expression;
+            }
+
+            $this->whitespace();
+
+            if (!$this->scanner->scanChar(',')) {
+                break;
+            }
+            $this->whitespace();
+        }
+
+        $this->scanner->expectChar(')');
+
+        return new ArgumentInvocation($positional, $named, $this->scanner->spanFrom($start), $rest, $keywordRest);
+    }
+
+    /**
+     * Consumes an expression.
+     *
+     * @param (callable(): bool)|null $until
+     */
+    protected function expression(?callable $until = null, bool $singleEquals = false, bool $bracketList = false): Expression
+    {
+        if ($until !== null && $until()) {
+            $this->scanner->error('Expected expression.');
+        }
+
+        $beforeBracket = null;
+
+        if ($bracketList) {
+            $beforeBracket = $this->scanner->getPosition();
+            $this->scanner->expectChar('[');
+            $this->whitespace();
+
+            if ($this->scanner->scanChar(']')) {
+                return new ListExpression([], ListSeparator::UNDECIDED, $this->scanner->spanFrom($beforeBracket), true);
+            }
+        }
+
+        $start = $this->scanner->getPosition();
+        $wasInParentheses = $this->inParentheses;
+        /**
+         * @var Expression[]|null $commaExpressions
+         */
+        $commaExpressions = null;
+        /**
+         * @var Expression[]|null $spaceExpressions
+         */
+        $spaceExpressions = null;
+        /**
+         * Operators whose right-hand $operands are not fully parsed yet, in order of
+         * appearance in the document. Because a low-precedence operator will cause
+         * parsing to finish for all preceding higher-precedence $operators, this is
+         * naturally ordered from lowest to highest precedence.
+         *
+         * @phpstan-var list<BinaryOperator::*>|null $operators
+         */
+        $operators = null;
+        /**
+         * The left-hand sides of $operators. `$operands[n]` is the left-hand side
+         * of `$operators[n]`.
+         *
+         * @var list<Expression>|null $operands
+         */
+        $operands = null;
+
+        /**
+         * Whether the single expression parsed so far may be interpreted as
+         * slash-separated numbers.
+         */
+        $allowSlash = true;
+
+        /**
+         * The leftmost expression that's been fully-parsed. This can be null in
+         * special cases where the expression begins with a sub-expression but has
+         * a later character that indicates that the outer expression isn't done,
+         * as here:
+         *
+         *     foo, bar
+         *         ^
+         *
+         * @var Expression|null $singleExpression
+         */
+        $singleExpression = $this->singleExpression();
+
+        /**
+         * Resets the scanner state to the state it was at the beginning of the
+         * expression, except for {@see $inParentheses}.
+         */
+        $resetState = function () use (&$commaExpressions, &$spaceExpressions, &$operators, &$operands, &$allowSlash, &$singleExpression, $start): void {
+            $commaExpressions = null;
+            $spaceExpressions = null;
+            $operators = null;
+            $operands = null;
+            $this->scanner->setPosition($start);
+            $allowSlash = true;
+            $singleExpression = $this->singleExpression();
+        };
+
+        $resolveOneOperation = function () use (&$operands, &$operators, &$singleExpression, &$allowSlash): void {
+            assert($operands !== null);
+            assert($operators !== null);
+            $operator = array_pop($operators);
+            assert($operator !== null, 'The list of operators must not be empty');
+
+            $left = array_pop($operands);
+            assert($left !== null, 'The list of operands must not be empty');
+
+            $right = $singleExpression;
+
+            if ($right === null) {
+                $this->scanner->error('Expected expression.', $this->scanner->getPosition() - \strlen($operator), \strlen($operator));
+            }
+
+            if ($allowSlash && !$this->inParentheses && $operator === BinaryOperator::DIVIDED_BY && self::isSlashOperand($left) && self::isSlashOperand($right)) {
+                $singleExpression = BinaryOperationExpression::slash($left, $right);
+            } else {
+                $singleExpression = new BinaryOperationExpression($operator, $left, $right);
+                $allowSlash = false;
+            }
+        };
+
+        $resolveOperations = function () use (&$operators, $resolveOneOperation): void {
+            if ($operators === null) {
+                return;
+            }
+
+            while ($operators) {
+                $resolveOneOperation();
+            }
+        };
+
+        $addSingleExpression = function (Expression $expression) use (&$singleExpression, &$allowSlash, &$spaceExpressions, $resetState, $resolveOperations): void {
+            if ($singleExpression !== null) {
+                // If we discover we're parsing a list whose first element is a division
+                // operation, and we're in parentheses, reparse outside of a paren
+                // context. This ensures that `(1/2 1)` doesn't perform division on its
+                // first element.
+                if ($this->inParentheses) {
+                    $this->inParentheses = false;
+
+                    if ($allowSlash) {
+                        $resetState();
+                        return;
+                    }
+                }
+
+                $spaceExpressions = $spaceExpressions ?? [];
+                $resolveOperations();
+
+                $spaceExpressions[] = $singleExpression;
+                $allowSlash = true;
+            }
+
+            $singleExpression = $expression;
+        };
+
+        $addOperator =
+            /**
+             * @param BinaryOperator::* $operator
+             */
+            function (string $operator) use (&$allowSlash, &$operators, &$operands, &$singleExpression, $resolveOneOperation): void {
+                /** @var BinaryOperator::* $operator */
+                if ($this->isPlainCss() && $operator !== BinaryOperator::DIVIDED_BY && $operator !== BinaryOperator::SINGLE_EQUALS) {
+                    $this->scanner->error("Operators aren't allowed in plain CSS.", $this->scanner->getPosition() - \strlen($operator), \strlen($operator));
+                }
+
+                $allowSlash = $allowSlash && $operator === BinaryOperator::DIVIDED_BY;
+
+                $operators = $operators ?? [];
+                $operands = $operands ?? [];
+
+                $precedence = BinaryOperator::getPrecedence($operator);
+
+                while ($operators && BinaryOperator::getPrecedence($operators[\count($operators) - 1]) >= $precedence) {
+                    $resolveOneOperation();
+                }
+
+                $operators[] = $operator;
+
+                if ($singleExpression === null) {
+                    $this->scanner->error('Expected expression.', $this->scanner->getPosition() - \strlen($operator), \strlen($operator));
+                }
+
+                $operands[] = $singleExpression;
+
+                $this->whitespace();
+                $singleExpression = $this->singleExpression();
+            };
+
+        $resolveSpaceExpressions = function () use (&$spaceExpressions, &$singleExpression, $resolveOperations): void {
+            $resolveOperations();
+
+            if ($spaceExpressions !== null) {
+                if ($singleExpression === null) {
+                    $this->scanner->error('Expected expression.');
+                }
+
+                $spaceExpressions[] = $singleExpression;
+                $singleExpression = new ListExpression(
+                    $spaceExpressions,
+                    ListSeparator::SPACE,
+                    $spaceExpressions[0]->getSpan()->expand($spaceExpressions[\count($spaceExpressions) - 1]->getSpan())
+                );
+                $spaceExpressions = null;
+            }
+        };
+
+        while (true) {
+            $this->whitespace();
+
+            if ($until !== null && $until()) {
+                break;
+            }
+
+            $first = $this->scanner->peekChar();
+
+            switch ($first) {
+                case '(':
+                    // Parenthesized numbers can't be slash-separated.
+                    $addSingleExpression($this->parentheses());
+                    break;
+
+                case '[':
+                    $addSingleExpression($this->expression(null, false, true));
+                    break;
+
+                case '$':
+                    $addSingleExpression($this->variable());
+                    break;
+
+                case '&':
+                    $addSingleExpression($this->selector());
+                    break;
+
+                case "'":
+                case '"':
+                    $addSingleExpression($this->interpolatedString());
+                    break;
+
+                case '#':
+                    $addSingleExpression($this->hashExpression());
+                    break;
+
+                case '=':
+                    $this->scanner->readChar();
+                    if ($singleEquals && $this->scanner->peekChar() !== '=') {
+                        $addOperator(BinaryOperator::SINGLE_EQUALS);
+                    } else {
+                        $this->scanner->expectChar('=');
+                        $addOperator(BinaryOperator::EQUALS);
+                    }
+                    break;
+
+                case '!':
+                    $next = $this->scanner->peekChar(1);
+
+                    if ($next === '=') {
+                        $this->scanner->readChar();
+                        $this->scanner->readChar();
+                        $addOperator(BinaryOperator::NOT_EQUALS);
+                    } elseif ($next === null || $next === 'i' || $next === 'I' || Character::isWhitespace($next)) {
+                        $addSingleExpression($this->importantExpression());
+                    } else {
+                        break 2;
+                    }
+                    break;
+
+                case '<':
+                    $this->scanner->readChar();
+                    $addOperator($this->scanner->scanChar('=') ? BinaryOperator::LESS_THAN_OR_EQUALS : BinaryOperator::LESS_THAN);
+                    break;
+
+                case '>':
+                    $this->scanner->readChar();
+                    $addOperator($this->scanner->scanChar('=') ? BinaryOperator::GREATER_THAN_OR_EQUALS : BinaryOperator::GREATER_THAN);
+                    break;
+
+                case '*':
+                    $this->scanner->readChar();
+                    $addOperator(BinaryOperator::TIMES);
+                    break;
+
+                case '+':
+                    if ($singleExpression === null) {
+                        $addSingleExpression($this->unaryOperation());
+                    } else {
+                        $this->scanner->readChar();
+                        $addOperator(BinaryOperator::PLUS);
+                    }
+                    break;
+
+                case '-':
+                    $next = $this->scanner->peekChar(1);
+                    // Make sure `1-2` parses as `1 - 2`, not `1 (-2)`.
+                    if ((Character::isDigit($next) || $next === '.') && ($singleExpression === null || Character::isWhitespace($this->scanner->peekChar(-1)))) {
+                        $addSingleExpression($this->number());
+                    } elseif ($this->lookingAtInterpolatedIdentifier()) {
+                        $addSingleExpression($this->identifierLike());
+                    } elseif ($singleExpression === null) {
+                        $addSingleExpression($this->unaryOperation());
+                    } else {
+                        $this->scanner->readChar();
+                        $addOperator(BinaryOperator::MINUS);
+                    }
+                    break;
+
+                case '/':
+                    if ($singleExpression === null) {
+                        $addSingleExpression($this->unaryOperation());
+                    } else {
+                        $this->scanner->readChar();
+                        $addOperator(BinaryOperator::DIVIDED_BY);
+                    }
+                    break;
+
+                case '%':
+                    $this->scanner->readChar();
+                    $addOperator(BinaryOperator::MODULO);
+                    break;
+
+                case '0':
+                case '1':
+                case '2':
+                case '3':
+                case '4':
+                case '5':
+                case '6':
+                case '7':
+                case '8':
+                case '9':
+                    $addSingleExpression($this->number());
+                    break;
+
+                case '.':
+                    if ($this->scanner->peekChar(1) === '.') {
+                        break 2;
+                    }
+
+                    $addSingleExpression($this->number());
+                    break;
+
+                case 'a':
+                    if (!$this->isPlainCss() && $this->scanIdentifier('and')) {
+                        $addOperator(BinaryOperator::AND);
+                    } else {
+                        $addSingleExpression($this->identifierLike());
+                    }
+                    break;
+
+                case 'o':
+                    if (!$this->isPlainCss() && $this->scanIdentifier('or')) {
+                        $addOperator(BinaryOperator::OR);
+                    } else {
+                        $addSingleExpression($this->identifierLike());
+                    }
+                    break;
+
+                case 'u':
+                case 'U':
+                    if ($this->scanner->peekChar(1) === '+') {
+                        $addSingleExpression($this->unicodeRange());
+                    } else {
+                        $addSingleExpression($this->identifierLike());
+                    }
+                    break;
+
+                case 'b':
+                case 'c':
+                case 'd':
+                case 'e':
+                case 'f':
+                case 'g':
+                case 'h':
+                case 'i':
+                case 'j':
+                case 'k':
+                case 'l':
+                case 'm':
+                case 'n':
+                case 'p':
+                case 'q':
+                case 'r':
+                case 's':
+                case 't':
+                case 'v':
+                case 'w':
+                case 'x':
+                case 'y':
+                case 'z':
+                case 'A':
+                case 'B':
+                case 'C':
+                case 'D':
+                case 'E':
+                case 'F':
+                case 'G':
+                case 'H':
+                case 'I':
+                case 'J':
+                case 'K':
+                case 'L':
+                case 'M':
+                case 'N':
+                case 'O':
+                case 'P':
+                case 'Q':
+                case 'R':
+                case 'S':
+                case 'T':
+                case 'V':
+                case 'W':
+                case 'X':
+                case 'Y':
+                case 'Z':
+                case '_':
+                case '\\':
+                    $addSingleExpression($this->identifierLike());
+                    break;
+
+                case ',':
+                    // If we discover we're parsing a list whose first element is a
+                    // division operation, and we're in parentheses, reparse outside of a
+                    // paren context. This ensures that `(1/2, 1)` doesn't perform division
+                    // on its first element.
+                    if ($this->inParentheses) {
+                        $this->inParentheses = false;
+
+                        if ($allowSlash) {
+                            $resetState();
+                            break;
+                        }
+                    }
+
+                    $commaExpressions = $commaExpressions ?? [];
+
+                    if ($singleExpression === null) {
+                        $this->scanner->error('Expected expression.');
+                    }
+                    $resolveSpaceExpressions();
+
+                    $commaExpressions[] = $singleExpression;
+
+                    $this->scanner->readChar();
+                    $allowSlash = true;
+                    $singleExpression = null;
+                    break;
+
+                default:
+                    if ($first !== null && \ord($first) >= 0x80) {
+                        $addSingleExpression($this->identifierLike());
+                        break;
+                    }
+
+                    break 2;
+            }
+        }
+
+        if ($bracketList) {
+            $this->scanner->expectChar(']');
+        }
+
+        if ($commaExpressions !== null) {
+            $resolveSpaceExpressions();
+            $this->inParentheses = $wasInParentheses;
+
+            if ($singleExpression !== null) {
+                $commaExpressions[] = $singleExpression;
+            }
+
+            return new ListExpression($commaExpressions, ListSeparator::COMMA, $this->scanner->spanFrom($beforeBracket ?? $start), $bracketList);
+        }
+
+        if ($bracketList && $spaceExpressions !== null) {
+            $resolveOperations();
+            assert($singleExpression !== null);
+            $spaceExpressions[] = $singleExpression;
+
+            return new ListExpression($spaceExpressions, ListSeparator::SPACE, $this->scanner->spanFrom($beforeBracket), true);
+        }
+
+        $resolveSpaceExpressions();
+        assert($singleExpression !== null);
+
+        if ($bracketList) {
+            assert($beforeBracket !== null);
+            $singleExpression = new ListExpression([$singleExpression], ListSeparator::UNDECIDED, $this->scanner->spanFrom($beforeBracket), true);
+        }
+
+        return $singleExpression;
+    }
+
+    /**
+     * Consumes an expression until it reaches a top-level comma.
+     *
+     * If $singleEquals is true, this will allow the Microsoft-style `=`
+     * operator at the top level.
+     */
+    private function expressionUntilComma(bool $singleEquals = false): Expression
+    {
+        return $this->expression(function () {
+            return $this->scanner->peekChar() === ',';
+        }, $singleEquals);
+    }
+
+    /**
+     * Whether $expression is allowed as an operand of a `/` expression that
+     * produces a potentially slash-separated number.
+     */
+    private static function isSlashOperand(Expression $expression): bool
+    {
+        return $expression instanceof NumberExpression || $expression instanceof CalculationExpression || ($expression instanceof BinaryOperationExpression && $expression->allowsSlash());
+    }
+
+    /**
+     * Consumes an expression that doesn't contain any top-level whitespace.
+     */
+    private function singleExpression(): Expression
+    {
+        $first = $this->scanner->peekChar();
+
+        switch ($first) {
+            case '(':
+                return $this->parentheses();
+            case '/':
+                return $this->unaryOperation();
+            case '.':
+                return $this->number();
+            case '[':
+                return $this->expression(null, false, true);
+            case '$':
+                return $this->variable();
+            case '&':
+                return $this->selector();
+
+            case "'":
+            case '"':
+                return $this->interpolatedString();
+
+            case '#':
+                return $this->hashExpression();
+
+            case '+':
+                return $this->plusExpression();
+
+            case '-':
+                return $this->minusExpression();
+
+            case '!':
+                return $this->importantExpression();
+
+            case 'u':
+            case 'U':
+                if ($this->scanner->peekChar(1) === '+') {
+                    return $this->unicodeRange();
+                }
+
+                return $this->identifierLike();
+
+            case '0':
+            case '1':
+            case '2':
+            case '3':
+            case '4':
+            case '5':
+            case '6':
+            case '7':
+            case '8':
+            case '9':
+                return $this->number();
+
+            case 'a':
+            case 'b':
+            case 'c':
+            case 'd':
+            case 'e':
+            case 'f':
+            case 'g':
+            case 'h':
+            case 'i':
+            case 'j':
+            case 'k':
+            case 'l':
+            case 'm':
+            case 'n':
+            case 'o':
+            case 'p':
+            case 'q':
+            case 'r':
+            case 's':
+            case 't':
+            case 'v':
+            case 'w':
+            case 'x':
+            case 'y':
+            case 'z':
+            case 'A':
+            case 'B':
+            case 'C':
+            case 'D':
+            case 'E':
+            case 'F':
+            case 'G':
+            case 'H':
+            case 'I':
+            case 'J':
+            case 'K':
+            case 'L':
+            case 'M':
+            case 'N':
+            case 'O':
+            case 'P':
+            case 'Q':
+            case 'R':
+            case 'S':
+            case 'T':
+            case 'V':
+            case 'W':
+            case 'X':
+            case 'Y':
+            case 'Z':
+            case '_':
+            case '\\':
+                return $this->identifierLike();
+
+            default:
+                if ($first !== null && \ord($first) >= 0x80) {
+                    return $this->identifierLike();
+                }
+
+                $this->scanner->error('Expected expression.');
+        }
+    }
+
+    /**
+     * Consumes a parenthesized expression.
+     */
+    private function parentheses(): Expression
+    {
+        if ($this->isPlainCss()) {
+            $this->scanner->error("Parentheses aren't allowed in plain CSS.");
+        }
+
+        $wasInParentheses = $this->inParentheses;
+        $this->inParentheses = true;
+
+        try {
+            $start = $this->scanner->getPosition();
+            $this->scanner->expectChar('(');
+            $this->whitespace();
+
+            if (!$this->lookingAtExpression()) {
+                $this->scanner->expectChar(')');
+
+                return new ListExpression([], ListSeparator::UNDECIDED, $this->scanner->spanFrom($start));
+            }
+
+            $first = $this->expressionUntilComma();
+
+            if ($this->scanner->scanChar(':')) {
+                $this->whitespace();
+
+                return $this->map($first, $start);
+            }
+
+            if (!$this->scanner->scanChar(',')) {
+                $this->scanner->expectChar(')');
+
+                return new ParenthesizedExpression($first, $this->scanner->spanFrom($start));
+            }
+
+            $this->whitespace();
+
+            $expressions = [$first];
+
+            while (true) {
+                if (!$this->lookingAtExpression()) {
+                    break;
+                }
+
+                $expressions[] = $this->expressionUntilComma();
+
+                if (!$this->scanner->scanChar(',')) {
+                    break;
+                }
+
+                $this->whitespace();
+            }
+
+            $this->scanner->expectChar(')');
+
+            return new ListExpression($expressions, ListSeparator::COMMA, $this->scanner->spanFrom($start));
+        } finally {
+            $this->inParentheses = $wasInParentheses;
+        }
+    }
+
+    /**
+     * Consumes a map expression.
+     *
+     * This expects to be called after the first colon in the map, with $first
+     * as the expression before the colon and $start the point before the
+     * opening parenthesis.
+     */
+    private function map(Expression $first, int $start): MapExpression
+    {
+        $pairs = [
+            [$first, $this->expressionUntilComma()],
+        ];
+
+        while ($this->scanner->scanChar(',')) {
+            $this->whitespace();
+            if (!$this->lookingAtExpression()) {
+                break;
+            }
+
+            $key = $this->expressionUntilComma();
+            $this->scanner->expectChar(':');
+            $this->whitespace();
+            $value = $this->expressionUntilComma();
+
+            $pairs[] = [$key, $value];
+        }
+
+        $this->scanner->expectChar(')');
+
+        return new MapExpression($pairs, $this->scanner->spanFrom($start));
+    }
+
+    /**
+     * Consumes an expression that starts with a `#`.
+     */
+    private function hashExpression(): Expression
+    {
+        assert($this->scanner->peekChar() === '#');
+        if ($this->scanner->peekChar(1) === '{') {
+            return $this->identifierLike();
+        }
+
+        $start = $this->scanner->getPosition();
+        $this->scanner->expectChar('#');
+
+        $first = $this->scanner->peekChar();
+        if ($first !== null && Character::isDigit($first)) {
+            return new ColorExpression($this->hexColorContents(), $this->scanner->spanFrom($start));
+        }
+
+        $afterHash = $this->scanner->getPosition();
+        $identifier = $this->interpolatedIdentifier();
+        if ($this->isHexColor($identifier)) {
+            $this->scanner->setPosition($afterHash);
+
+            return new ColorExpression($this->hexColorContents(), $this->scanner->spanFrom($start));
+        }
+
+        $buffer = new InterpolationBuffer();
+        $buffer->write('#');
+        $buffer->addInterpolation($identifier);
+
+        return new StringExpression($buffer->buildInterpolation($this->scanner->spanFrom($start)));
+    }
+
+    /**
+     * Consumes the contents of a hex color, after the `#`.
+     */
+    private function hexColorContents(): SassColor
+    {
+        $digit1 = $this->hexDigit();
+        $digit2 = $this->hexDigit();
+        $digit3 = $this->hexDigit();
+
+        $alpha = null;
+
+        if (!Character::isHex($this->scanner->peekChar())) {
+            // #abc
+            $red = ($digit1 << 4) + $digit1;
+            $green = ($digit2 << 4) + $digit2;
+            $blue = ($digit3 << 4) + $digit3;
+        } else {
+            $digit4 = $this->hexDigit();
+
+            if (!Character::isHex($this->scanner->peekChar())) {
+                #abcd
+                $red = ($digit1 << 4) + $digit1;
+                $green = ($digit2 << 4) + $digit2;
+                $blue = ($digit3 << 4) + $digit3;
+                $alpha = (($digit4 << 4) + $digit4) / 0xff;
+            } else {
+                $red = ($digit1 << 4) + $digit2;
+                $green = ($digit3 << 4) + $digit4;
+                $blue = ($this->hexDigit() << 4) + $this->hexDigit();
+
+                if (Character::isHex($this->scanner->peekChar())) {
+                    $alpha = (($this->hexDigit() << 4) + $this->hexDigit()) / 0xff;
+                }
+            }
+        }
+
+        return SassColor::rgb($red, $green, $blue, $alpha);
+    }
+
+    private function isHexColor(Interpolation $interpolation): bool
+    {
+        $plain = $interpolation->getAsPlain();
+
+        if ($plain === null) {
+            return false;
+        }
+
+        $length = \strlen($plain);
+
+        if ($length !== 3 && $length !== 4 && $length !== 6 && $length !== 8) {
+            return false;
+        }
+
+        for ($i = 0; $i < $length; $i++) {
+            if (!Character::isHex($plain[$i])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Consumes a single hexadecimal digit.
+     */
+    private function hexDigit(): int
+    {
+        $char = $this->scanner->peekChar();
+
+        if ($char === null || !Character::isHex($char)) {
+            $this->scanner->error('Expected hex digit.');
+        }
+
+        return (int) hexdec($this->scanner->readChar());
+    }
+
+    /**
+     * Consumes an expression that starts with a `+`.
+     */
+    private function plusExpression(): Expression
+    {
+        assert($this->scanner->peekChar() === '+');
+        $next = $this->scanner->peekChar(1);
+
+        if (Character::isDigit($next) || $next === '.') {
+            return $this->number();
+        }
+
+        return $this->unaryOperation();
+    }
+
+    /**
+     * Consumes an expression that starts with a `-`.
+     */
+    private function minusExpression(): Expression
+    {
+        assert($this->scanner->peekChar() === '-');
+        $next = $this->scanner->peekChar(1);
+
+        if (Character::isDigit($next) || $next === '.') {
+            return $this->number();
+        }
+
+        if ($this->lookingAtInterpolatedIdentifier()) {
+            return $this->identifierLike();
+        }
+
+        return $this->unaryOperation();
+    }
+
+    /**
+     * Consumes an `!important` expression.
+     */
+    private function importantExpression(): Expression
+    {
+        assert($this->scanner->peekChar() === '!');
+
+        $start = $this->scanner->getPosition();
+        $this->scanner->readChar();
+        $this->whitespace();
+        $this->expectIdentifier('important');
+
+        return StringExpression::plain('!important', $this->scanner->spanFrom($start));
+    }
+
+    /**
+     * Consumes a unary operation expression.
+     */
+    private function unaryOperation(): UnaryOperationExpression
+    {
+        $start = $this->scanner->getPosition();
+        $operator = $this->unaryOperatorFor($this->scanner->readChar());
+
+        if ($operator === null) {
+            $this->scanner->error('Expected unary operator.', $this->scanner->getPosition() - 1);
+        }
+
+        if ($this->isPlainCss() && $operator !== UnaryOperator::DIVIDE) {
+            $this->scanner->error("Operators aren't allowed in plain CSS.", $this->scanner->getPosition() - 1, 1);
+        }
+
+        $this->whitespace();
+        $operand = $this->singleExpression();
+
+        return new UnaryOperationExpression($operator, $operand, $this->scanner->spanFrom($start));
+    }
+
+    /**
+     * Returns the unary operator corresponding to $character, or `null` if
+     * the character is not a unary operator.
+     *
+     * @return UnaryOperator::*|null
+     */
+    private function unaryOperatorFor(string $character): ?string
+    {
+        switch ($character) {
+            case '+':
+                return UnaryOperator::PLUS;
+
+            case '-':
+                return UnaryOperator::MINUS;
+
+            case '/':
+                return UnaryOperator::DIVIDE;
+
+            default:
+                return null;
+        }
+    }
+
+    /**
+     * Consumes a number expression.
+     */
+    private function number(): NumberExpression
+    {
+        $start = $this->scanner->getPosition();
+        $first = $this->scanner->peekChar();
+        $sign = $first === '-' ? -1 : 1;
+
+        if ($first === '+' || $first === '-') {
+            $this->scanner->readChar();
+        }
+
+        $number = $this->scanner->peekChar() === '.' ? 0 : $this->naturalNumber();
+
+        // Don't complain about a dot after a number unless the number starts with a
+        // dot. We don't allow a plain ".", but we need to allow "1." so that
+        // "1..." will work as a rest argument.
+        $number += $this->tryDecimal($this->scanner->getPosition() !== $start);
+        $number *= $this->tryExponent();
+
+        $unit = null;
+        if ($this->scanner->scanChar('%')) {
+            $unit = '%';
+        } elseif ($this->lookingAtIdentifier() && ($this->scanner->peekChar() !== '-' || $this->scanner->peekChar(1) !== '-')) {
+            $unit = $this->identifier(false, true);
+        }
+
+        return new NumberExpression($sign * $number, $this->scanner->spanFrom($start), $unit);
+    }
+
+    /**
+     * Consumes the decimal component of a number and returns its value, or 0 if
+     * there is no decimal component.
+     *
+     * If $allowTrailingDot is `false`, this will throw an error if there's a
+     * dot without any numbers following it. Otherwise, it will ignore the dot
+     * without consuming it.
+     *
+     * @param bool $allowTrailingDot
+     *
+     * @return int|float
+     */
+    private function tryDecimal(bool $allowTrailingDot = false)
+    {
+        $start = $this->scanner->getPosition();
+
+        if ($this->scanner->peekChar() !== '.') {
+            return 0;
+        }
+
+        if (!Character::isDigit($this->scanner->peekChar(1))) {
+            if ($allowTrailingDot) {
+                return 0;
+            }
+
+            $this->scanner->error('Expected digit.', $this->scanner->getPosition() + 1);
+        }
+
+        $this->scanner->readChar();
+        while (Character::isDigit($this->scanner->peekChar())) {
+            $this->scanner->readChar();
+        }
+
+        // Use PHP's built-in float parsing so that we don't accumulate
+        // floating-point errors for numbers with lots of digits.
+        return floatval($this->scanner->substring($start));
+    }
+
+    /**
+     * Consumes the exponent component of a number and returns its value, or 1 if
+     * there is no exponent component.
+     *
+     * @return int|float
+     */
+    private function tryExponent()
+    {
+        $first = $this->scanner->peekChar();
+
+        if ($first !== 'e' && $first !== 'E') {
+            return 1;
+        }
+
+        $next = $this->scanner->peekChar(1);
+
+        if (!Character::isDigit($next) && $next !== '-' && $next !== '+') {
+            return 1;
+        }
+
+        $this->scanner->readChar();
+        $exponentSign = $next === '-' ? -1 : 1;
+        if ($next === '+' || $next === '-') {
+            $this->scanner->readChar();
+        }
+
+        if (!Character::isDigit($this->scanner->peekChar())) {
+            $this->scanner->error('Expected digit.');
+        }
+
+        $exponent = 0.0;
+
+        while (Character::isDigit($this->scanner->peekChar())) {
+            $exponent *= 10;
+            $exponent += \ord($this->scanner->readChar()) - \ord('0');
+        }
+
+        return pow(10, $exponentSign * $exponent);
+    }
+
+    /**
+     * Consumes a unicode range expression.
+     */
+    private function unicodeRange(): StringExpression
+    {
+        $start = $this->scanner->getPosition();
+        $this->expectIdentChar('u');
+        $this->scanner->expectChar('+');
+
+        $firstRangeLength = 0;
+        while ($this->scanCharIf([Character::class, 'isHex'])) {
+            $firstRangeLength++;
+        }
+
+        $hasQuestionMark = false;
+
+        while ($this->scanner->scanChar('?')) {
+            $hasQuestionMark = true;
+            $firstRangeLength++;
+        }
+
+        if ($firstRangeLength === 0) {
+            $this->scanner->error('Expected hex digit or "?".');
+        } elseif ($firstRangeLength > 6) {
+            $this->error('Expected at most 6 digits.', $this->scanner->spanFrom($start));
+        } elseif ($hasQuestionMark) {
+            return StringExpression::plain($this->scanner->substring($start), $this->scanner->spanFrom($start));
+        }
+
+        if ($this->scanner->scanChar('-')) {
+            $secondRangeStart = $this->scanner->getPosition();
+            $secondRangeLength = 0;
+            while ($this->scanCharIf([Character::class, 'isHex'])) {
+                $secondRangeLength++;
+            }
+
+            if ($secondRangeLength === 0) {
+                $this->scanner->error('Expected hex digit.');
+            } elseif ($secondRangeLength > 6) {
+                $this->error('Expected at most 6 digits.', $this->scanner->spanFrom($secondRangeStart));
+            }
+        }
+
+        if ($this->lookingAtInterpolatedIdentifierBody()) {
+            $this->scanner->error('Expected end of identifier.');
+        }
+
+        return StringExpression::plain($this->scanner->substring($start), $this->scanner->spanFrom($start));
+    }
+
+    /**
+     * Consumes a variable expression.
+     */
+    private function variable(): VariableExpression
+    {
+        $start = $this->scanner->getPosition();
+        $name = $this->variableName();
+
+        if ($this->isPlainCss()) {
+            $this->error('Sass variables aren\'t allowed in plain CSS.', $this->scanner->spanFrom($start));
+        }
+
+        return new VariableExpression($name, $this->scanner->spanFrom($start));
+    }
+
+    /**
+     * Consumes a selector expression.
+     */
+    private function selector(): SelectorExpression
+    {
+        if ($this->isPlainCss()) {
+            $this->scanner->error("The parent selector isn't allowed in plain CSS.", null, 1);
+        }
+
+        $start = $this->scanner->getPosition();
+        $this->scanner->expectChar('&');
+
+        if ($this->scanner->scanChar('&')) {
+            $this->warn('In Sass, "&&" means two copies of the parent selector. You probably want to use "and" instead.', $this->scanner->spanFrom($start));
+            $this->scanner->setPosition($this->scanner->getPosition() - 1);
+        }
+
+        return new SelectorExpression($this->scanner->spanFrom($start));
+    }
+
+    /**
+     * Consumes a quoted string expression.
+     */
+    protected function interpolatedString(): StringExpression
+    {
+        $start = $this->scanner->getPosition();
+        $quote = $this->scanner->readChar();
+
+        if ($quote !== "'" && $quote !== '"') {
+            $this->scanner->error('Expected string.', $start);
+        }
+
+        $buffer = new InterpolationBuffer();
+
+        while (true) {
+            $next = $this->scanner->peekChar();
+
+            if ($next === $quote) {
+                $this->scanner->readChar();
+                break;
+            }
+
+            if ($next === null || Character::isNewline($next)) {
+                $this->scanner->error("Expected $quote.");
+            }
+
+            if ($next === '\\') {
+                $second = $this->scanner->peekChar(1);
+
+                if (Character::isNewline($second)) {
+                    $this->scanner->readChar();
+                    $this->scanner->readChar();
+
+                    if ($second === "\r") {
+                        $this->scanner->scanChar("\n");
+                    }
+                } else {
+                    $buffer->write($this->escapeCharacter());
+                }
+            } elseif ($next === '#') {
+                if ($this->scanner->peekChar(1) === '{') {
+                    $buffer->add($this->singleInterpolation());
+                } else {
+                    $buffer->write($this->scanner->readChar());
+                }
+            } else {
+                $buffer->write($this->scanner->readUtf8Char());
+            }
+        }
+
+        return new StringExpression($buffer->buildInterpolation($this->scanner->spanFrom($start)), true);
+    }
+
+    /**
+     * Consumes an expression that starts like an identifier.
+     */
+    protected function identifierLike(): Expression
+    {
+        $start = $this->scanner->getPosition();
+        $identifier = $this->interpolatedIdentifier();
+        $plain = $identifier->getAsPlain();
+
+        if ($plain !== null) {
+            if ($plain === 'if' && $this->scanner->peekChar() === '(') {
+                $invocation = $this->argumentInvocation();
+
+                return new IfExpression($invocation, $identifier->getSpan()->expand($invocation->getSpan()));
+            }
+
+            if ($plain === 'not') {
+                $this->whitespace();
+
+                return new UnaryOperationExpression(UnaryOperator::NOT, $this->singleExpression(), $identifier->getSpan());
+            }
+
+            $lower = strtolower($plain);
+
+            if ($this->scanner->peekChar() !== '(') {
+                switch ($plain) {
+                    case 'false':
+                        return new BooleanExpression(false, $identifier->getSpan());
+                    case 'null':
+                        return new NullExpression($identifier->getSpan());
+                    case 'true':
+                        return new BooleanExpression(true, $identifier->getSpan());
+                }
+
+                $color = Colors::colorNameToColor($lower);
+
+                if ($color !== null) {
+                    return new ColorExpression($color, $identifier->getSpan());
+                }
+            }
+
+            $specialFunction = $this->trySpecialFunction($lower, $start);
+
+            if ($specialFunction !== null) {
+                return $specialFunction;
+            }
+        }
+
+        switch ($this->scanner->peekChar()) {
+            case '.':
+                if ($this->scanner->peekChar(1) === '.') {
+                    return new StringExpression($identifier);
+                }
+
+                $this->scanner->readChar();
+
+                if ($plain !== null) {
+                    return $this->namespacedExpression($plain, $start);
+                }
+
+                $this->error("Interpolation isn't allowed in namespaces.", $identifier->getSpan());
+
+            case '(':
+                if ($plain === null) {
+                    return new InterpolatedFunctionExpression($identifier, $this->argumentInvocation(), $this->scanner->spanFrom($start));
+                }
+
+                return new FunctionExpression($plain, $this->argumentInvocation(), $this->scanner->spanFrom($start));
+
+            default:
+                return new StringExpression($identifier);
+        }
+    }
+
+    /**
+     * Consumes an expression after a namespace.
+     *
+     * This assumes the scanner is positioned immediately after the `.`. The
+     * $start should refer to the state at the beginning of the namespace.
+     */
+    protected function namespacedExpression(string $namespace, int $start): Expression
+    {
+        if ($this->scanner->peekChar() === '$') {
+            $name = $this->variableName();
+            $this->assertPublic($name, function () use ($start) {
+                return $this->scanner->spanFrom($start);
+            });
+
+            // TODO remove this when implementing modules
+            $this->error('Sass modules are not implemented yet.', $this->scanner->spanFrom($start));
+            // return new VariableExpression($name, $this->scanner->spanFrom($start), $plain);
+        }
+
+        // TODO remove this when implementing modules
+        $this->publicIdentifier();
+        $this->error('Sass modules are not implemented yet.', $this->scanner->spanFrom($start));
+        // return new FunctionExpression($this->publicIdentifier(), $this->argumentInvocation(), $this->scanner->spanFrom($start), $plain);
+
+    }
+
+    /**
+     * If $name is the name of a function with special syntax, consumes it.
+     *
+     * Otherwise, returns `null`. $start is the location before the beginning of $name.
+     */
+    protected function trySpecialFunction(string $name, int $start): ?Expression
+    {
+        $calculation = $this->scanner->peekChar() === '(' ? $this->tryCalculation($name, $start) : null;
+
+        if ($calculation !== null) {
+            return $calculation;
+        }
+
+        $normalized = Util::unvendor($name);
+
+        switch ($normalized) {
+            case 'calc':
+            case 'element':
+            case 'expression':
+                if (!$this->scanner->scanChar('(')) {
+                    return null;
+                }
+
+                $buffer = new InterpolationBuffer();
+                $buffer->write($name);
+                $buffer->write('(');
+                break;
+
+            case 'progid':
+                if (!$this->scanner->scanChar(':')) {
+                    return null;
+                }
+
+                $buffer = new InterpolationBuffer();
+                $buffer->write($name);
+                $buffer->write(':');
+
+                $next = $this->scanner->peekChar();
+
+                while ($next !== null && (Character::isAlphabetic($next) || $next === '.')) {
+                    $buffer->write($this->scanner->readChar());
+                    $next = $this->scanner->peekChar();
+                }
+
+                $this->scanner->expectChar('(');
+                $buffer->write('(');
+                break;
+
+            case 'url':
+                $contents = $this->tryUrlContents($start);
+
+                if ($contents === null) {
+                    return null;
+                }
+
+                return new StringExpression($contents);
+
+            default:
+                return null;
+        }
+
+        $buffer->addInterpolation($this->interpolatedDeclarationValue(true));
+        $this->scanner->expectChar(')');
+        $buffer->write(')');
+
+        return new StringExpression($buffer->buildInterpolation($this->scanner->spanFrom($start)));
+    }
+
+    /**
+     * If $name is the name of a calculation expression, parses the
+     * corresponding calculation and returns it.
+     *
+     * Assumes the scanner is positioned immediately before the opening
+     * parenthesis of the argument list.
+     */
+    private function tryCalculation(string $name, int $start): ?CalculationExpression
+    {
+        assert($this->scanner->peekChar() === '(');
+
+        switch ($name) {
+            case 'calc':
+                $arguments = $this->calculationArguments(1);
+
+                return new CalculationExpression($name, $arguments, $this->scanner->spanFrom($start));
+
+            case 'min':
+            case 'max':
+                // min() and max() are parsed as calculations if possible, and otherwise
+                // are parsed as normal Sass functions.
+                $beforeArguments = $this->scanner->getPosition();
+
+                try {
+                    $arguments = $this->calculationArguments();
+                } catch (FormatException $e) {
+                    $this->scanner->setPosition($beforeArguments);
+
+                    return null;
+                }
+
+                return new CalculationExpression($name, $arguments, $this->scanner->spanFrom($start));
+
+            case 'clamp':
+                $arguments = $this->calculationArguments(3);
+
+                return new CalculationExpression($name, $arguments, $this->scanner->spanFrom($start));
+
+            default:
+                return null;
+        }
+    }
+
+    /**
+     * Consumes and returns arguments for a calculation expression, including the
+     * opening and closing parentheses.
+     *
+     * If $maxArgs is passed, at most that many arguments are consumed.
+     * Otherwise, any number greater than zero are consumed.
+     *
+     * @param int|null $maxArgs
+     *
+     * @return list<Expression>
+     *
+     * @throws FormatException
+     */
+    private function calculationArguments(?int $maxArgs = null): array
+    {
+        $this->scanner->expectChar('(');
+        $interpolation = $this->tryCalculationInterpolation();
+
+        if ($interpolation !== null) {
+            $this->scanner->expectChar(')');
+
+            return [$interpolation];
+        }
+
+        $this->whitespace();
+
+        $arguments = [$this->calculationSum()];
+
+        while (($maxArgs === null || \count($arguments) < $maxArgs) && $this->scanner->scanChar(',')) {
+            $this->whitespace();
+            $arguments[] = $this->calculationSum();
+        }
+
+        $this->scanner->expectChar(')', \count($arguments) === $maxArgs ? '"+", "-", "*", "/", or ")"' : '"+", "-", "*", "/", ",", or ")"');
+
+        return $arguments;
+    }
+
+    /**
+     * Parses a calculation operation or value expression.
+     */
+    private function calculationSum(): Expression
+    {
+        $sum = $this->calculationProduct();
+
+        while (true) {
+            $next = $this->scanner->peekChar();
+
+            if ($next === '+' || $next === '-') {
+                if (!Character::isWhitespace($this->scanner->peekChar(-1)) || !Character::isWhitespace($this->scanner->peekChar(1))) {
+                    $this->scanner->error('"+" and "-" must be surrounded by whitespace in calculations.');
+                }
+
+                $this->scanner->readChar();
+                $this->whitespace();
+                $sum = new BinaryOperationExpression(
+                    $next === '+' ? BinaryOperator::PLUS : BinaryOperator::MINUS,
+                    $sum,
+                    $this->calculationProduct()
+                );
+            } else {
+                return $sum;
+            }
+        }
+    }
+
+    /**
+     * Parses a calculation product or value expression.
+     */
+    private function calculationProduct(): Expression
+    {
+        $product = $this->calculationValue();
+
+        while (true) {
+            $this->whitespace();
+            $next = $this->scanner->peekChar();
+
+            if ($next === '*' || $next === '/') {
+                $this->scanner->readChar();
+                $this->whitespace();
+                $product = new BinaryOperationExpression(
+                    $next === '*' ? BinaryOperator::TIMES : BinaryOperator::DIVIDED_BY,
+                    $product,
+                    $this->calculationValue()
+                );
+            } else {
+                return $product;
+            }
+        }
+    }
+
+    /**
+     * Parses a single calculation value.
+     */
+    private function calculationValue(): Expression
+    {
+        $next = $this->scanner->peekChar();
+
+        if ($next === '+' || $next === '-' || $next === '.' || Character::isDigit($next)) {
+            return $this->number();
+        }
+
+        if ($next === '$') {
+            return $this->variable();
+        }
+
+        if ($next === '(') {
+            $start = $this->scanner->getPosition();
+            $this->scanner->readChar();
+
+            $value = $this->tryCalculationInterpolation();
+
+            if ($value === null) {
+                $this->whitespace();
+                $value = $this->calculationSum();
+            }
+
+            $this->whitespace();
+            $this->scanner->expectChar(')');
+
+            return new ParenthesizedExpression($value, $this->scanner->spanFrom($start));
+        }
+
+        if (!$this->lookingAtIdentifier()) {
+            $this->scanner->error('Expected number, variable, function, or calculation.');
+        }
+
+        $start = $this->scanner->getPosition();
+        $ident = $this->identifier();
+
+        if ($this->scanner->scanChar('.')) {
+            return $this->namespacedExpression($ident, $start);
+        }
+
+        if ($this->scanner->peekChar() !== '(') {
+            $this->scanner->error('Expected "(" or ".".');
+        }
+
+        $lowercase = strtolower($ident);
+        $calculation = $this->tryCalculation($lowercase, $start);
+
+        if ($calculation !== null) {
+            return $calculation;
+        }
+
+        if ($lowercase === 'if') {
+            return new IfExpression($this->argumentInvocation(), $this->scanner->spanFrom($start));
+        }
+
+        return new FunctionExpression($ident, $this->argumentInvocation(), $this->scanner->spanFrom($start));
+    }
+
+    /**
+     * If the following text up to the next unbalanced `")"`, `"]"`, or `"}"`
+     * contains interpolation, parses that interpolation as an unquoted
+     * {@see StringExpression} and returns it.
+     */
+    private function tryCalculationInterpolation(): ?StringExpression
+    {
+        return $this->containsCalculationInterpolation() ? new StringExpression($this->interpolatedDeclarationValue()) : null;
+    }
+
+    /**
+     * Returns whether the following text up to the next unbalanced `")"`, `"]"`,
+     * or `"}"` contains interpolation.
+     */
+    private function containsCalculationInterpolation(): bool
+    {
+        $parens = 0;
+        $brackets = [];
+
+        /**
+         * Scan manually rather than using {@see scanner} and saving and restoring its
+         * state to avoid the overhead of updating line and column information.
+         */
+        $string = $this->scanner->getString();
+
+        for ($i = $this->scanner->getPosition(); $i < \strlen($string); $i++) {
+            $next = $string[$i];
+
+            switch ($next) {
+                case '\\':
+                    $i++;
+                    break;
+
+                case '#':
+                    if ($parens === 0 && ($string[$i + 1] ?? '') === '{') {
+                        return true;
+                    }
+                    break;
+
+                case '(':
+                    $parens++;
+                    // fallthrough
+                case '{':
+                case '[':
+                    $brackets[] = Character::opposite($next);
+                    break;
+
+                case ')':
+                    $parens--;
+                    // fallthrough
+                case '}':
+                case ']':
+                    if (empty($brackets) || array_pop($brackets) !== $next) {
+                        return false;
+                    }
+                    break;
+            }
+        }
+
+        return false;
+    }
+
+    private function tryUrlContents(int $start, ?string $name = null): ?Interpolation
+    {
+        $beginningOfContents = $this->scanner->getPosition();
+
+        if (!$this->scanner->scanChar('(')) {
+            return null;
+        }
+        $this->whitespaceWithoutComments();
+
+        $buffer = new InterpolationBuffer();
+        $buffer->write($name ?? 'url');
+        $buffer->write('(');
+
+        while (true) {
+            $next = $this->scanner->peekChar();
+
+            if ($next === null) {
+                break;
+            }
+
+            if ($next === '\\') {
+                $buffer->write($this->escape());
+            } elseif ($next === '!' || $next === '%' || $next === '&' || (\ord($next) >= \ord('*') && \ord($next) <= \ord('~')) || \ord($next) >= 0x80) {
+                $buffer->write($this->scanner->readUtf8Char());
+            } elseif ($next === '#') {
+                if ($this->scanner->peekChar(1) === '{') {
+                    $buffer->add($this->singleInterpolation());
+                } else {
+                    $buffer->write($this->scanner->readChar());
+                }
+            } elseif (Character::isWhitespace($next)) {
+                $this->whitespaceWithoutComments();
+
+                if ($this->scanner->peekChar() !== ')') {
+                    break;
+                }
+            } elseif ($next === ')') {
+                $buffer->write($this->scanner->readChar());
+
+                return $buffer->buildInterpolation($this->scanner->spanFrom($start));
+            } else {
+                break;
+            }
+        }
+
+        $this->scanner->setPosition($beginningOfContents);
+
+        return null;
+    }
+
+    /**
+     * Consumes a `url` token that's allowed to contain SassScript.
+     */
+    protected function dynamicUrl(): Expression
+    {
+        $start = $this->scanner->getPosition();
+        $this->expectIdentifier('url');
+
+        $contents = $this->tryUrlContents($start);
+
+        if ($contents !== null) {
+            return new StringExpression($contents);
+        }
+
+        return new InterpolatedFunctionExpression(new Interpolation(['url'], $this->scanner->spanFrom($start)), $this->argumentInvocation(), $this->scanner->spanFrom($start));
+    }
+
+    /**
+     * Consumes tokens up to "{", "}", ";", or "!".
+     *
+     * This respects string and comment boundaries and supports interpolation.
+     * Once this interpolation is evaluated, it's expected to be re-parsed.
+     *
+     * If $omitComments is true, comments will still be consumed, but they will
+     * not be included in the returned interpolation.
+     *
+     * Differences from {@see interpolatedDeclarationValue} include:
+     *
+     * - This does not balance brackets.
+     * - This does not interpret backslashes, since the text is expected to be
+     *   re-parsed.
+     * - This supports Sass-style single-line comments.
+     * - This does not compress adjacent whitespace characters.
+     */
+    protected function almostAnyValue(bool $omitComments = false): Interpolation
+    {
+        $start = $this->scanner->getPosition();
+        $buffer = new InterpolationBuffer();
+
+        while (true) {
+            $next = $this->scanner->peekChar();
+
+            switch ($next) {
+                case '\\':
+                    // Write a literal backslash because this text will be re-parsed.
+                    $buffer->write($this->scanner->readChar());
+                    $buffer->write($this->scanner->readUtf8Char());
+                    break;
+
+                case '"':
+                case "'":
+                    $buffer->addInterpolation($this->interpolatedString()->asInterpolation());
+                    break;
+
+                case '/':
+                    $commentStart = $this->scanner->getPosition();
+
+                    if ($this->scanComment()) {
+                        if (!$omitComments) {
+                            $buffer->write($this->scanner->substring($commentStart));
+                        }
+                    } else {
+                        $buffer->write($this->scanner->readChar());
+                    }
+                    break;
+
+                case '#':
+                    if ($this->scanner->peekChar(1) === '{') {
+                        // Add a full interpolated identifier to handle cases like
+                        // "#{...}--1", since "--1" isn't a valid identifier on its own.
+                        $buffer->addInterpolation($this->interpolatedIdentifier());
+                    } else {
+                        $buffer->write($this->scanner->readChar());
+                    }
+                    break;
+
+                case "\r":
+                case "\n":
+                case "\f":
+                    if ($this->isIndented()) {
+                        break 2;
+                    }
+                    $buffer->write($this->scanner->readChar());
+                    break;
+
+                case '!':
+                case ';':
+                case '{':
+                case '}':
+                    break 2;
+
+                case 'u':
+                case 'U':
+                    $beforeUrl = $this->scanner->getPosition();
+
+                    if (!$this->scanIdentifier('url')) {
+                        $buffer->write($this->scanner->readChar());
+                        break;
+                    }
+
+                    $contents = $this->tryUrlContents($beforeUrl);
+
+                    if ($contents === null) {
+                        $this->scanner->setPosition($beforeUrl);
+                        $buffer->write($this->scanner->readChar());
+                    } else {
+                        $buffer->addInterpolation($contents);
+                    }
+                    break;
+
+                default:
+                    if ($next === null) {
+                        break 2;
+                    }
+
+                    if ($this->lookingAtIdentifier()) {
+                        $buffer->write($this->identifier());
+                    } else {
+                        $buffer->write($this->scanner->readUtf8Char());
+                    }
+                    break;
+            }
+        }
+
+        return $buffer->buildInterpolation($this->scanner->spanFrom($start));
+    }
+
+    /**
+     * Consumes tokens until it reaches a top-level `";"`, `")"`, `"]"`,
+     * or `"}"` and returns their contents as a string.
+     *
+     * If $allowEmpty is `false` (the default), this requires at least one token.
+     *
+     * If $allowSemicolon is `true`, this doesn't stop at semicolons and instead
+     * includes them in the interpolated output.
+     *
+     * If $allowColon is `false`, this stops at top-level colons.
+     *
+     * Unlike {@see declarationValue}, this allows interpolation.
+     */
+    private function interpolatedDeclarationValue(bool $allowEmpty = false, bool $allowSemicolon = false, bool $allowColon = true): Interpolation
+    {
+        $start = $this->scanner->getPosition();
+        $buffer = new InterpolationBuffer();
+        $brackets = [];
+        $wroteNewline = false;
+
+        while (true) {
+            $next = $this->scanner->peekChar();
+
+            if ($next === null) {
+                break;
+            }
+
+            switch ($next) {
+                case '\\':
+                    $buffer->write($this->escape(true));
+                    $wroteNewline = false;
+                    break;
+
+                case '"':
+                case "'":
+                    $buffer->addInterpolation($this->interpolatedString()->asInterpolation());
+                    $wroteNewline = false;
+                    break;
+
+                case '/':
+                    if ($this->scanner->peekChar(1) === '*') {
+                        $buffer->write($this->rawText([$this, 'loudComment']));
+                    } else {
+                        $buffer->write($this->scanner->readChar());
+                    }
+                    $wroteNewline = false;
+                    break;
+
+                case '#':
+                    if ($this->scanner->peekChar(1) === '{') {
+                        // Add a full interpolated identifier to handle cases like
+                        // "#{...}--1", since "--1" isn't a valid identifier on its own.
+                        $buffer->addInterpolation($this->interpolatedIdentifier());
+                    } else {
+                        $buffer->write($this->scanner->readChar());
+                    }
+                    $wroteNewline = false;
+                    break;
+
+                case ' ':
+                case "\t":
+                    $second = $this->scanner->peekChar(1);
+                    if ($wroteNewline || $second === null || !Character::isWhitespace($second)) {
+                        $buffer->write($this->scanner->readChar());
+                    } else {
+                        $this->scanner->readChar();
+                    }
+                    break;
+
+                case "\n":
+                case "\r":
+                case "\f":
+                    if ($this->isIndented()) {
+                        break 2;
+                    }
+                    $prev = $this->scanner->peekChar(-1);
+                    if ($prev === null || !Character::isNewline($prev)) {
+                        $buffer->write("\n");
+                    }
+                    $this->scanner->readChar();
+                    $wroteNewline = true;
+                    break;
+
+                case '(':
+                case '{':
+                case '[':
+                    $buffer->write($next);
+                    $brackets[] = Character::opposite($this->scanner->readChar());
+                    $wroteNewline = false;
+                    break;
+
+                case ')':
+                case '}':
+                case ']':
+                    if (empty($brackets)) {
+                        break 2;
+                    }
+
+                    $buffer->write($next);
+                    $this->scanner->expectChar(array_pop($brackets));
+                    $wroteNewline = false;
+                    break;
+
+                case ';':
+                    if (!$allowSemicolon && empty($brackets)) {
+                        break 2;
+                    }
+
+                    $buffer->write($this->scanner->readChar());
+                    $wroteNewline = false;
+                    break;
+
+                case ':':
+                    if (!$allowColon && empty($brackets)) {
+                        break 2;
+                    }
+
+                    $buffer->write($this->scanner->readChar());
+                    $wroteNewline = false;
+                    break;
+
+                case 'u':
+                case 'U':
+                    $beforeUrl = $this->scanner->getPosition();
+
+                    if (!$this->scanIdentifier('url')) {
+                        $buffer->write($this->scanner->readChar());
+                        $wroteNewline = false;
+                        break;
+
+                    }
+
+                    $contents = $this->tryUrlContents($beforeUrl);
+
+                    if ($contents === null) {
+                        $this->scanner->setPosition($beforeUrl);
+                        $buffer->write($this->scanner->readChar());
+                    } else {
+                        $buffer->addInterpolation($contents);
+                    }
+
+                    $wroteNewline = false;
+                    break;
+
+                default:
+                    if ($this->lookingAtIdentifier()) {
+                        $buffer->write($this->identifier());
+                    } else {
+                        $buffer->write($this->scanner->readUtf8Char());
+                    }
+                    $wroteNewline = false;
+                    break;
+            }
+        }
+
+        if (!empty($brackets)) {
+            $this->scanner->expectChar(array_pop($brackets));
+        }
+
+        if (!$allowEmpty && $buffer->isEmpty()) {
+            $this->scanner->error('Expected token.');
+        }
+
+        return $buffer->buildInterpolation($this->scanner->spanFrom($start));
+    }
+
+    /**
+     * Consumes an identifier that may contain interpolation.
+     */
+    protected function interpolatedIdentifier(): Interpolation
+    {
+        $start = $this->scanner->getPosition();
+        $buffer = new InterpolationBuffer();
+
+        if ($this->scanner->scanChar('-')) {
+            $buffer->write('-');
+
+            if ($this->scanner->scanChar('-')) {
+                $buffer->write('-');
+                $this->interpolatedIdentifierBody($buffer);
+
+                return $buffer->buildInterpolation($this->scanner->spanFrom($start));
+            }
+        }
+
+        $first = $this->scanner->peekChar();
+
+        if ($first === null) {
+            $this->scanner->error('Expected identifier.');
+        }
+
+        if (Character::isNameStart($first)) {
+            $buffer->write($this->scanner->readUtf8Char());
+        } elseif ($first === '\\') {
+            $buffer->write($this->escape(true));
+        } elseif ($first === '#' && $this->scanner->peekChar(1) === '{') {
+            $buffer->add($this->singleInterpolation());
+        } else {
+            $this->scanner->error('Expected identifier.');
+        }
+
+        $this->interpolatedIdentifierBody($buffer);
+
+        return $buffer->buildInterpolation($this->scanner->spanFrom($start));
+    }
+
+    /**
+     * Consumes a chunk of a possibly-interpolated CSS identifier after the name
+     * start, and adds the contents to the $buffer buffer.
+     */
+    private function interpolatedIdentifierBody(InterpolationBuffer $buffer): void
+    {
+        while (true) {
+            $next = $this->scanner->peekChar();
+
+            if ($next === null) {
+                break;
+            }
+
+            if ($next === '_' || $next === '-' || Character::isAlphanumeric($next) || \ord($next) >= 0x80) {
+                $buffer->write($this->scanner->readUtf8Char());
+            } elseif ($next === '\\') {
+                $buffer->write($this->escape());
+            } elseif ($next === '#' && $this->scanner->peekChar(1) === '{') {
+                $buffer->add($this->singleInterpolation());
+            } else {
+                break;
+            }
+        }
+    }
+
+    /**
+     * Consumes interpolation.
+     */
+    protected function singleInterpolation(): Expression
+    {
+        $start = $this->scanner->getPosition();
+
+        $this->scanner->expect('#{');
+
+        $this->whitespace();
+
+        $contents = $this->expression();
+
+        $this->scanner->expectChar('}');
+
+        if ($this->isPlainCss()) {
+            $this->error('Interpolation isn\'t allowed in plain CSS.', $this->scanner->spanFrom($start));
+        }
+
+        return $contents;
+    }
+
+    /**
+     * Consumes a list of media queries.
+     */
+    private function mediaQueryList(): Interpolation
+    {
+        $start = $this->scanner->getPosition();
+        $buffer = new InterpolationBuffer();
+
+        while (true) {
+            $this->whitespace();
+            $this->mediaQuery($buffer);
+
+            if (!$this->scanner->scanChar(',')) {
+                break;
+            }
+
+            $buffer->write(', ');
+        }
+
+        return $buffer->buildInterpolation($this->scanner->spanFrom($start));
+    }
+
+    /**
+     * Consumes a single media query.
+     */
+    private function mediaQuery(InterpolationBuffer $buffer): void
+    {
+        if ($this->scanner->peekChar() !== '(') {
+            $buffer->addInterpolation($this->interpolatedIdentifier());
+            $this->whitespace();
+
+            if (!$this->lookingAtInterpolatedIdentifier()) {
+                // For example, "@media screen {".
+                return;
+            }
+
+            $buffer->write(' ');
+            $identifier = $this->interpolatedIdentifier();
+            $this->whitespace();
+
+            if (StringUtil::equalsIgnoreCase($identifier->getAsPlain(), 'and')) {
+                // For example, "@media screen and ..."
+                $buffer->write(' and ');
+            } else {
+                $buffer->addInterpolation($identifier);
+
+                if ($this->scanIdentifier('and')) {
+                    // For example, "@media only screen and ..."
+                    $this->whitespace();
+                    $buffer->write(' and ');
+                } else {
+                    // For example, "@media only screen {"
+                    return;
+                }
+            }
+        }
+
+        // We've consumed either `IDENTIFIER "and"` or
+        // `IDENTIFIER IDENTIFIER "and"`.
+
+        while (true) {
+            $this->whitespace();
+            $buffer->addInterpolation($this->mediaFeature());
+            $this->whitespace();
+
+            if (!$this->scanIdentifier('and')) {
+                break;
+            }
+
+            $buffer->write(' and ');
+        }
+    }
+
+    /**
+     * Consumes a media query feature.
+     */
+    private function mediaFeature(): Interpolation
+    {
+        if ($this->scanner->peekChar() === '#') {
+            $interpolation = $this->singleInterpolation();
+
+            return new Interpolation([$interpolation], $interpolation->getSpan());
+        }
+
+        $start = $this->scanner->getPosition();
+        $buffer = new InterpolationBuffer();
+        $this->scanner->expectChar('(');
+        $buffer->write('(');
+        $this->whitespace();
+
+        $buffer->add($this->expressionUntilComparison());
+
+        if ($this->scanner->scanChar(':')) {
+            $this->whitespace();
+            $buffer->write(': ');
+            $buffer->add($this->expression());
+        } else {
+            $next = $this->scanner->peekChar();
+
+            if ($next === '<' || $next === '>' || $next === '=') {
+                $buffer->write(' ');
+                $buffer->write($this->scanner->readChar());
+                if (($next === '<' || $next === '>') && $this->scanner->scanChar('=')) {
+                    $buffer->write('=');
+                }
+                $buffer->write(' ');
+
+                $this->whitespace();
+                $buffer->add($this->expressionUntilComparison());
+
+                if (($next === '<' || $next === '>') && $this->scanner->scanChar($next)) {
+                    $buffer->write(' ');
+                    $buffer->write($next);
+                    if ($this->scanner->scanChar('=')) {
+                        $buffer->write('=');
+                    }
+                    $buffer->write(' ');
+
+                    $this->whitespace();
+                    $buffer->add($this->expressionUntilComparison());
+                }
+            }
+        }
+
+        $this->scanner->expectChar(')');
+        $this->whitespace();
+        $buffer->write(')');
+
+        return $buffer->buildInterpolation($this->scanner->spanFrom($start));
+    }
+
+    /**
+     * Consumes an expression until it reaches a top-level `<`, `>`, or a `=`
+     * that's not `==`.
+     */
+    private function expressionUntilComparison(): Expression
+    {
+        return $this->expression(function () {
+            $next = $this->scanner->peekChar();
+
+            if ($next === '=') {
+                return $this->scanner->peekChar(1) !== '=';
+            }
+
+            return $next === '<' || $next === '>';
+        });
+    }
+
+    /**
+     * Consumes a `@supports` condition.
+     */
+    private function supportsCondition(): SupportsCondition
+    {
+        $start = $this->scanner->getPosition();
+
+        if ($this->scanIdentifier('not')) {
+            $this->whitespace();
+
+            return new SupportsNegation($this->supportsConditionInParens(), $this->scanner->spanFrom($start));
+        }
+
+        $condition = $this->supportsConditionInParens();
+        $this->whitespace();
+        $operator = null;
+
+        while ($this->lookingAtIdentifier()) {
+            if ($operator !== null) {
+                $this->expectIdentifier($operator);
+            } elseif ($this->scanIdentifier('or')) {
+                $operator = 'or';
+            } else {
+                $this->expectIdentifier('and');
+                $operator = 'and';
+            }
+
+            $this->whitespace();
+            $right = $this->supportsConditionInParens();
+
+            $condition = new SupportsOperation($condition, $right, $operator, $this->scanner->spanFrom($start));
+            $this->whitespace();
+        }
+
+        return $condition;
+    }
+
+    /**
+     * Consumes a parenthesized supports condition, or an interpolation.
+     */
+    private function supportsConditionInParens(): SupportsCondition
+    {
+        $start = $this->scanner->getPosition();
+
+        if ($this->lookingAtInterpolatedIdentifier()) {
+            $identifier = $this->interpolatedIdentifier();
+
+            if ($identifier->getAsPlain() !== null && strtolower($identifier->getAsPlain()) === 'not') {
+                $this->error('"not" is not a valid identifier here.', $identifier->getSpan());
+            }
+
+            if ($this->scanner->scanChar('(')) {
+                $arguments = $this->interpolatedDeclarationValue(true, true);
+                $this->scanner->expectChar(')');
+
+                return new SupportsFunction($identifier, $arguments, $this->scanner->spanFrom($start));
+            }
+
+            if (\count($identifier->getContents()) !== 1 || !$identifier->getContents()[0] instanceof Expression) {
+                $this->error('Expected @supports condition.', $identifier->getSpan());
+            } else {
+                return new SupportsInterpolation($identifier->getContents()[0], $identifier->getSpan());
+            }
+        }
+
+        $this->scanner->expectChar('(');
+        $this->whitespace();
+
+        if ($this->scanIdentifier('not')) {
+            $this->whitespace();
+            $condition = $this->supportsConditionInParens();
+            $this->scanner->expectChar(')');
+
+            return new SupportsNegation($condition, $this->scanner->spanFrom($start));
+        }
+
+        if ($this->scanner->peekChar() === '(') {
+            $condition = $this->supportsCondition();
+            $this->scanner->expectChar(')');
+
+            return $condition;
+        }
+
+        // Unfortunately, we may have to backtrack here. The grammar is:
+        //
+        //       Expression ":" Expression
+        //     | InterpolatedIdentifier InterpolatedAnyValue?
+        //
+        // These aren't ambiguous because this `InterpolatedAnyValue` is forbidden
+        // from containing a top-level colon, but we still have to parse the full
+        // expression to figure out if there's a colon after it.
+        //
+        // We could avoid the overhead of a full expression parse by looking ahead
+        // for a colon (outside of balanced brackets), but in practice we expect the
+        // vast majority of real uses to be `Expression ":" Expression`, so it makes
+        // sense to parse that case faster in exchange for less code complexity and
+        // a slower backtracking case.
+
+        $nameStart = $this->scanner->getPosition();
+        $wasInParentheses = $this->inParentheses;
+
+        try {
+            $name = $this->expression();
+            $this->scanner->expectChar(':');
+        } catch (FormatException $e) {
+            $this->scanner->setPosition($nameStart);
+            $this->inParentheses = $wasInParentheses;
+
+            $identifier = $this->interpolatedIdentifier();
+            $operation = $this->trySupportsOperation($identifier, $nameStart);
+
+            if ($operation !== null) {
+                $this->scanner->expectChar(')');
+
+                return $operation;
+            }
+
+            // If parsing an expression fails, try to parse an
+            // `InterpolatedAnyValue` instead. But if that value runs into a
+            // top-level colon, then this is probably intended to be a declaration
+            // after all, so we rethrow the declaration-parsing error.
+            $buffer = new InterpolationBuffer();
+            $buffer->addInterpolation($identifier);
+            $buffer->addInterpolation($this->interpolatedDeclarationValue(true, true, false));
+
+            $contents = $buffer->buildInterpolation($this->scanner->spanFrom($nameStart));
+
+            if ($this->scanner->peekChar() === ':') {
+                throw $e;
+            }
+
+            $this->scanner->expectChar(')');
+
+            return new SupportsAnything($contents, $this->scanner->spanFrom($start));
+        }
+
+        $this->whitespace();
+        $value = $this->expression();
+        $this->scanner->expectChar(')');
+
+        return new SupportsDeclaration($name, $value, $this->scanner->spanFrom($start));
+    }
+
+    /**
+     * If $interpolation is followed by `"and"` or `"or"`, parse it as a supports operation.
+     *
+     * Otherwise, return `null` without moving the scanner position.
+     */
+    private function trySupportsOperation(Interpolation $interpolation, int $start): ?SupportsOperation
+    {
+        if (\count($interpolation->getContents()) !== 1) {
+            return null;
+        }
+
+        $expression = $interpolation->getContents()[0];
+
+        if (!$expression instanceof Expression) {
+            return null;
+        }
+
+        $beforeWhitespace = $this->scanner->getPosition();
+        $this->whitespace();
+
+        $operation = null;
+        $operator = null;
+
+        while ($this->lookingAtIdentifier()) {
+            if ($operator !== null) {
+                $this->expectIdentifier($operator);
+            } elseif ($this->scanIdentifier('and')) {
+                $operator = 'and';
+            } elseif ($this->scanIdentifier('or')) {
+                $operator = 'or';
+            } else {
+                $this->scanner->setPosition($beforeWhitespace);
+
+                return null;
+            }
+
+            $this->whitespace();
+            $right = $this->supportsConditionInParens();
+
+            $operation = new SupportsOperation($operation ?? new SupportsInterpolation($expression, $interpolation->getSpan()), $right, $operator, $this->scanner->spanFrom($start));
+            $this->whitespace();
+        }
+
+        return $operation;
+    }
+
+    /**
+     * Returns whether the scanner is immediately before an identifier that may
+     * contain interpolation.
+     *
+     * This is based on [the CSS algorithm][], but it assumes all backslashes
+     * start escapes and it considers interpolation to be valid in an identifier.
+     *
+     * [the CSS algorithm]: https://drafts.csswg.org/css-syntax-3/#would-start-an-identifier
+     */
+    private function lookingAtInterpolatedIdentifier(): bool
+    {
+        $first = $this->scanner->peekChar();
+
+        if ($first === null) {
+            return false;
+        }
+
+        if ($first === '\\' || Character::isNameStart($first)) {
+            return true;
+        }
+
+        if ($first === '#' && $this->scanner->peekChar(1) === '{') {
+            return true;
+        }
+
+        if ($first !== '-') {
+            return false;
+        }
+
+        $second = $this->scanner->peekChar(1);
+
+        if ($second === null) {
+            return false;
+        }
+
+        if ($second === '#') {
+            return $this->scanner->peekChar(2) === '{';
+        }
+
+        return $second === '\\' || $second === '-' || Character::isNameStart($second);
+    }
+
+    /**
+     * Returns whether the scanner is immediately before a sequence of characters
+     * that could be part of an CSS identifier body.
+     *
+     * The identifier body may include interpolation.
+     */
+    private function lookingAtInterpolatedIdentifierBody(): bool
+    {
+        $first = $this->scanner->peekChar();
+
+        if ($first === null) {
+            return false;
+        }
+
+        if ($first === '\\' || Character::isName($first)) {
+            return true;
+        }
+
+        return $first === '#' && $this->scanner->peekChar(1) === '{';
+    }
+
+    /**
+     * Returns whether the scanner is immediately before a SassScript expression.
+     */
+    private function lookingAtExpression(): bool
+    {
+        $character = $this->scanner->peekChar();
+
+        if ($character === null) {
+            return false;
+        }
+
+        if ($character === '.') {
+            return $this->scanner->peekChar(1) !== '.';
+        }
+
+        if ($character === '!') {
+            $next = $this->scanner->peekChar(1);
+
+            return $next === null || $next === 'i' || $next === 'I' || Character::isWhitespace($next);
+        }
+
+        return $character === '(' ||
+            $character === '/' ||
+            $character === '[' ||
+            $character === "'" ||
+            $character === '"' ||
+            $character === '#' ||
+            $character === '+' ||
+            $character === '-' ||
+            $character === '\\' ||
+            $character === '$' ||
+            $character === '&' ||
+            Character::isNameStart($character) ||
+            Character::isDigit($character);
+    }
+
+    /**
+     * Consumes a block of $child statements and passes them, as well as the
+     * span from $start to the end of the child block, to $create.
+     *
+     * @template T
+     * @param callable(): Statement $child
+     * @param callable(Statement[], FileSpan): T $create
+     * @return T
+     */
+    private function withChildren(callable $child, int $start, callable $create)
+    {
+        $children = $this->children($child);
+        $result = $create($children, $this->scanner->spanFrom($start));
+        $this->whitespaceWithoutComments();
+
+        return $result;
+    }
+
+    /**
+     * Like {@see identifier}, but rejects identifiers that begin with `_` or `-`.
+     */
+    private function publicIdentifier(): string
+    {
+        $start = $this->scanner->getPosition();
+        $result = $this->identifier(true);
+        $this->assertPublic($result, function () use ($start) {
+            return $this->scanner->spanFrom($start);
+        });
+
+        return $result;
+    }
+
+    /**
+     * Throws an error if $identifier isn't public.
+     *
+     * Calls $span to provide the span for an error if one occurs.
+     *
+     * @param callable(): FileSpan $span
+     */
+    private function assertPublic(string $identifier, callable $span): void
+    {
+        if (!Character::isPrivate($identifier)) {
+            return;
+        }
+
+        $this->error("Private members can't be accessed from outside their modules.", $span());
+    }
+
+    /**
+     * Whether this is parsing the indented syntax.
+     */
+    abstract protected function isIndented(): bool;
+
+    /**
+     * Whether this is a plain CSS stylesheet.
+     */
+    protected function isPlainCss(): bool
+    {
+        return false;
+    }
+
+    /**
+     * The indentation level at the current scanner position.
+     *
+     * This value isn't used directly by StylesheetParser; it's just passed to
+     * {@see scanElse}.
+     */
+    abstract protected function getCurrentIndentation(): int;
+
+    /**
+     * Parses and returns a selector used in a style rule.
+     */
+    abstract protected function styleRuleSelector(): Interpolation;
+
+    /**
+     * Asserts that the scanner is positioned before a statement separator, or at
+     * the end of a list of statements.
+     *
+     * If the name of the parent rule is passed, it's used for error reporting.
+     *
+     * This consumes whitespace, but nothing else, including comments.
+     *
+     * @throws FormatException
+     */
+    abstract protected function expectStatementSeparator(?string $name = null): void;
+
+    /**
+     * Whether the scanner is positioned at the end of a statement.
+     */
+    abstract protected function atEndOfStatement(): bool;
+
+    /**
+     * Whether the scanner is positioned before a block of children that can be
+     * parsed with {@see children}.
+     */
+    abstract protected function lookingAtChildren(): bool;
+
+    /**
+     * Tries to scan an `@else` rule after an `@if` block, and returns whether that succeeded.
+     *
+     * This should just scan the rule name, not anything afterwards.
+     * $ifIndentation is the result of {@see getCurrentIndentation} from before the
+     * corresponding `@if` was parsed.
+     */
+    abstract protected function scanElse(int $ifIndentation): bool;
+
+    /**
+     * Consumes a block of child statements.
+     *
+     * Unlike most production consumers, this does *not* consume trailing
+     * whitespace. This is necessary to ensure that the source span for the
+     * parent rule doesn't cover whitespace after the rule.
+     *
+     * @param callable(): Statement $child
+     *
+     * @return Statement[]
+     */
+    abstract protected function children(callable $child): array;
+
+    /**
+     * Consumes top-level statements.
+     *
+     * The $statement callback may return `null`, indicating that a statement
+     * was consumed that shouldn't be added to the AST.
+     *
+     * @param callable(): ?Statement $statement
+     *
+     * @return Statement[]
+     */
+    abstract protected function statements(callable $statement): array;
+}

--- a/src/SourceSpan/FileSpan.php
+++ b/src/SourceSpan/FileSpan.php
@@ -1,0 +1,131 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\SourceSpan;
+
+use ScssPhp\ScssPhp\Util\ErrorUtil;
+use ScssPhp\ScssPhp\Util\Path;
+
+/**
+ * @internal
+ */
+final class FileSpan
+{
+    /**
+     * @var SourceFile
+     * @readonly
+     */
+    private $file;
+
+    /**
+     * @var int
+     * @readonly
+     */
+    private $start;
+
+    /**
+     * @var int
+     * @readonly
+     */
+    private $end;
+
+    /**
+     * @param SourceFile $file
+     * @param int        $start The offset of the beginning of the span.
+     * @param int        $end   The offset of the end of the span.
+     */
+    public function __construct(SourceFile $file, int $start, int $end)
+    {
+        $this->file = $file;
+        $this->start = $start;
+        $this->end = $end;
+    }
+
+    public function getFile(): SourceFile
+    {
+        return $this->file;
+    }
+
+    public function getLength(): int
+    {
+        return $this->end - $this->start;
+    }
+
+    public function getStart(): SourceLocation
+    {
+        return new SourceLocation($this->file, $this->start);
+    }
+
+    public function getEnd(): SourceLocation
+    {
+        return new SourceLocation($this->file, $this->end);
+    }
+
+    public function getText(): string
+    {
+        return $this->file->getText($this->start, $this->end);
+    }
+
+    public function expand(FileSpan $other): FileSpan
+    {
+        if ($this->file->getSourceUrl() !== $other->file->getSourceUrl()) {
+            throw new \InvalidArgumentException('Source map URLs don\'t match.');
+        }
+
+        $start = min($this->start, $other->start);
+        $end = max($this->end, $other->end);
+
+        return new FileSpan($this->file, $start, $end);
+    }
+
+    /**
+     * Formats $message in a human-friendly way associated with this span.
+     *
+     * @param string $message
+     *
+     * @return string
+     */
+    public function message(string $message): string
+    {
+        $startLine = $this->getStart()->getLine() + 1;
+        $startColumn = $this->getStart()->getColumn() + 1;
+        $sourceUrl = $this->file->getSourceUrl();
+
+        $buffer = "line $startLine, column $startColumn";
+
+        if ($sourceUrl !== null) {
+            $prettyUri = Path::prettyUri($sourceUrl);
+            $buffer .= " of $prettyUri";
+        }
+
+        $buffer .= ": $message";
+
+        // TODO implement the highlighting of a code snippet
+
+        return $buffer;
+    }
+
+    /**
+     * Return a span from $start bytes (inclusive) to $end bytes
+     * (exclusive) after the beginning of this span
+     */
+    public function subspan(int $start, ?int $end = null): FileSpan
+    {
+        ErrorUtil::checkValidRange($start, $end, $this->getLength());
+
+        if ($start === 0 && ($end === null || $end === $this->getLength())) {
+            return $this;
+        }
+
+        return $this->file->span($this->start + $start, $end === null ? $this->end : $this->start + $end);
+    }
+}

--- a/src/SourceSpan/SourceFile.php
+++ b/src/SourceSpan/SourceFile.php
@@ -1,0 +1,209 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\SourceSpan;
+
+/**
+ * @internal
+ */
+final class SourceFile
+{
+    /**
+     * @var string
+     * @readonly
+     */
+    private $string;
+
+    /**
+     * @var string|null
+     * @readonly
+     */
+    private $sourceUrl;
+
+    /**
+     * @var int[]
+     * @readonly
+     */
+    private $lineStarts;
+
+    /**
+     * The 0-based last line that was returned by {@see getLine}
+     *
+     * This optimizes computation for successive accesses to
+     * the same line or to the next line.
+     * It is stored as 0-based to correspond to the indices
+     * in {@see $lineStarts}.
+     *
+     * @var int|null
+     */
+    private $cachedLine;
+
+    public function __construct(string $content, ?string $sourceUrl)
+    {
+        $this->string = $content;
+        $this->sourceUrl = $sourceUrl;
+
+        // Extract line starts
+        $this->lineStarts = [0];
+
+        if ($content === '') {
+            return;
+        }
+
+        $prev = 0;
+
+        while (($pos = strpos($content, "\n", $prev)) !== false) {
+            $this->lineStarts[] = $pos;
+            $prev = $pos + 1;
+        }
+
+        $this->lineStarts[] = \strlen($content);
+
+        if (substr($content, -1) !== "\n") {
+            $this->lineStarts[] = \strlen($content) + 1;
+        }
+    }
+
+    public function span(int $start, ?int $end = null): FileSpan
+    {
+        if ($end === null) {
+            $end = \strlen($this->string);
+        }
+
+        return new FileSpan($this, $start, $end);
+    }
+
+    public function getSourceUrl(): ?string
+    {
+        return $this->sourceUrl;
+    }
+
+    /**
+     * The 0-based line
+     *
+     * @param int $position
+     *
+     * @return int
+     */
+    public function getLine(int $position): int
+    {
+        if ($position < 0) {
+            throw new \RangeException('Position cannot be negative');
+        }
+
+        if ($position > \strlen($this->string)) {
+            throw new \RangeException('Position cannot be greater than the number of characters in the string.');
+        }
+
+        if ($this->isNearCacheLine($position)) {
+            assert($this->cachedLine !== null);
+
+            return $this->cachedLine;
+        }
+
+        $low = 0;
+        $high = \count($this->lineStarts);
+
+        while ($low < $high) {
+            $mid = (int) (($high + $low) / 2);
+
+            if ($position < $this->lineStarts[$mid]) {
+                $high = $mid - 1;
+                continue;
+            }
+
+            if ($position >= $this->lineStarts[$mid + 1]) {
+                $low = $mid + 1;
+                continue;
+            }
+
+            $this->cachedLine = $mid;
+
+            return $this->cachedLine;
+        }
+
+        $this->cachedLine = $low;
+
+        return $this->cachedLine;
+    }
+
+    /**
+     * Returns `true` if $position is near {@see $cachedLine}.
+     *
+     * Checks on {@see $cachedLine} and the next line. If it's on the next line, it
+     * updates {@see $cachedLine} to point to that.
+     *
+     * @param int $position
+     *
+     * @return bool
+     */
+    private function isNearCacheLine(int $position): bool
+    {
+        if ($this->cachedLine === null) {
+            return false;
+        }
+
+        if ($position < $this->lineStarts[$this->cachedLine]) {
+            return false;
+        }
+
+        if ($this->cachedLine >= \count($this->lineStarts) - 1 ||
+            $position < $this->lineStarts[$this->cachedLine + 1]
+        ) {
+            return true;
+        }
+
+        if ($this->cachedLine >= \count($this->lineStarts) - 2 ||
+            $position < $this->lineStarts[$this->cachedLine + 2]
+        ) {
+            ++$this->cachedLine;
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * The 0-based column of that position
+     *
+     * @param int $position
+     *
+     * @return int
+     */
+    public function getColumn(int $position): int
+    {
+        $line = $this->getLine($position);
+
+        return $position - $this->lineStarts[$line];
+    }
+
+    /**
+     * Returns the text of the file from $start to $end (exclusive).
+     *
+     * If $end isn't passed, it defaults to the end of the file.
+     */
+    public function getText(int $start, ?int $end = null): string
+    {
+        if ($end === null) {
+            return substr($this->string, $start);
+        }
+
+        if ($end < $start) {
+            $length = 0;
+        } else {
+            $length = $end - $start;
+        }
+
+        return substr($this->string, $start, $length);
+    }
+}

--- a/src/SourceSpan/SourceLocation.php
+++ b/src/SourceSpan/SourceLocation.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\SourceSpan;
+
+/**
+ * @internal
+ */
+final class SourceLocation
+{
+    /**
+     * @var SourceFile
+     * @readonly
+     */
+    private $file;
+
+    /**
+     * @var int
+     * @readonly
+     */
+    private $offset;
+
+    public function __construct(SourceFile $file, int $offset)
+    {
+        $this->file = $file;
+        $this->offset = $offset;
+    }
+
+    public function getFile(): SourceFile
+    {
+        return $this->file;
+    }
+
+    public function getOffset(): int
+    {
+        return $this->offset;
+    }
+
+    public function getLine(): int
+    {
+        return $this->file->getLine($this->offset);
+    }
+
+    public function getColumn(): int
+    {
+        return $this->file->getColumn($this->offset);
+    }
+}

--- a/src/Syntax.php
+++ b/src/Syntax.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp;
+
+final class Syntax
+{
+    /**
+     * The CSS-superset SCSS syntax.
+     */
+    const SCSS = 'scss';
+
+    /**
+     * The whitespace-sensitive indented syntax.
+     */
+    const SASS = 'sass';
+
+    /**
+     * The plain CSS syntax, which disallows special Sass features.
+     */
+    const CSS = 'css';
+
+    /**
+     * @return Syntax::*
+     */
+    public static function forPath(string $path): string
+    {
+        if (substr($path, -5) === '.sass') {
+            return self::SASS;
+        }
+
+        if (substr($path, -4) === '.css') {
+            return self::CSS;
+        }
+
+        return self::SCSS;
+    }
+}

--- a/src/Util.php
+++ b/src/Util.php
@@ -77,6 +77,40 @@ final class Util
     }
 
     /**
+     * Returns $name without a vendor prefix.
+     *
+     * If $name has no vendor prefix, it's returned as-is.
+     *
+     * @param string $name
+     *
+     * @return string
+     */
+    public static function unvendor(string $name): string
+    {
+        $length = \strlen($name);
+
+        if ($length < 2) {
+            return $name;
+        }
+
+        if ($name[0] !== '-') {
+            return $name;
+        }
+
+        if ($name[1] === '-') {
+            return $name;
+        }
+
+        for ($i = 2; $i < $length; $i++) {
+            if ($name[$i] === '-') {
+                return substr($name, $i + 1);
+            }
+        }
+
+        return $name;
+    }
+
+    /**
      * mb_chr() wrapper
      *
      * @param integer $code

--- a/src/Util/Character.php
+++ b/src/Util/Character.php
@@ -42,6 +42,14 @@ final class Character
     }
 
     /**
+     * Returns whether $character is a letter or a number.
+     */
+    public static function isAlphanumeric(string $character): bool
+    {
+        return self::isAlphabetic($character) || self::isDigit($character);
+    }
+
+    /**
      * Returns whether $character is a letter.
      */
     public static function isAlphabetic(string $character): bool
@@ -54,8 +62,12 @@ final class Character
     /**
      * Returns whether $character is a digit.
      */
-    public static function isDigit(string $character): bool
+    public static function isDigit(?string $character): bool
     {
+        if ($character === null) {
+            return false;
+        }
+
         $charCode = \ord($character);
 
         return $charCode >= \ord('0') && $charCode <= \ord('9');
@@ -80,8 +92,12 @@ final class Character
     /**
      * Returns whether $character is a hexadecimal digit.
      */
-    public static function isHex(string $character): bool
+    public static function isHex(?string $character): bool
     {
+        if ($character === null) {
+            return false;
+        }
+
         if (self::isDigit($character)) {
             return true;
         }
@@ -97,6 +113,18 @@ final class Character
         }
 
         return false;
+    }
+
+    /**
+     * Returns whether $identifier is module-private.
+     *
+     * Assumes $identifier is a valid Sass identifier.
+     */
+    public static function isPrivate(string $identifier): bool
+    {
+        $first = $identifier[0];
+
+        return $first === '-' || $first === '_';
     }
 
     /**

--- a/src/Util/Character.php
+++ b/src/Util/Character.php
@@ -18,6 +18,40 @@ namespace ScssPhp\ScssPhp\Util;
 final class Character
 {
     /**
+     * Returns whether $character is an ASCII whitespace character.
+     */
+    public static function isWhitespace(?string $character): bool
+    {
+        return $character === ' ' || $character === "\t" || $character === "\n" || $character === "\r" || $character === "\f";
+    }
+
+    /**
+     * Returns whether $character is a space or a tab character.
+     */
+    public static function isSpaceOrTab(?string $character): bool
+    {
+        return $character === ' ' || $character === "\t";
+    }
+
+    /**
+     * Returns whether $character is an ASCII newline character.
+     */
+    public static function isNewline(?string $character): bool
+    {
+        return $character === "\n" || $character === "\r" || $character === "\f";
+    }
+
+    /**
+     * Returns whether $character is a letter.
+     */
+    public static function isAlphabetic(string $character): bool
+    {
+        $charCode = \ord($character);
+
+        return ($charCode >= \ord('a') && $charCode <= \ord('z')) || ($charCode >= \ord('A') && $charCode <= \ord('Z'));
+    }
+
+    /**
      * Returns whether $character is a digit.
      */
     public static function isDigit(string $character): bool
@@ -25,6 +59,22 @@ final class Character
         $charCode = \ord($character);
 
         return $charCode >= \ord('0') && $charCode <= \ord('9');
+    }
+
+    /**
+     * Returns whether $character is legal as the start of a Sass identifier.
+     */
+    public static function isNameStart(string $character): bool
+    {
+        return $character === '_' || self::isAlphabetic($character) || \ord($character) >= 0x80;
+    }
+
+    /**
+     * Returns whether $character is legal in the body of a Sass identifier.
+     */
+    public static function isName(string $character): bool
+    {
+        return self::isNameStart($character) || self::isDigit($character) || $character === '-';
     }
 
     /**
@@ -47,5 +97,26 @@ final class Character
         }
 
         return false;
+    }
+
+    /**
+     * Assumes that $character is a left-hand brace-like character, and returns
+     * the right-hand version.
+     */
+    public static function opposite(string $character): string
+    {
+        switch ($character) {
+            case '(':
+                return ')';
+
+            case '{':
+                return '}';
+
+            case '[':
+                return ']';
+
+            default:
+                throw new \InvalidArgumentException(sprintf('Expected a brace character. Got "%s"', $character));
+        }
     }
 }

--- a/src/Util/ErrorUtil.php
+++ b/src/Util/ErrorUtil.php
@@ -28,4 +28,35 @@ class ErrorUtil
             throw new \OutOfRangeException("Invalid value:$nameDisplay must be between $minValue and $maxValue: $value.");
         }
     }
+
+    /**
+     * Check that a range represents a slice of an indexable object.
+     *
+     * Throws if the range is not valid for an indexable object with
+     * the given length.
+     * A range is valid for an indexable object with a given $length
+     * if `0 <= $start <= $end <= $length`.
+     * An `end` of `null` is considered equivalent to `length`.
+     *
+     * @throws \OutOfRangeException
+     */
+    public static function checkValidRange(int $start, ?int $end, int $length, ?string $startName = null, ?string $endName = null): void
+    {
+        if ($start < 0 || $start > $length) {
+            $startName = $startName ?? 'start';
+            $startNameDisplay = $startName ? " $startName" : '';
+
+            throw new \OutOfRangeException("Invalid value:$startNameDisplay must be between 0 and $length: $start.");
+        }
+
+        if ($end !== null) {
+
+            if ($end < $start || $end > $length) {
+                $endName = $endName ?? 'end';
+                $endNameDisplay = $endName ? " $endName" : '';
+
+                throw new \OutOfRangeException("Invalid value:$endNameDisplay must be between $start and $length: $end.");
+            }
+        }
+    }
 }

--- a/src/Util/ParserUtil.php
+++ b/src/Util/ParserUtil.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Util;
+
+use ScssPhp\ScssPhp\Parser\StringScanner;
+use ScssPhp\ScssPhp\Util;
+
+/**
+ * @internal
+ */
+final class ParserUtil
+{
+    /**
+     * Consumes an escape sequence from $scanner and returns the character it
+     * represents.
+     */
+    public static function consumeEscapedCharacter(StringScanner $scanner): string
+    {
+        // See https://drafts.csswg.org/css-syntax-3/#consume-escaped-code-point.
+        $scanner->expectChar('\\');
+
+        $first = $scanner->peekChar();
+
+        if ($first === null) {
+            return "\u{FFFD}";
+        }
+
+        if (Character::isNewline($first)) {
+            $scanner->error('Expected escape sequence.');
+        }
+
+        if (Character::isHex($first)) {
+            $value = 0;
+            for ($i = 0; $i < 6; $i++) {
+                $next = $scanner->peekChar();
+
+                if ($next === null || !Character::isHex($next)) {
+                    break;
+                }
+
+                $value *= 16;
+                $value += hexdec($scanner->readChar());
+                assert(\is_int($value));
+            }
+
+            if (Character::isWhitespace($scanner->peekChar())) {
+                $scanner->readChar();
+            }
+
+            if ($value === 0 || ($value >= 0xD800 && $value <= 0xDFFF) || $value >= 0x10FFFF) {
+                return "\u{FFFD}";
+            }
+
+            return Util::mbChr($value);
+        }
+
+        return $scanner->readUtf8Char();
+    }
+}

--- a/src/Util/Path.php
+++ b/src/Util/Path.php
@@ -74,4 +74,30 @@ final class Path
 
         return $part1 . $separator . $part2;
     }
+
+    /**
+     * Returns a pretty URI for a path
+     *
+     * @param string $path
+     *
+     * @return string
+     */
+    public static function prettyUri(string $path): string
+    {
+        $normalizedPath = $path;
+        $normalizedRootDirectory = getcwd().'/';
+
+        if (\DIRECTORY_SEPARATOR === '\\') {
+            $normalizedRootDirectory = str_replace('\\', '/', $normalizedRootDirectory);
+            $normalizedPath = str_replace('\\', '/', $path);
+        }
+
+        // TODO add support for returning a relative path using ../ in some cases, like Dart's path.prettyUri method
+
+        if (0 === strpos($normalizedPath, $normalizedRootDirectory)) {
+            return substr($path, \strlen($normalizedRootDirectory));
+        }
+
+        return $path;
+    }
 }

--- a/src/Util/SpanUtil.php
+++ b/src/Util/SpanUtil.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Util;
+
+use ScssPhp\ScssPhp\Parser\StringScanner;
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+
+/**
+ * @internal
+ */
+class SpanUtil
+{
+    /**
+     * Returns this span with all leading whitespace trimmed.
+     */
+    public static function trimLeft(FileSpan $span): FileSpan
+    {
+        $start = 0;
+        $text = $span->getText();
+        $textLength = \strlen($text);
+
+        while ($start < $textLength && Character::isWhitespace($text[$start])) {
+            $start++;
+        }
+
+        return $span->subspan($start);
+    }
+    /**
+     * Returns the span of the identifier at the start of this span.
+     *
+     * If $includeLeading is greater than 0, that many additional characters
+     * will be included from the start of this span before looking for an
+     * identifier.
+     */
+    public static function initialIdentifier(FileSpan $span, int $includeLeading = 0): FileSpan
+    {
+        $scanner = new StringScanner($span->getText());
+
+        for ($i = 0; $i < $includeLeading; $i++) {
+            $scanner->readUtf8Char();
+        }
+
+        self::scanIdentifier($scanner);
+
+        return $span->subspan(0, $scanner->getPosition());
+    }
+
+    /**
+     * Returns a subspan excluding the identifier at the start of this span.
+     */
+    public static function withoutInitialIdentifier(FileSpan $span): FileSpan
+    {
+        $scanner = new StringScanner($span->getText());
+        self::scanIdentifier($scanner);
+
+        return $span->subspan($scanner->getPosition());
+    }
+
+    /**
+     * Returns a subspan excluding a namespace and `.` at the start of this span.
+     */
+    public static function withoutNamespace(FileSpan $span): FileSpan
+    {
+        return self::withoutInitialIdentifier($span)->subspan(1);
+    }
+
+    /**
+     * Returns a subspan excluding an initial at-rule and any whitespace after
+     * it.
+     */
+    public static function withoutInitialAtRule(FileSpan $span): FileSpan
+    {
+        $scanner = new StringScanner($span->getText());
+        $scanner->expectChar('@');
+        self::scanIdentifier($scanner);
+
+        return self::trimLeft($span->subspan($scanner->getPosition()));
+    }
+
+    /**
+     * Consumes an identifier from $scanner.
+     */
+    private static function scanIdentifier(StringScanner $scanner): void
+    {
+        while (!$scanner->isDone()) {
+            $char = $scanner->peekChar();
+
+            if ($char === '\\') {
+                ParserUtil::consumeEscapedCharacter($scanner);
+            } elseif ($char !== null && Character::isName($char)) {
+                $scanner->readUtf8Char();
+            } else {
+                break;
+            }
+        }
+    }
+}

--- a/src/Util/StringUtil.php
+++ b/src/Util/StringUtil.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Util;
+
+/**
+ * @internal
+ */
+final class StringUtil
+{
+    /**
+     * Checks whether $haystack ends with $needle.
+     *
+     * This is a userland implementation of `str_ends_with` of PHP 8+.
+     *
+     * @param string $haystack
+     * @param string $needle
+     *
+     * @return bool
+     */
+    public static function endsWith(string $haystack, string $needle): bool
+    {
+        if (\PHP_VERSION_ID >= 80000) {
+            return str_ends_with($haystack, $needle);
+        }
+
+        return '' === $needle || ('' !== $haystack && 0 === substr_compare($haystack, $needle, -\strlen($needle)));
+    }
+
+    /**
+     * Returns whether $string1 and $string2 are equal, ignoring ASCII case.
+     *
+     * @param string|null $string1
+     * @param string      $string2
+     *
+     * @return bool
+     */
+    public static function equalsIgnoreCase(?string $string1, string $string2): bool
+    {
+        if ($string1 === $string2) {
+            return true;
+        }
+
+        if ($string1 === null) {
+            return false;
+        }
+
+        return self::toAsciiLowerCase($string1) === self::toAsciiLowerCase($string2);
+    }
+
+    /**
+     * Converts all ASCII chars to lowercase in the input string.
+     *
+     * This does not uses `strtolower` because `strtolower` is locale-dependant
+     * rather than operating on ASCII.
+     * Passing an input string in an encoding that it is not ASCII compatible is
+     * unsupported, and will probably generate garbage.
+     *
+     * @param string $string
+     *
+     * @return string
+     */
+    public static function toAsciiLowerCase(string $string): string
+    {
+        return strtr($string, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz');
+    }
+}

--- a/src/Visitor/ExpressionVisitor.php
+++ b/src/Visitor/ExpressionVisitor.php
@@ -1,0 +1,126 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Visitor;
+
+use ScssPhp\ScssPhp\Ast\Sass\Expression\BinaryOperationExpression;
+use ScssPhp\ScssPhp\Ast\Sass\Expression\BooleanExpression;
+use ScssPhp\ScssPhp\Ast\Sass\Expression\CalculationExpression;
+use ScssPhp\ScssPhp\Ast\Sass\Expression\ColorExpression;
+use ScssPhp\ScssPhp\Ast\Sass\Expression\FunctionExpression;
+use ScssPhp\ScssPhp\Ast\Sass\Expression\IfExpression;
+use ScssPhp\ScssPhp\Ast\Sass\Expression\InterpolatedFunctionExpression;
+use ScssPhp\ScssPhp\Ast\Sass\Expression\ListExpression;
+use ScssPhp\ScssPhp\Ast\Sass\Expression\MapExpression;
+use ScssPhp\ScssPhp\Ast\Sass\Expression\NullExpression;
+use ScssPhp\ScssPhp\Ast\Sass\Expression\NumberExpression;
+use ScssPhp\ScssPhp\Ast\Sass\Expression\ParenthesizedExpression;
+use ScssPhp\ScssPhp\Ast\Sass\Expression\SelectorExpression;
+use ScssPhp\ScssPhp\Ast\Sass\Expression\StringExpression;
+use ScssPhp\ScssPhp\Ast\Sass\Expression\UnaryOperationExpression;
+use ScssPhp\ScssPhp\Ast\Sass\Expression\ValueExpression;
+use ScssPhp\ScssPhp\Ast\Sass\Expression\VariableExpression;
+
+/**
+ * An interface for visitors that traverse SassScript expressions.
+ *
+ * @internal
+ *
+ * @template T
+ */
+interface ExpressionVisitor
+{
+    /**
+     * @return T
+     */
+    public function visitBinaryOperationExpression(BinaryOperationExpression $node);
+
+    /**
+     * @return T
+     */
+    public function visitBooleanExpression(BooleanExpression $node);
+
+    /**
+     * @return T
+     */
+    public function visitCalculationExpression(CalculationExpression $node);
+
+    /**
+     * @return T
+     */
+    public function visitColorExpression(ColorExpression $node);
+
+    /**
+     * @return T
+     */
+    public function visitInterpolatedFunctionExpression(InterpolatedFunctionExpression $node);
+
+    /**
+     * @return T
+     */
+    public function visitFunctionExpression(FunctionExpression $node);
+
+    /**
+     * @return T
+     */
+    public function visitIfExpression(IfExpression $node);
+
+    /**
+     * @return T
+     */
+    public function visitListExpression(ListExpression $node);
+
+    /**
+     * @return T
+     */
+    public function visitMapExpression(MapExpression $node);
+
+    /**
+     * @return T
+     */
+    public function visitNullExpression(NullExpression $node);
+
+    /**
+     * @return T
+     */
+    public function visitNumberExpression(NumberExpression $node);
+
+    /**
+     * @return T
+     */
+    public function visitParenthesizedExpression(ParenthesizedExpression $node);
+
+    /**
+     * @return T
+     */
+    public function visitSelectorExpression(SelectorExpression $node);
+
+    /**
+     * @return T
+     */
+    public function visitStringExpression(StringExpression $node);
+
+    /**
+     * @return T
+     */
+    public function visitUnaryOperationExpression(UnaryOperationExpression $node);
+
+    /**
+     * @return T
+     */
+    public function visitValueExpression(ValueExpression $node);
+
+    /**
+     * @return T
+     */
+    public function visitVariableExpression(VariableExpression $node);
+}

--- a/src/Visitor/StatementSearchVisitor.php
+++ b/src/Visitor/StatementSearchVisitor.php
@@ -1,0 +1,415 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Visitor;
+
+use ScssPhp\ScssPhp\Ast\Sass\Argument;
+use ScssPhp\ScssPhp\Ast\Sass\ArgumentInvocation;
+use ScssPhp\ScssPhp\Ast\Sass\Expression;
+use ScssPhp\ScssPhp\Ast\Sass\Import;
+use ScssPhp\ScssPhp\Ast\Sass\Import\StaticImport;
+use ScssPhp\ScssPhp\Ast\Sass\Interpolation;
+use ScssPhp\ScssPhp\Ast\Sass\Statement;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\AtRootRule;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\AtRule;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\CallableDeclaration;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\ContentBlock;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\ContentRule;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\DebugRule;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\Declaration;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\EachRule;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\ErrorRule;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\ExtendRule;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\ForRule;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\FunctionRule;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\IfClause;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\IfRule;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\ImportRule;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\IncludeRule;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\LoudComment;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\MediaRule;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\MixinRule;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\ParentStatement;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\ReturnRule;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\SilentComment;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\StyleRule;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\Stylesheet;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\SupportsRule;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\VariableDeclaration;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\WarnRule;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\WhileRule;
+use ScssPhp\ScssPhp\Ast\Sass\SupportsCondition;
+use ScssPhp\ScssPhp\Ast\Sass\SupportsCondition\SupportsDeclaration;
+use ScssPhp\ScssPhp\Ast\Sass\SupportsCondition\SupportsInterpolation;
+use ScssPhp\ScssPhp\Ast\Sass\SupportsCondition\SupportsNegation;
+use ScssPhp\ScssPhp\Ast\Sass\SupportsCondition\SupportsOperation;
+
+/**
+ * A StatementVisitor whose `visit*` methods default to returning `null`, but
+ * which returns the first non-`null` value returned by any method.
+ *
+ * This can be extended to find the first instance of particular nodes in the
+ * AST.
+ *
+ * @internal
+ *
+ * @template T
+ * @template-implements StatementVisitor<T|null>
+ */
+abstract class StatementSearchVisitor implements StatementVisitor
+{
+    public function visitAtRootRule(AtRootRule $node)
+    {
+        if ($node->getQuery() !== null) {
+            $result = $this->visitInterpolation($node->getQuery());
+
+            if ($result !== null) {
+                return $result;
+            }
+        }
+
+        return $this->visitChildren($node->getChildren());
+    }
+
+    public function visitAtRule(AtRule $node)
+    {
+        $value = $this->visitInterpolation($node->getName());
+
+        if ($node->getValue() !== null) {
+            $value = $value ?? $this->visitInterpolation($node->getValue());
+        }
+
+        if ($node->getChildren() !== null) {
+            $value = $value ?? $this->visitChildren($node->getChildren());
+        }
+
+        return $value;
+    }
+
+    public function visitContentBlock(ContentBlock $node)
+    {
+        return $this->visitCallableDeclaration($node);
+    }
+
+    public function visitContentRule(ContentRule $node)
+    {
+        return $this->visitArgumentInvocation($node->getArguments());
+    }
+
+    public function visitDebugRule(DebugRule $node)
+    {
+        return $this->visitExpression($node->getExpression());
+    }
+
+    public function visitDeclaration(Declaration $node)
+    {
+        $value = $this->visitInterpolation($node->getName());
+
+        if ($node->getValue() !== null) {
+            $value = $value ?? $this->visitExpression($node->getValue());
+        }
+
+        if ($node->getChildren() !== null) {
+            $value = $value ?? $this->visitChildren($node->getChildren());
+        }
+
+        return $value;
+    }
+
+    public function visitEachRule(EachRule $node)
+    {
+        return $this->visitExpression($node->getList()) ?? $this->visitChildren($node->getChildren());
+    }
+
+    public function visitErrorRule(ErrorRule $node)
+    {
+        return $this->visitExpression($node->getExpression());
+    }
+
+    public function visitExtendRule(ExtendRule $node)
+    {
+        return $this->visitInterpolation($node->getSelector());
+    }
+
+    public function visitForRule(ForRule $node)
+    {
+        return $this->visitExpression($node->getFrom()) ?? $this->visitExpression($node->getTo()) ?? $this->visitChildren($node->getChildren());
+    }
+
+    public function visitFunctionRule(FunctionRule $node)
+    {
+        return $this->visitCallableDeclaration($node);
+    }
+
+    public function visitIfRule(IfRule $node)
+    {
+        $value = $this->searchIterable($node->getClauses(), function (IfClause $clause) {
+            return $this->visitExpression($clause->getExpression()) ?? $this->visitChildren($clause->getChildren());
+        });
+
+        if ($node->getLastClause() !== null) {
+            $value = $value ?? $this->visitChildren($node->getLastClause()->getChildren());
+        }
+
+        return $value;
+    }
+
+    public function visitImportRule(ImportRule $node)
+    {
+        return $this->searchIterable($node->getImports(), function (Import $import) {
+            if ($import instanceof StaticImport) {
+                $value = $this->visitInterpolation($import->getUrl());
+
+                if ($import->getSupports() !== null) {
+                    $value = $value ?? $this->visitSupportsCondition($import->getSupports());
+                }
+
+                if ($import->getMedia() !== null) {
+                    $value = $value ?? $this->visitInterpolation($import->getMedia());
+                }
+
+                return $value;
+            }
+
+            return null;
+        });
+    }
+
+    public function visitIncludeRule(IncludeRule $node)
+    {
+        $value = $this->visitArgumentInvocation($node->getArguments());
+
+        if ($value !== null) {
+            return $value;
+        }
+
+        if ($node->getContent() !== null) {
+            return $this->visitContentBlock($node->getContent());
+        }
+
+        return null;
+    }
+
+    public function visitLoudComment(LoudComment $node)
+    {
+        return $this->visitInterpolation($node->getText());
+    }
+
+    public function visitMediaRule(MediaRule $node)
+    {
+        return $this->visitInterpolation($node->getQuery()) ?? $this->visitChildren($node->getChildren());
+    }
+
+    public function visitMixinRule(MixinRule $node)
+    {
+        return $this->visitCallableDeclaration($node);
+    }
+
+    public function visitReturnRule(ReturnRule $node)
+    {
+        return $this->visitExpression($node->getExpression());
+    }
+
+    public function visitSilentComment(SilentComment $node)
+    {
+        return null;
+    }
+
+    public function visitStyleRule(StyleRule $node)
+    {
+        return $this->visitInterpolation($node->getSelector()) ?? $this->visitChildren($node->getChildren());
+    }
+
+    public function visitStylesheet(Stylesheet $node)
+    {
+        return $this->visitChildren($node->getChildren());
+    }
+
+    public function visitSupportsRule(SupportsRule $node)
+    {
+        return $this->visitSupportsCondition($node->getCondition()) ?? $this->visitChildren($node->getChildren());
+    }
+
+    public function visitVariableDeclaration(VariableDeclaration $node)
+    {
+        return $this->visitExpression($node->getExpression());
+    }
+
+    public function visitWarnRule(WarnRule $node)
+    {
+        return $this->visitExpression($node->getExpression());
+    }
+
+    public function visitWhileRule(WhileRule $node)
+    {
+        return $this->visitExpression($node->getCondition()) ?? $this->visitChildren($node->getChildren());
+    }
+
+    /**
+     * Visits each of $node's expressions and children.
+     *
+     * The default implementations of {@see visitFunctionRule} and {@see visitMixinRule}
+     * call this.
+     *
+     * @return T|null
+     */
+    protected function visitCallableDeclaration(CallableDeclaration $node)
+    {
+        return $this->searchIterable($node->getArguments()->getArguments(), function (Argument $argument) {
+            if ($argument->getDefaultValue() === null) {
+                return null;
+            }
+
+            return $this->visitExpression($argument->getDefaultValue());
+        }) ?? $this->visitChildren($node->getChildren());
+    }
+
+    /**
+     * Visits each expression in an invocation.
+     *
+     * The default implementation of the visit methods calls this to visit any
+     * argument invocation in a statement.
+     *
+     * @return T|null
+     */
+    protected function visitArgumentInvocation(ArgumentInvocation $invocation)
+    {
+        $value = $this->searchIterable($invocation->getPositional(), [$this, 'visitExpression'])
+            ?? $this->searchIterable($invocation->getNamed(), [$this, 'visitExpression']);
+
+        if ($value !== null) {
+            return $value;
+        }
+
+        if ($invocation->getRest() !== null) {
+            $value = $this->visitExpression($invocation->getRest());
+
+            if ($value !== null) {
+                return $value;
+            }
+        }
+
+        if ($invocation->getKeywordRest() !== null) {
+            return $this->visitExpression($invocation->getKeywordRest());
+        }
+
+        return null;
+    }
+
+    /**
+     * Visits each expression in $condition.
+     *
+     * The default implementation of the visit methods call this to visit any
+     * {@see SupportsCondition} they encounter.
+     *
+     * @return T|null
+     */
+    protected function visitSupportsCondition(SupportsCondition $condition)
+    {
+        if ($condition instanceof SupportsOperation) {
+            return $this->visitSupportsCondition($condition->getLeft()) ?? $this->visitSupportsCondition($condition->getRight());
+        }
+
+        if ($condition instanceof SupportsNegation) {
+            return $this->visitSupportsCondition($condition->getCondition());
+        }
+
+        if ($condition instanceof SupportsInterpolation) {
+            return $this->visitExpression($condition->getExpression());
+        }
+
+        if ($condition instanceof SupportsDeclaration) {
+            return $this->visitExpression($condition->getName()) ?? $this->visitExpression($condition->getValue());
+        }
+
+        return null;
+    }
+
+    /**
+     * Visits each child in $children.
+     *
+     * The default implementation of the visit methods for all {@see ParentStatement}s
+     * call this.
+     *
+     * @param Statement[] $children
+     *
+     * @return T|null
+     */
+    protected function visitChildren(array $children)
+    {
+        foreach ($children as $child) {
+            $result = $child->accepts($this);
+
+            if ($result !== null) {
+                return $result;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Visits each expression in an interpolation.
+     *
+     * The default implementation of the visit methods call this to visit any
+     * interpolation in a statement.
+     *
+     * @return T|null
+     */
+    protected function visitInterpolation(Interpolation $interpolation)
+    {
+        foreach ($interpolation->getContents() as $node) {
+            if ($node instanceof Expression) {
+                $result = $this->visitExpression($node);
+
+                if ($result !== null) {
+                    return $result;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Visits an expression
+     *
+     * @return T|null
+     */
+    protected function visitExpression(Expression $expression)
+    {
+        return null;
+    }
+
+    /**
+     * Returns the first `T` returned by $callback for an element of $iterable,
+     * or `null` if it returns `null` for every element.
+     *
+     * @template E
+     * @param iterable<E> $iterable
+     * @param callable(E): (T|null) $callback
+     *
+     * @return T|null
+     */
+    private function searchIterable(iterable $iterable, callable $callback)
+    {
+        foreach ($iterable as $element) {
+            $value = $callback($element);
+
+            if ($value !== null) {
+                return $value;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Visitor/StatementVisitor.php
+++ b/src/Visitor/StatementVisitor.php
@@ -1,0 +1,174 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Visitor;
+
+use ScssPhp\ScssPhp\Ast\Sass\Statement\AtRootRule;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\AtRule;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\ContentBlock;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\ContentRule;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\DebugRule;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\Declaration;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\EachRule;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\ErrorRule;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\ExtendRule;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\ForRule;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\FunctionRule;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\IfRule;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\ImportRule;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\IncludeRule;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\LoudComment;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\MediaRule;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\MixinRule;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\ReturnRule;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\SilentComment;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\StyleRule;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\Stylesheet;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\SupportsRule;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\VariableDeclaration;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\WarnRule;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\WhileRule;
+
+/**
+ * An interface for visitors that traverse SassScript statements.
+ *
+ * @internal
+ *
+ * @template T
+ */
+interface StatementVisitor
+{
+    /**
+     * @return T
+     */
+    public function visitAtRootRule(AtRootRule $node);
+
+    /**
+     * @return T
+     */
+    public function visitAtRule(AtRule $node);
+
+    /**
+     * @return T
+     */
+    public function visitContentBlock(ContentBlock $node);
+
+    /**
+     * @return T
+     */
+    public function visitContentRule(ContentRule $node);
+
+    /**
+     * @return T
+     */
+    public function visitDebugRule(DebugRule $node);
+
+    /**
+     * @return T
+     */
+    public function visitDeclaration(Declaration $node);
+
+    /**
+     * @return T
+     */
+    public function visitEachRule(EachRule $node);
+
+    /**
+     * @return T
+     */
+    public function visitErrorRule(ErrorRule $node);
+
+    /**
+     * @return T
+     */
+    public function visitExtendRule(ExtendRule $node);
+
+    /**
+     * @return T
+     */
+    public function visitForRule(ForRule $node);
+
+    /**
+     * @return T
+     */
+    public function visitFunctionRule(FunctionRule $node);
+
+    /**
+     * @return T
+     */
+    public function visitIfRule(IfRule $node);
+
+    /**
+     * @return T
+     */
+    public function visitImportRule(ImportRule $node);
+
+    /**
+     * @return T
+     */
+    public function visitIncludeRule(IncludeRule $node);
+
+    /**
+     * @return T
+     */
+    public function visitLoudComment(LoudComment $node);
+
+    /**
+     * @return T
+     */
+    public function visitMediaRule(MediaRule $node);
+
+    /**
+     * @return T
+     */
+    public function visitMixinRule(MixinRule $node);
+
+    /**
+     * @return T
+     */
+    public function visitReturnRule(ReturnRule $node);
+
+    /**
+     * @return T
+     */
+    public function visitSilentComment(SilentComment $node);
+
+    /**
+     * @return T
+     */
+    public function visitStyleRule(StyleRule $node);
+
+    /**
+     * @return T
+     */
+    public function visitStylesheet(Stylesheet $node);
+
+    /**
+     * @return T
+     */
+    public function visitSupportsRule(SupportsRule $node);
+
+    /**
+     * @return T
+     */
+    public function visitVariableDeclaration(VariableDeclaration $node);
+
+    /**
+     * @return T
+     */
+    public function visitWarnRule(WarnRule $node);
+
+    /**
+     * @return T
+     */
+    public function visitWhileRule(WhileRule $node);
+}

--- a/tests/SassSpecTest.php
+++ b/tests/SassSpecTest.php
@@ -13,6 +13,7 @@
 namespace ScssPhp\ScssPhp\Tests;
 
 use PHPUnit\Framework\TestCase;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\Stylesheet;
 use ScssPhp\ScssPhp\Compiler;
 use ScssPhp\ScssPhp\Exception\SassException;
 use ScssPhp\ScssPhp\Logger\StreamLogger;
@@ -251,6 +252,12 @@ class SassSpecTest extends TestCase
 
         if (false !== strpos($fullInputs, '@forward ') || false !== strpos($fullInputs, '@use ')) {
             $this->markTestSkipped('Sass modules are not supported.');
+        }
+
+        // Our new parser is a port of the dart-sass one, so it should be able to parse all non-error specs
+        // without triggering a parsing error.
+        if (!$error && !preg_match('/:todo:\n *+- dart-sass\n/', $options) && !\in_array($this->canonicalTestName($name), ['directives/forward/escaped', 'directives/use/escaped'])) {
+            Stylesheet::parseScss($scss, null, 'input.scss');
         }
 
         if (! getenv('TEST_SASS_SPEC') && $this->matchExclusionList($name, $this->getExclusionList())) {

--- a/vendor-bin/phpstan/composer.json
+++ b/vendor-bin/phpstan/composer.json
@@ -3,6 +3,7 @@
         "sort-packages": true
     },
     "require": {
-        "phpstan/phpstan": "^0.12.98"
+        "phpstan/phpstan": "^0.12.98",
+        "symfony/polyfill-php80": "^1.23"
     }
 }


### PR DESCRIPTION
This is a full rewrite of the stylesheet parser by porting the dart-sass one (`@use` and `@forward` are not implemented for now, but usage of namespaced members is parsed fully before throwing a proper error about modules not being implemented yet).

This new parser outputs a proper Sass AST. I also ported part of the SourceSpan Dart package to represent spans of the original source. This will allow us to have a much better error reporting in the future (but I haven't implemented the rendering of code snippets associated to the spans yet, this is left for a next PR).

TODOs:
- [ ] use this new parser in the Compiler
- [ ] figure out the impact on the parser cache
- [ ] figure out how to deal with interpolation (converting the Sass AST to our legacy representation to delay rewriting the evaluation layer might not be possible, as the legacy way to represent interpolation is totally flawed)
- [ ] remove the old parsing code
- [x] deal with phpstan reporting a few weird things

Closes #413