### PR TITLE
Make the comparison script able to use sassc

### DIFF
--- a/tests/compare-scss.sh
+++ b/tests/compare-scss.sh
@@ -2,10 +2,11 @@
 
 test_dir=$(dirname $0)
 diff_tool="$1"
+sass_executable=${SASS_EXECUTABLE:-sass}
 
 for file in $(ls $test_dir/inputs/*.scss); do
 	out_file=$(echo $file | sed -e 's/inputs/outputs/' -e 's/\.scss$/\.css/')
-	sass=$(sass --no-source-map $file 2> /dev/null)
+	sass=$($sass_executable --style=expanded $file 2> /dev/null)
 	if [ $? = "0" ]; then
 	  # Perform the same normalization than SassSpecTest regarding formatting
 		normalized_sass=$(echo "$sass" | sed -e ':a' -e 'N' -e '$!ba' -e 's/}\n\n/}\n/g' -e 's/,\n/, /g')


### PR DESCRIPTION
The sass executable being used is now configurable through the `SASS_EXECUTABLE` environment variable, allowing to use `sassc` instead of `sass` for instance.
The options used when calling the executable are also restricted to options common to sassc and dart-sass (so no `--no-source-map` option, which was useless anyway as that's the default in dart-sass when writing the CSS to stdout) and the expanded style is configured explicitly (as that's not the default in libsass).

This makes it easier to assert our own expectation against official implementation, as it avoids having to edit the script.