### PR TITLE
Make Node\Number compatible with PHP 8.1

### DIFF
--- a/src/Node/Number.php
+++ b/src/Node/Number.php
@@ -143,6 +143,7 @@ final class Number extends Node implements \ArrayAccess
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         if ($offset === -3) {
@@ -168,6 +169,7 @@ final class Number extends Node implements \ArrayAccess
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         switch ($offset) {
@@ -194,6 +196,7 @@ final class Number extends Node implements \ArrayAccess
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         throw new \BadMethodCallException('Number is immutable');
@@ -202,6 +205,7 @@ final class Number extends Node implements \ArrayAccess
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         throw new \BadMethodCallException('Number is immutable');


### PR DESCRIPTION
I can't update the GitHub Actions Workflow to include PHP 8.1, because one of phpunit's dependencies is not yet officially compatible with PHP 8.1. However I've hacked around this in a test branch in our repository: https://github.com/WoltLab/scssphp/pull/1. PHP 7.2 is broken there due to this hack, but should work for the actions in this official PR.

-----------------

> Return type of ScssPhp\ScssPhp\Node\Number::offsetExists($offset) should
> either be compatible with ArrayAccess::offsetExists(mixed $offset): bool, or
> the #[ReturnTypeWillChange] attribute should be used to temporarily suppress
> the notice

Adding the proper return types does not work, because PHP 7.x does not yet
support the `mixed` type that is needed for offsetGet().