### PR TITLE
Improve the comparison script to normalize formatting

### DIFF
--- a/tests/compare-scss.sh
+++ b/tests/compare-scss.sh
@@ -7,14 +7,16 @@ for file in $(ls $test_dir/inputs/*.scss); do
 	out_file=$(echo $file | sed -e 's/inputs/outputs/' -e 's/\.scss$/\.css/')
 	sass=$(sass --no-source-map $file 2> /dev/null)
 	if [ $? = "0" ]; then
+	  # Perform the same normalization than SassSpecTest regarding formatting
+		normalized_sass=$(echo "$sass" | sed -e ':a' -e 'N' -e '$!ba' -e 's/}\n\n/}\n/g' -e 's/,\n/, /g')
 		# echo $file
 		# echo "$sass"
 		# echo
 
-		if [ "$(cat $out_file)" != "$sass" ]; then
+		if [ "$(cat $out_file)" != "$sass" ] && [ "$(cat $out_file)" != "$normalized_sass" ]; then
 			echo "* [FAIL]    $file"
 			if [ -n "$diff_tool" ]; then
-				$diff_tool $out_file <(echo "$sass") 2> /dev/null
+				$diff_tool $out_file <(echo "$normalized_sass") 2> /dev/null
 			fi
 		else
 			echo "  [PASS]    $file"


### PR DESCRIPTION
This applies the same normalization rules than in our SassSpecTest, making the script more lenient regarding the formatting rules.