### PR TITLE
Allow passing the load-path option multiple times

### DIFF
--- a/bin/pscss
+++ b/bin/pscss
@@ -26,7 +26,7 @@ use ScssPhp\ScssPhp\Parser;
 use ScssPhp\ScssPhp\Version;
 
 $style = null;
-$loadPaths = null;
+$loadPaths = [];
 $dumpTree = false;
 $inputFile = null;
 $changeDir = false;
@@ -148,7 +148,7 @@ EOT;
     $value = parseArgument($i, array('-I', '--load-path'));
 
     if (isset($value)) {
-        $loadPaths = $value;
+        $loadPaths[] = $value;
         continue;
     }
 
@@ -188,7 +188,7 @@ if ($dumpTree) {
 $scss = new Compiler();
 
 if ($loadPaths) {
-    $scss->setImportPaths(explode(PATH_SEPARATOR, $loadPaths));
+    $scss->setImportPaths($loadPaths);
 }
 
 if ($style) {


### PR DESCRIPTION
This is the way this option works in official sass implementation, rather than our approach relying on PATH_SEPARATOR. Making the CLI consistent is useful for using it as a drop-in replacement for testing purposes.