### PR TITLE
Remove the pscss CLI from the package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,6 +5,7 @@ MAINTENANCE.md export-ignore
 .github/ export-ignore
 .gitignore export-ignore
 .travis.yml export-ignore
+bin/ export-ignore
 docs/ export-ignore
 phpstan*.neon export-ignore
 phpunit.xml.dist export-ignore

--- a/composer.json
+++ b/composer.json
@@ -82,7 +82,6 @@
             }
         }
     ],
-    "bin": ["bin/pscss"],
     "config": {
         "sort-packages": true
     }


### PR DESCRIPTION
The CLI is still there in the repository as a maintenance tool allowing to run the compiler to test it. However, the intended usage of the package is to use the compiler programmatically. Projects able to rely on a CLI tool to compile their Scss files should rather use the official Sass CLI instead.

Closes #417 