### PR TITLE
Enhancing custom import functions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,3 +11,6 @@ phpstan*.neon export-ignore
 phpunit.xml.dist export-ignore
 tests/ export-ignore
 vendor-bin/ export-ignore
+tests/outputs/*.css text eol=lf
+tests/inputs/*.scss text eol=lf
+tests/inputs/imports/*.scss text eol=lf

--- a/docs/docs/extending/importers.md
+++ b/docs/docs/extending/importers.md
@@ -36,3 +36,26 @@ $compiler->addImportPath(function($path) {
 // will import 'stylesheets/sub.scss'
 echo $compiler->compileString('@import "sub.scss";')->getCss();
 ```
+
+Optional, the current `\ScssPhp\ScssPhp\Compiler` can be accessed with the
+second parameter. Allowing to retry the `findImport` function after correcting
+`$path`
+```php
+use ScssPhp\ScssPhp\Compiler;
+
+$compiler = new Compiler();
+$compiler->addImportPath(function($path, $compiler) {
+    if (Compiler::isCssImport($path)) {
+        return null;
+    }
+
+    if (substr($path, 0, 19) !== "thirdparty_package/") {
+        return null;
+    }
+
+    return $compiler->findImport(substr($path, 19), "path_to_thirdparty_package/");
+});
+
+// will import 'path_to_thirdparty_package/_variables.scss'
+echo $compiler->compileString('@import "thirdparty_package/variables";')->getCss();
+```

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -5294,7 +5294,7 @@ EOL;
      *
      * @return string|null
      */
-    private function findImport(string $url, ?string $currentDir = null): ?string
+    public function findImport(string $url, ?string $currentDir = null): ?string
     {
         // Vanilla css and external requests. These are not meant to be Sass imports.
         if (self::isCssImport($url)) {
@@ -5318,7 +5318,7 @@ EOL;
                 }
             } elseif (\is_callable($dir)) {
                 // check custom callback for import path
-                $file = \call_user_func($dir, $url);
+                $file = \call_user_func($dir, $url, $this);
 
                 if (! \is_null($file)) {
                     return $file;

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -113,7 +113,7 @@ class ApiTest extends TestCase
             return null;
         }
 
-        return $compiler->findImport("imports/".substr($path, 15));
+        return $compiler->findImport(substr($path, 15), __DIR__ . '/inputs/imports/');
     }
 
     public function testImportAbsolutePath()

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -76,7 +76,7 @@ class ApiTest extends TestCase
         );
     }
 
-    public function testImportCustomCallback()
+    public function testImportCustomCallbackOnlyPath()
     {
         $this->scss = new Compiler();
 
@@ -88,6 +88,32 @@ class ApiTest extends TestCase
             trim(file_get_contents(__DIR__ . '/outputs/variables.css')),
             $this->compile('@import "variables.foo";')
         );
+    }
+
+    public function testCustomImportCallback()
+    {
+        $this->scss = new Compiler();
+        $this->scss->addImportPath(__DIR__ . '/inputs/');
+
+        // Add custom callback to replace "custom_imports" by "imports" again.
+        $this->scss->addImportPath([$this, 'customImportCallback']);
+
+        // Get contents of inputs/import.scss and replace all "imports" directories to "custom_imports"
+        $cscc = file_get_contents(__DIR__ . '/inputs/import.scss');
+        $cscc = str_replace('"imports/', '"custom_imports/', $cscc);
+
+        $this->assertEquals(
+            trim(file_get_contents(__DIR__ . '/outputs/import.css')),
+            $this->compile($cscc)
+        );
+    }
+
+    public function customImportCallback($path, $compiler) {
+        if (substr($path, 0, 15) !== "custom_imports/") {
+            return null;
+        }
+
+        return $compiler->findImport("imports/".substr($path, 15));
     }
 
     public function testImportAbsolutePath()


### PR DESCRIPTION
Hi, I was encountering an issue where I wanted to import some parts of a thirdparty package (bootstrap) but that was checkout in such a way that it not really nice to read in my scss source files.
A bit context, i'm making a template engine which uses scss, but allows you to import parts of bootstrap.

What I wanted to work:
`@import "bootstrap/functions";`
The path of this functions file is:
`bootstrap\scss\_functions.scss`

With these changes, the `functions` part is now resolving to `_functions.scss`

I needed access to the `Compiler->findImport` function for this, so I'm not sure how this will work with the import caching mechanism. Or how this could be improved.

As a bonus, I force the input and output to have Linux style line-endings as I was having problems with the unittests on Windows.