### PR TITLE
Add support for PHP 8.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [ '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0' ]
+                php: [ '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1' ]
                 extensions: [ '' ]
                 os: [ubuntu-latest]
                 include:

--- a/src/Node/Number.php
+++ b/src/Node/Number.php
@@ -149,6 +149,7 @@ class Number extends Node implements \ArrayAccess
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         if ($offset === -3) {
@@ -174,6 +175,7 @@ class Number extends Node implements \ArrayAccess
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         switch ($offset) {
@@ -200,6 +202,7 @@ class Number extends Node implements \ArrayAccess
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         throw new \BadMethodCallException('Number is immutable');
@@ -208,6 +211,7 @@ class Number extends Node implements \ArrayAccess
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         throw new \BadMethodCallException('Number is immutable');


### PR DESCRIPTION
With PHP 8.1 being in RC, we need to support it in our 1.x branch, as 2.0 might not be released before PHP 8.1 becomes stable.

This backports https://github.com/scssphp/scssphp/pull/453 to the 1.x branch.