### PR TITLE
Remove outdated sourcemap option

### DIFF
--- a/docs/docs/README.md
+++ b/docs/docs/README.md
@@ -135,9 +135,6 @@ use ScssPhp\ScssPhp\Compiler;
 $compiler = new Compiler();
 $compiler->setSourceMap(Compiler::SOURCE_MAP_FILE);
 $compiler->setSourceMapOptions([
-    // absolute path to write .map file
-    'sourceMapWriteTo'  => '/var/www/vhost/my-style.map',
-
     // relative or full url to the above .map file
     'sourceMapURL' => './my-style.map',
 


### PR DESCRIPTION
This option is only used when using the legacy API (as it was writing the file to disk). But the doc is showing the modern API so the option has no effect other than introducing confusion.