### PR TITLE
Improve the handling of charset rules

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -221,6 +221,8 @@ class Compiler
     protected $storeEnv;
     /**
      * @var bool|null
+     *
+     * @deprecated
      */
     protected $charsetSeen;
     /**
@@ -463,7 +465,6 @@ class Compiler
         $this->env            = null;
         $this->scope          = null;
         $this->storeEnv       = null;
-        $this->charsetSeen    = null;
         $this->shouldEvaluate = null;
         $this->ignoreCallStackMessage = false;
         $this->parsedFiles = [];
@@ -516,11 +517,9 @@ class Compiler
 
             $prefix = '';
 
-            if (!$this->charsetSeen) {
-                if (strlen($out) !== Util::mbStrlen($out)) {
-                    $prefix = '@charset "UTF-8";' . "\n";
-                    $out = $prefix . $out;
-                }
+            if (strlen($out) !== Util::mbStrlen($out)) {
+                $prefix = '@charset "UTF-8";' . "\n";
+                $out = $prefix . $out;
             }
 
             $sourceMap = null;
@@ -2877,10 +2876,6 @@ class Compiler
                 break;
 
             case Type::T_CHARSET:
-                if (! $this->charsetSeen) {
-                    $this->charsetSeen = true;
-                    $this->appendRootDirective('@charset ' . $this->compileValue($child[1]) . ';', $out);
-                }
                 break;
 
             case Type::T_CUSTOM_PROPERTY:

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -194,6 +194,11 @@ class Compiler
     protected $sourceMapOptions = [];
 
     /**
+     * @var bool
+     */
+    private $charset = true;
+
+    /**
      * @var string|\ScssPhp\ScssPhp\Formatter
      */
     protected $formatter = Expanded::class;
@@ -517,7 +522,7 @@ class Compiler
 
             $prefix = '';
 
-            if (strlen($out) !== Util::mbStrlen($out)) {
+            if ($this->charset && strlen($out) !== Util::mbStrlen($out)) {
                 $prefix = '@charset "UTF-8";' . "\n";
                 $out = $prefix . $out;
             }
@@ -5491,6 +5496,25 @@ EOL;
     {
         @trigger_error('The line number output is not supported anymore. '
                        . 'Use source maps instead.', E_USER_DEPRECATED);
+    }
+
+    /**
+     * Configures the handling of non-ASCII outputs.
+     *
+     * If $charset is `true`, this will include a `@charset` declaration or a
+     * UTF-8 [byte-order mark][] if the stylesheet contains any non-ASCII
+     * characters. Otherwise, it will never include a `@charset` declaration or a
+     * byte-order mark.
+     *
+     * [byte-order mark]: https://en.wikipedia.org/wiki/Byte_order_mark#UTF-8
+     *
+     * @param bool $charset
+     *
+     * @return void
+     */
+    public function setCharset($charset)
+    {
+        $this->charset = $charset;
     }
 
     /**

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -232,6 +232,28 @@ class ApiTest extends TestCase
         ];
     }
 
+    public function testCompileWithoutCharset()
+    {
+        $this->scss = new Compiler();
+        $this->scss->setCharset(false);
+
+        self::assertEquals(
+            "a {\n  b: \"à\";\n}",
+            $this->compile('a { b: "à" }')
+        );
+    }
+
+    public function testCompileWithCharset()
+    {
+        $this->scss = new Compiler();
+        $this->scss->setCharset(true);
+
+        self::assertEquals(
+            "@charset \"UTF-8\";\na {\n  b: \"à\";\n}",
+            $this->compile('a { b: "à" }')
+        );
+    }
+
     public function testCompileByteOrderMarker()
     {
         $this->scss = new Compiler();

--- a/tests/outputs/directives.css
+++ b/tests/outputs/directives.css
@@ -1,4 +1,3 @@
-@charset "hello-world";
 @page :left {
   div {
     color: red;


### PR DESCRIPTION
- Fix the handling of `@charset` in source files, ignoring it properly
- Implement the `charset` option that was added in dart-sass recently to allow disabling the rendering of the `@charset "UTF-8";` prefix
- ~~Use an UTF-8 BOM as the prefix in compressed mode as it is shorter (this is what dart-sass does).~~ (not applied in 1.x)