### PR TITLE
Simplify the foundation test

### DIFF
--- a/tests/FrameworkTest.php
+++ b/tests/FrameworkTest.php
@@ -63,19 +63,11 @@ SCSS;
     public function testFoundation()
     {
         $compiler = new Compiler();
-        $compiler->addImportPath(dirname(__DIR__) . '/vendor/zurb/foundation/scss');
         $compiler->setLogger(new QuietLogger());
 
-        // The Foundation entrypoint only define mixins. To get a useful compilation
-        // executing their code, we need to actually use the mixin.
-        $scss = <<<'SCSS'
-@import "settings/settings";
-@import "foundation";
+        $entrypoint = dirname(__DIR__) . '/vendor/zurb/foundation/assets/foundation.scss';
 
-@include foundation-everything;
-SCSS;
-
-        $result = $compiler->compileString($scss);
+        $result = $compiler->compileString(file_get_contents($entrypoint), $entrypoint);
 
         $this->assertNotEmpty($result->getCss());
     }


### PR DESCRIPTION
foundation actually contains asset files generating CSS, so we don't need to make our own custom entrypoint.