### PR TITLE
Add a warning when extending a compound selector

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -3072,6 +3072,21 @@ class Compiler
                             $selectors = $this->multiplySelectors($this->env, $child['selfParent']);
                         }
 
+                        if (\count($result) > 1) {
+                            $replacement = implode(', ', $result);
+                            $fname = $this->getPrettyPath($this->sourceNames[$this->sourceIndex]);
+                            $line = $this->sourceLine;
+
+                            $message = <<<EOL
+on line $line of $fname:
+Compound selectors may no longer be extended.
+Consider `@extend $replacement` instead.
+See http://bit.ly/ExtendCompound for details.
+EOL;
+
+                            $this->logger->warn($message);
+                        }
+
                         $this->pushExtends($result, $selectors, $child);
                     }
                 }


### PR DESCRIPTION
dart-sass does not implement extending a compound selector, because the way the spec explains the intent of `@extends` would mean that `@extends .foo.bar` should be the same than `@extends .foo, .bar`.
libsass implements its own behavior when extending a compound selector, which is not compatible with the intent of the `@extends` spec, and reports a deprecation warning.
scssphp implements something similar to libsass, without actually being the same (partially caused by the fact that our whole `@extends` implementation is not spec compliant).

This implements the same deprecation warning than libsass, suggesting to use `@extends .foo, .bar` instead of the compound selector `.foo.bar`. In practice, if the expected output was the old libsass one rather than the one corresponding to the spirit of the spec, migrating to extending a placeholder might be needed instead.

This PR targets the 1.x branch to release it as 1.6.0. The goal is that 2.0 can turn this into an error (as done in dart-sass), which will avoid us to find a way to preserve support for a non-standard extension of compound selectors for the whole life of 2.x (and will unlock rewriting the `@extends` layer based on the dart-sass implementation in a future 2.y release to become spec compliant for supported cases).