### PR TITLE
Pin the phpstan version for the 1.x branch

### DIFF
--- a/vendor-bin/phpstan/composer.json
+++ b/vendor-bin/phpstan/composer.json
@@ -3,6 +3,6 @@
         "sort-packages": true
     },
     "require": {
-        "phpstan/phpstan": "^0.12.94"
+        "phpstan/phpstan": "0.12.94"
     }
 }


### PR DESCRIPTION
The 1.x codebase relies heavily on the baseline to ignore existing issues. But the baseline is sensitive to phpstan version changes, as new versions tend to improve the accuracy of error messages and so change
them.