### PR TITLE
Fix the implementation of color-adjusting functions

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -8460,9 +8460,9 @@ EOL;
     protected function libTransparentize($args)
     {
         $color = $this->assertColor($args[0], 'color');
-        $amount = $this->coercePercent($this->assertNumber($args[1], 'amount'));
+        $amount = $this->assertNumber($args[1], 'amount');
 
-        $color[4] = (isset($color[4]) ? $color[4] : 1) - $amount;
+        $color[4] = (isset($color[4]) ? $color[4] : 1) - $amount->valueInRange(0, 1, 'amount');
         $color[4] = min(1, max(0, $color[4]));
 
         return $color;

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -7228,9 +7228,13 @@ EOL;
      * @param array|Number $value
      *
      * @return integer|float
+     *
+     * @deprecated
      */
     protected function coercePercent($value)
     {
+        @trigger_error(sprintf('"%s" is deprecated since 1.7.0.', __METHOD__), E_USER_DEPRECATED);
+
         if ($value instanceof Number) {
             if ($value->hasUnit('%')) {
                 return $value->getDimension() / 100;

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -8326,6 +8326,12 @@ EOL;
     {
         $hsl = $this->toHSL($color[1], $color[2], $color[3]);
         $hsl[$idx] += $amount;
+
+        if ($idx !== 1) {
+            // Clamp the saturation and lightness
+            $hsl[$idx] = min(max(0, $hsl[$idx]), 100);
+        }
+
         $out = $this->toRGB($hsl[1], $hsl[2], $hsl[3]);
 
         if (isset($color[4])) {
@@ -8383,9 +8389,9 @@ EOL;
     protected function libDesaturate($args)
     {
         $color = $this->assertColor($args[0], 'color');
-        $amount = 100 * $this->coercePercent($this->assertNumber($args[1], 'amount'));
+        $amount = $this->assertNumber($args[1], 'amount');
 
-        return $this->adjustHsl($color, 2, -$amount);
+        return $this->adjustHsl($color, 2, -$amount->valueInRange(0, 100, 'amount'));
     }
 
     protected static $libGrayscale = ['color'];

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -8379,10 +8379,10 @@ EOL;
             return null;
         }
 
-        $color = $this->assertColor($value, 'color');
-        $amount = 100 * $this->coercePercent($this->assertNumber($args[1], 'amount'));
+        $color = $this->assertColor($args[0], 'color');
+        $amount = $this->assertNumber($args[1], 'amount');
 
-        return $this->adjustHsl($color, 2, $amount);
+        return $this->adjustHsl($color, 2, $amount->valueInRange(0, 100, 'amount'));
     }
 
     protected static $libDesaturate = ['color', 'amount'];

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -8441,9 +8441,9 @@ EOL;
     protected function libOpacify($args)
     {
         $color = $this->assertColor($args[0], 'color');
-        $amount = $this->coercePercent($this->assertNumber($args[1], 'amount'));
+        $amount = $this->assertNumber($args[1], 'amount');
 
-        $color[4] = (isset($color[4]) ? $color[4] : 1) + $amount;
+        $color[4] = (isset($color[4]) ? $color[4] : 1) + $amount->valueInRange(0, 1, 'amount');
         $color[4] = min(1, max(0, $color[4]));
 
         return $color;

--- a/tests/specs/sass-spec-exclude.txt
+++ b/tests/specs/sass-spec-exclude.txt
@@ -2,8 +2,6 @@ core_functions/color/alpha/error/quoted_string
 core_functions/color/alpha/error/type
 core_functions/color/alpha/error/unquoted_string/no_equals
 core_functions/color/alpha/error/unquoted_string/non_identifier_before_equals
-core_functions/color/fade_in/error/bounds/too_high
-core_functions/color/fade_in/error/bounds/too_low
 core_functions/color/fade_out/error/bounds/too_high
 core_functions/color/fade_out/error/bounds/too_low
 core_functions/color/hsl/error/four_args/hue/type

--- a/tests/specs/sass-spec-exclude.txt
+++ b/tests/specs/sass-spec-exclude.txt
@@ -114,8 +114,6 @@ core_functions/color/rgb/one_arg/special_functions/no_alpha/min/string/arg_3
 core_functions/color/rgb/one_arg/special_functions/no_alpha/var/arg_1
 core_functions/color/rgb/one_arg/special_functions/no_alpha/var/arg_2
 core_functions/color/rgb/one_arg/special_functions/no_alpha/var/arg_3
-core_functions/color/saturate/error/two_args/bounds/too_high
-core_functions/color/saturate/error/two_args/bounds/too_low
 core_functions/color/saturation/fraction
 core_functions/color/saturation/max
 core_functions/color/saturation/middle
@@ -930,7 +928,6 @@ non_conformant/basic/15_arithmetic_and_lists
 non_conformant/basic/23_basic_value_interpolation
 non_conformant/basic/41_slashy_urls
 non_conformant/basic/54_adjacent_identifiers_with_hyphens
-non_conformant/errors/fn-saturate-out-of-range
 non_conformant/errors/import/file/control-else
 non_conformant/errors/import/file/control-if
 non_conformant/errors/import/file/loop/each

--- a/tests/specs/sass-spec-exclude.txt
+++ b/tests/specs/sass-spec-exclude.txt
@@ -2,8 +2,6 @@ core_functions/color/alpha/error/quoted_string
 core_functions/color/alpha/error/type
 core_functions/color/alpha/error/unquoted_string/no_equals
 core_functions/color/alpha/error/unquoted_string/non_identifier_before_equals
-core_functions/color/fade_out/error/bounds/too_high
-core_functions/color/fade_out/error/bounds/too_low
 core_functions/color/hsl/error/four_args/hue/type
 core_functions/color/hsl/error/four_args/lightness/type
 core_functions/color/hsl/error/four_args/saturation/type

--- a/tests/specs/sass-spec-exclude.txt
+++ b/tests/specs/sass-spec-exclude.txt
@@ -2,8 +2,6 @@ core_functions/color/alpha/error/quoted_string
 core_functions/color/alpha/error/type
 core_functions/color/alpha/error/unquoted_string/no_equals
 core_functions/color/alpha/error/unquoted_string/non_identifier_before_equals
-core_functions/color/desaturate/error/bounds/too_high
-core_functions/color/desaturate/error/bounds/too_low
 core_functions/color/fade_in/error/bounds/too_high
 core_functions/color/fade_in/error/bounds/too_low
 core_functions/color/fade_out/error/bounds/too_high


### PR DESCRIPTION
This does the same kind of fix than for #462 but for other color functions that were badly mixing percentages and unitless numbers.