### PR TITLE
Use the UTF-8 BOM as prefix in compressed output

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -399,7 +399,11 @@ final class Compiler
             $prefix = '';
 
             if ($this->charset && strlen($out) !== Util::mbStrlen($out)) {
-                $prefix = '@charset "UTF-8";' . "\n";
+                if ($this->outputStyle === OutputStyle::COMPRESSED) {
+                    $prefix = "\u{FEFF}";
+                } else {
+                    $prefix = '@charset "UTF-8";' . "\n";
+                }
                 $out = $prefix . $out;
             }
 


### PR DESCRIPTION
This is consistent with the behavior of dart-sass. It produces an equivalent CSS (the CSS spec mentions that the UTF-8 BOM must be supported as a way to detect the UTF-8 charset) while being shorter. The charset rule is kept in expanded output as it is human-readable.