### PR TITLE
Add a deprecation warning when calling core functions with wrong names

### DIFF
--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -14,6 +14,7 @@ namespace ScssPhp\ScssPhp\Tests;
 
 use PHPUnit\Framework\TestCase;
 use ScssPhp\ScssPhp\Compiler;
+use ScssPhp\ScssPhp\Logger\StreamLogger;
 use ScssPhp\ScssPhp\Node\Number;
 use ScssPhp\ScssPhp\ValueConverter;
 use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
@@ -126,6 +127,98 @@ class ApiTest extends TestCase
             'result: 15;',
             $this->compile('result: divide($divisor: 2, $dividend: 30);')
         );
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testWrongCaseInFunctionName()
+    {
+        $this->scss = new Compiler();
+
+        $logStream = fopen("php://memory", 'r+');
+        assert($logStream !== false);
+        $this->scss->setLogger(new StreamLogger($logStream));
+
+        $this->expectDeprecation("Calling built-in functions with a non-standard name is deprecated since Scssphp 1.8.0 and will not work anymore in 2.0.\nUse \"fade-out\" instead of \"faDe-out\".");
+
+        $result = $this->compile('a { b: faDe-out(#e7e8ea, 0.75) }');
+
+        rewind($logStream);
+        $output = stream_get_contents($logStream);
+        fclose($logStream);
+
+        $this->assertEquals("a {\n  b: rgba(231, 232, 234, 0.25);\n}", $result);
+        $this->assertEquals("DEPRECATION WARNING: Calling built-in functions with a non-standard name is deprecated since Scssphp 1.8.0 and will not work anymore in 2.0.\nUse \"fade-out\" instead of \"faDe-out\".\n         on line 1 of (unknown file)", trim($output));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testWrongCaseAtBeginningOfFunctionName()
+    {
+        $this->scss = new Compiler();
+
+        $logStream = fopen("php://memory", 'r+');
+        assert($logStream !== false);
+        $this->scss->setLogger(new StreamLogger($logStream));
+
+        $this->expectDeprecation("Calling built-in functions with a non-standard name is deprecated since Scssphp 1.8.0 and will not work anymore in 2.0.\nUse \"fade-out\" instead of \"Fade-out\".");
+
+        $result = $this->compile('a { b: Fade-out(#e7e8ea, 0.75) }');
+
+        rewind($logStream);
+        $output = stream_get_contents($logStream);
+        fclose($logStream);
+
+        $this->assertEquals("a {\n  b: rgba(231, 232, 234, 0.25);\n}", $result);
+        $this->assertEquals("DEPRECATION WARNING: Calling built-in functions with a non-standard name is deprecated since Scssphp 1.8.0 and will not work anymore in 2.0.\nUse \"fade-out\" instead of \"Fade-out\".\n         on line 1 of (unknown file)", trim($output));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testOmittedDashInFunctionName()
+    {
+        $this->scss = new Compiler();
+
+        $logStream = fopen("php://memory", 'r+');
+        assert($logStream !== false);
+        $this->scss->setLogger(new StreamLogger($logStream));
+
+        $this->expectDeprecation("Calling built-in functions with a non-standard name is deprecated since Scssphp 1.8.0 and will not work anymore in 2.0.\nUse \"fade-out\" instead of \"fadeout\".");
+
+        $result = $this->compile('a { b: fadeout(#e7e8ea, 0.75) }');
+
+        rewind($logStream);
+        $output = stream_get_contents($logStream);
+        fclose($logStream);
+
+        $this->assertEquals("a {\n  b: rgba(231, 232, 234, 0.25);\n}", $result);
+        $this->assertEquals("DEPRECATION WARNING: Calling built-in functions with a non-standard name is deprecated since Scssphp 1.8.0 and will not work anymore in 2.0.\nUse \"fade-out\" instead of \"fadeout\".\n         on line 1 of (unknown file)", trim($output));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testAdditionalDashInFunctionName()
+    {
+        $this->scss = new Compiler();
+
+        $logStream = fopen("php://memory", 'r+');
+        assert($logStream !== false);
+        $this->scss->setLogger(new StreamLogger($logStream));
+
+        $this->expectDeprecation("Calling built-in functions with a non-standard name is deprecated since Scssphp 1.8.0 and will not work anymore in 2.0.\nUse \"transparentize\" instead of \"trans-parentize\".");
+
+        $result = $this->compile('a { b: trans-parentize(#e7e8ea, 0.75) }');
+
+        rewind($logStream);
+        $output = stream_get_contents($logStream);
+        fclose($logStream);
+
+        $this->assertEquals("a {\n  b: rgba(231, 232, 234, 0.25);\n}", $result);
+        $this->assertEquals("DEPRECATION WARNING: Calling built-in functions with a non-standard name is deprecated since Scssphp 1.8.0 and will not work anymore in 2.0.\nUse \"transparentize\" instead of \"trans-parentize\".\n         on line 1 of (unknown file)", trim($output));
     }
 
     public function testImportCustomCallback()


### PR DESCRIPTION
Due to the internal implementation of the function discovery for core functions, extra names were available for all functions with different positions of dashes/underscores in the function name (additional ones or omitted ones) or a different case. Those functions names are not standard and would be treated as CSS functions by official Sass implementations.

closes #477 