### PR TITLE
Add tests against the Bourbon framework

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
         "sass/sass-spec": "*",
         "squizlabs/php_codesniffer": "~3.5",
         "symfony/phpunit-bridge": "^5.1",
+        "thoughtbot/bourbon": "^7.0",
         "twbs/bootstrap": "~5.0",
         "twbs/bootstrap4": "4.6.0",
         "zurb/foundation": "~6.5"
@@ -59,6 +60,24 @@
                     "type": "zip",
                     "url": "https://api.github.com/repos/sass/sass-spec/zipball/eb2d7a0865c1faf0b55a39ff962b24aca9b4c955",
                     "reference": "eb2d7a0865c1faf0b55a39ff962b24aca9b4c955",
+                    "shasum": ""
+                }
+            }
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "thoughtbot/bourbon",
+                "version": "v7.0.0",
+                "source": {
+                    "type": "git",
+                    "url": "https://github.com/thoughtbot/bourbon.git",
+                    "reference": "fbe338ee6807e7f7aa996d82c8a16f248bb149b3"
+                },
+                "dist": {
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/thoughtbot/bourbon/zipball/fbe338ee6807e7f7aa996d82c8a16f248bb149b3",
+                    "reference": "fbe338ee6807e7f7aa996d82c8a16f248bb149b3",
                     "shasum": ""
                 }
             }

--- a/tests/FrameworkTest.php
+++ b/tests/FrameworkTest.php
@@ -71,4 +71,32 @@ SCSS;
 
         $this->assertNotEmpty($result->getCss());
     }
+
+    /**
+     * @dataProvider provideBourbonEntrypoints
+     */
+    public function testBourbon($entrypoint)
+    {
+        $compiler = new Compiler();
+        $compiler->setLogger(new QuietLogger());
+        $compiler->addImportPath(dirname(__DIR__) . '/vendor/thoughtbot/bourbon');
+        $compiler->addImportPath(dirname(__DIR__) . '/vendor/thoughtbot/bourbon/spec/fixtures');
+
+        $result = $compiler->compileString(file_get_contents($entrypoint), $entrypoint);
+
+        $this->assertNotEmpty($result->getCss());
+    }
+
+    public static function provideBourbonEntrypoints()
+    {
+        $iterator = new \RecursiveDirectoryIterator(dirname(__DIR__) . '/vendor/thoughtbot/bourbon/spec/fixtures', \FilesystemIterator::SKIP_DOTS);
+        $iterator = new \RecursiveCallbackFilterIterator($iterator, function (\SplFileInfo $current) {
+            return $current->isDir() || $current->getFilename()[0] !== '_';
+        });
+
+        /** @var \SplFileInfo $file */
+        foreach (new \RecursiveIteratorIterator($iterator) as $file) {
+            yield [$file->getRealPath()];
+        }
+    }
 }


### PR DESCRIPTION
This framework is also tested by the new CI jobs of dart-sass, alongside Foundation, Bootstrap 4 and Bootstrap 5 (that we already test) and Bulma (which uses the indented syntax and so not supported by scssphp).
As bourbon is a Sass framework providing mixins and functions rather than a CSS framework, we test it by compiling their test fixtures (as done by dart-sass).