### PR TITLE
Enforce the usage of standard names for core functions

### DIFF
--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -17,7 +17,6 @@ use ScssPhp\ScssPhp\Compiler;
 use ScssPhp\ScssPhp\Logger\StreamLogger;
 use ScssPhp\ScssPhp\Node\Number;
 use ScssPhp\ScssPhp\ValueConverter;
-use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 
 /**
  * API test
@@ -26,8 +25,6 @@ use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
  */
 class ApiTest extends TestCase
 {
-    use ExpectDeprecationTrait;
-
     /**
      * @var Compiler
      */
@@ -80,9 +77,6 @@ class ApiTest extends TestCase
         );
     }
 
-    /**
-     * @group legacy
-     */
     public function testWrongCaseInFunctionName()
     {
         $this->scss = new Compiler();
@@ -91,21 +85,16 @@ class ApiTest extends TestCase
         assert($logStream !== false);
         $this->scss->setLogger(new StreamLogger($logStream));
 
-        $this->expectDeprecation("Calling built-in functions with a non-standard name is deprecated since Scssphp 1.8.0 and will not work anymore in 2.0 (they will be treated as CSS function calls instead).\nUse \"fade-out\" instead of \"faDe-out\".");
-
         $result = $this->compile('a { b: faDe-out(#e7e8ea, 0.75) }');
 
         rewind($logStream);
         $output = stream_get_contents($logStream);
         fclose($logStream);
 
-        $this->assertEquals("a {\n  b: rgba(231, 232, 234, 0.25);\n}", $result);
-        $this->assertEquals("DEPRECATION WARNING: Calling built-in functions with a non-standard name is deprecated since Scssphp 1.8.0 and will not work anymore in 2.0 (they will be treated as CSS function calls instead).\nUse \"fade-out\" instead of \"faDe-out\".\n         on line 1 of (unknown file)", trim($output));
+        $this->assertEquals("a {\n  b: faDe-out(#e7e8ea, 0.75);\n}", $result);
+        $this->assertEquals('', trim($output));
     }
 
-    /**
-     * @group legacy
-     */
     public function testWrongCaseAtBeginningOfFunctionName()
     {
         $this->scss = new Compiler();
@@ -114,21 +103,16 @@ class ApiTest extends TestCase
         assert($logStream !== false);
         $this->scss->setLogger(new StreamLogger($logStream));
 
-        $this->expectDeprecation("Calling built-in functions with a non-standard name is deprecated since Scssphp 1.8.0 and will not work anymore in 2.0 (they will be treated as CSS function calls instead).\nUse \"fade-out\" instead of \"Fade-out\".");
-
         $result = $this->compile('a { b: Fade-out(#e7e8ea, 0.75) }');
 
         rewind($logStream);
         $output = stream_get_contents($logStream);
         fclose($logStream);
 
-        $this->assertEquals("a {\n  b: rgba(231, 232, 234, 0.25);\n}", $result);
-        $this->assertEquals("DEPRECATION WARNING: Calling built-in functions with a non-standard name is deprecated since Scssphp 1.8.0 and will not work anymore in 2.0 (they will be treated as CSS function calls instead).\nUse \"fade-out\" instead of \"Fade-out\".\n         on line 1 of (unknown file)", trim($output));
+        $this->assertEquals("a {\n  b: Fade-out(#e7e8ea, 0.75);\n}", $result);
+        $this->assertEquals('', trim($output));
     }
 
-    /**
-     * @group legacy
-     */
     public function testOmittedDashInFunctionName()
     {
         $this->scss = new Compiler();
@@ -137,21 +121,16 @@ class ApiTest extends TestCase
         assert($logStream !== false);
         $this->scss->setLogger(new StreamLogger($logStream));
 
-        $this->expectDeprecation("Calling built-in functions with a non-standard name is deprecated since Scssphp 1.8.0 and will not work anymore in 2.0 (they will be treated as CSS function calls instead).\nUse \"fade-out\" instead of \"fadeout\".");
-
         $result = $this->compile('a { b: fadeout(#e7e8ea, 0.75) }');
 
         rewind($logStream);
         $output = stream_get_contents($logStream);
         fclose($logStream);
 
-        $this->assertEquals("a {\n  b: rgba(231, 232, 234, 0.25);\n}", $result);
-        $this->assertEquals("DEPRECATION WARNING: Calling built-in functions with a non-standard name is deprecated since Scssphp 1.8.0 and will not work anymore in 2.0 (they will be treated as CSS function calls instead).\nUse \"fade-out\" instead of \"fadeout\".\n         on line 1 of (unknown file)", trim($output));
+        $this->assertEquals("a {\n  b: fadeout(#e7e8ea, 0.75);\n}", $result);
+        $this->assertEquals('', trim($output));
     }
 
-    /**
-     * @group legacy
-     */
     public function testAdditionalDashInFunctionName()
     {
         $this->scss = new Compiler();
@@ -160,16 +139,14 @@ class ApiTest extends TestCase
         assert($logStream !== false);
         $this->scss->setLogger(new StreamLogger($logStream));
 
-        $this->expectDeprecation("Calling built-in functions with a non-standard name is deprecated since Scssphp 1.8.0 and will not work anymore in 2.0 (they will be treated as CSS function calls instead).\nUse \"transparentize\" instead of \"trans-parentize\".");
-
         $result = $this->compile('a { b: trans-parentize(#e7e8ea, 0.75) }');
 
         rewind($logStream);
         $output = stream_get_contents($logStream);
         fclose($logStream);
 
-        $this->assertEquals("a {\n  b: rgba(231, 232, 234, 0.25);\n}", $result);
-        $this->assertEquals("DEPRECATION WARNING: Calling built-in functions with a non-standard name is deprecated since Scssphp 1.8.0 and will not work anymore in 2.0 (they will be treated as CSS function calls instead).\nUse \"transparentize\" instead of \"trans-parentize\".\n         on line 1 of (unknown file)", trim($output));
+        $this->assertEquals("a {\n  b: trans-parentize(#e7e8ea, 0.75);\n}", $result);
+        $this->assertEquals('', trim($output));
     }
 
     public function testImportCustomCallback()


### PR DESCRIPTION
Refs #477
This replaces the deprecation by the standard behavior, i.e. not considering those non-standard names as equivalent.