### PR TITLE
Fix the pretty file path on Windows

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -5891,7 +5891,7 @@ EOL;
         }
 
         if (0 === strpos($normalizedPath, $normalizedRootDirectory)) {
-            return substr($normalizedPath, \strlen($normalizedRootDirectory));
+            return substr($path, \strlen($normalizedRootDirectory));
         }
 
         return $path;


### PR DESCRIPTION
The pretty path should still use the windows separator rather than the normalized one.