### PR TITLE
Remove wrong deprecation warnings about unterminated interpolation

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -1580,7 +1580,9 @@ class Parser
                     } else {
                         list($line, $column) = $this->getSourcePosition($this->count);
                         $file = $this->sourceName;
-                        $this->logger->warn("Unterminated interpolations in multiline comments are deprecated and will be removed in ScssPhp 2.0, in \"$file\", line $line, column $column.", true);
+                        if (!$this->discardComments) {
+                            $this->logger->warn("Unterminated interpolations in multiline comments are deprecated and will be removed in ScssPhp 2.0, in \"$file\", line $line, column $column.", true);
+                        }
                         $comment[] = substr($this->buffer, $this->count, 2);
 
                         $this->count += 2;


### PR DESCRIPTION
If comments are discarded rather than being added in the CSS output, unterminated interpolations are not an issue, as they are not interpolated.