### PR TITLE
Fix the CI job running without mbstring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,12 @@ jobs:
                     php-version: "${{ matrix.php }}"
                     extensions: "${{ matrix.extensions }}"
 
+            # PHPUnit 8.5.18+ and 9.5.7+ contains a runtime check for ext-mbstring, so we need to use an older version
+            # for running tests without ext-mbstring.
+            -   name: Force the PHPUnit version
+                if: ${{ matrix.extensions == ':mbstring' }}
+                run: composer require --dev --no-update phpunit/phpunit 9.5.6
+
             -   name: Install dependencies
                 # PHPUnit requires ext-mbstring. But it is only necessary for features that we don't currently use:
                 # - the testdox, JUnit and XML result printers

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -141,11 +141,6 @@ parameters:
 			path: src/Compiler.php
 
 		-
-			message: "#^Cannot access offset 1 on array\\<int, string\\>\\|false\\.$#"
-			count: 2
-			path: src/Compiler.php
-
-		-
 			message: "#^Cannot access property \\$assignSeparator on ScssPhp\\\\ScssPhp\\\\Formatter\\|string\\.$#"
 			count: 1
 			path: src/Compiler.php
@@ -193,6 +188,11 @@ parameters:
 		-
 			message: "#^If condition is always false\\.$#"
 			count: 1
+			path: src/Compiler.php
+
+		-
+			message: "#^Left side of && is always true\\.$#"
+			count: 2
 			path: src/Compiler.php
 
 		-
@@ -1457,7 +1457,7 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$stack of function array_shift expects array, array\\<int, string\\>\\|false given\\.$#"
-			count: 1
+			count: 2
 			path: src/Compiler.php
 
 		-
@@ -1467,6 +1467,11 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$string of function substr expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Compiler.php
+
+		-
+			message: "#^Parameter \\#1 \\$var of function count expects array\\|Countable, array\\<int, string\\>\\|false given\\.$#"
 			count: 1
 			path: src/Compiler.php
 
@@ -1597,12 +1602,22 @@ parameters:
 
 		-
 			message: "#^Right side of && is always true\\.$#"
+			count: 4
+			path: src/Compiler.php
+
+		-
+			message: "#^Variable \\$env might not be defined\\.$#"
 			count: 3
 			path: src/Compiler.php
 
 		-
 			message: "#^Variable \\$h might not be defined\\.$#"
 			count: 2
+			path: src/Compiler.php
+
+		-
+			message: "#^Variable \\$storeEnv might not be defined\\.$#"
+			count: 1
 			path: src/Compiler.php
 
 		-
@@ -2081,7 +2096,7 @@ parameters:
 			path: src/SourceMap/SourceMapGenerator.php
 
 		-
-			message: "#^Property ScssPhp\\\\ScssPhp\\\\SourceMap\\\\SourceMapGenerator\\:\\:\\$options \\(array\\('sourceRoot' \\=\\> string, 'sourceMapFilename' \\=\\> string\\|null, 'sourceMapURL' \\=\\> string\\|null, 'sourceMapWriteTo' \\=\\> string\\|null, 'outputSourceFiles' \\=\\> bool, 'sourceMapRootpath' \\=\\> string, 'sourceMapBasepath' \\=\\> string\\)\\) does not accept array\\<string, bool\\|string\\|null\\>\\.$#"
+			message: "#^Property ScssPhp\\\\ScssPhp\\\\SourceMap\\\\SourceMapGenerator\\:\\:\\$options \\(array\\('sourceRoot' \\=\\> string, 'sourceMapFilename' \\=\\> string\\|null, 'sourceMapURL' \\=\\> string\\|null, 'sourceMapWriteTo' \\=\\> string\\|null, 'outputSourceFiles' \\=\\> bool, 'sourceMapRootpath' \\=\\> string, 'sourceMapBasepath' \\=\\> string\\)\\) does not accept array\\<non\\-empty\\-string, bool\\|string\\|null\\>&nonEmpty\\.$#"
 			count: 1
 			path: src/SourceMap/SourceMapGenerator.php
 

--- a/vendor-bin/phpstan/composer.json
+++ b/vendor-bin/phpstan/composer.json
@@ -3,6 +3,6 @@
         "sort-packages": true
     },
     "require": {
-        "phpstan/phpstan": "^0.12.90"
+        "phpstan/phpstan": "^0.12.94"
     }
 }


### PR DESCRIPTION
PHPUnit has added a runtime check for the necessary extensions. As it needs the mbstring extension for some features (that we don't use), we need to use an older version that relied only on the composer requirement.