### PR TITLE
Implement the selector parser ported from dart-sass

### DIFF
--- a/src/Ast/Selector/AttributeOperator.php
+++ b/src/Ast/Selector/AttributeOperator.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Selector;
+
+final class AttributeOperator
+{
+    /**
+     * The attribute value exactly equals the given value.
+     */
+    public const EQUAL = '=';
+
+    /**
+     * The attribute value is a whitespace-separated list of words, one of which
+     * is the given value.
+     */
+    public const INCLUDE = '~=';
+
+    /**
+     * The attribute value is either exactly the given value, or starts with the
+     * given value followed by a dash.
+     */
+    public const DASH = '|=';
+
+    /**
+     * The attribute value begins with the given value.
+     */
+    public const PREFIX = '^=';
+
+    /**
+     * The attribute value ends with the given value.
+     */
+    public const SUFFIX = '$=';
+
+    /**
+     * The attribute value contains the given value.
+     */
+    public const SUBSTRING = '*=';
+}

--- a/src/Ast/Selector/AttributeSelector.php
+++ b/src/Ast/Selector/AttributeSelector.php
@@ -1,0 +1,140 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Selector;
+
+use ScssPhp\ScssPhp\Visitor\SelectorVisitor;
+
+/**
+ * An attribute selector.
+ *
+ * This selects for elements with the given attribute, and optionally with a
+ * value matching certain conditions as well.
+ */
+final class AttributeSelector extends SimpleSelector
+{
+    /**
+     * The name of the attribute being selected for.
+     *
+     * @var QualifiedName
+     * @readonly
+     */
+    private $name;
+
+    /**
+     * The operator that defines the semantics of {@see value}.
+     *
+     * If this is `null`, this matches any element with the given property,
+     * regardless of this value. It's `null` if and only if {@see value} is `null`.
+     *
+     * @var string|null
+     * @phpstan-var AttributeOperator::*|null
+     * @readonly
+     */
+    private $op;
+
+    /**
+     * An assertion about the value of {@see name}.
+     *
+     * The precise semantics of this string are defined by {@see op}.
+     *
+     * If this is `null`, this matches any element with the given property,
+     * regardless of this value. It's `null` if and only if {@see op} is `null`.
+     *
+     * @var string|null
+     * @readonly
+     */
+    private $value;
+
+    /**
+     * The modifier which indicates how the attribute selector should be
+     * processed.
+     *
+     * See for example [case-sensitivity][] modifiers.
+     *
+     * [case-sensitivity]: https://www.w3.org/TR/selectors-4/#attribute-case
+     *
+     * If {@see op} is `null`, this is always `null` as well.
+     *
+     * @var string|null
+     * @readonly
+     */
+    private $modifier;
+
+    /**
+     * Creates an attribute selector that matches any element with a property of
+     * the given name.
+     */
+    public static function create(QualifiedName $name): AttributeSelector
+    {
+        return new AttributeSelector($name, null, null, null);
+    }
+
+    /**
+     * Creates an attribute selector that matches an element with a property
+     * named $name, whose value matches $value based on the semantics of $op.
+     *
+     * @phpstan-param AttributeOperator::*|null $op
+     */
+    public static function withOperator(QualifiedName $name, ?string $op, ?string $value, ?string $modifier = null): AttributeSelector
+    {
+        return new AttributeSelector($name, $op, $value, $modifier);
+    }
+
+    /**
+     * @phpstan-param AttributeOperator::*|null $op
+     */
+    private function __construct(QualifiedName $name, ?string $op, ?string $value, ?string $modifier)
+    {
+        $this->name = $name;
+        $this->op = $op;
+        $this->value = $value;
+        $this->modifier = $modifier;
+    }
+
+    public function getName(): QualifiedName
+    {
+        return $this->name;
+    }
+
+    /**
+     * @phpstan-return AttributeOperator::*
+     */
+    public function getOp(): ?string
+    {
+        return $this->op;
+    }
+
+    public function getValue(): ?string
+    {
+        return $this->value;
+    }
+
+    public function getModifier(): ?string
+    {
+        return $this->modifier;
+    }
+
+    public function accept(SelectorVisitor $visitor)
+    {
+        return $visitor->visitAttributeSelector($this);
+    }
+
+    public function equals(object $other): bool
+    {
+        return $other instanceof AttributeSelector &&
+            $other->name->equals($this->name) &&
+            $other->op === $this->op &&
+            $other->value === $this->value &&
+            $other->modifier === $this->modifier;
+    }
+}

--- a/src/Ast/Selector/ClassSelector.php
+++ b/src/Ast/Selector/ClassSelector.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Selector;
+
+use ScssPhp\ScssPhp\Visitor\SelectorVisitor;
+
+/**
+ * A class selector.
+ *
+ * This selects elements whose `class` attribute contains an identifier with
+ * the given name.
+ */
+final class ClassSelector extends SimpleSelector
+{
+    /**
+     * The class name this selects for.
+     *
+     * @var string
+     * @readonly
+     */
+    private $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function accept(SelectorVisitor $visitor)
+    {
+        return $visitor->visitClassSelector($this);
+    }
+
+    public function equals(object $other): bool
+    {
+        return $other instanceof ClassSelector && $other->name === $this->name;
+    }
+
+    public function addSuffix(string $suffix): SimpleSelector
+    {
+        return new ClassSelector($this->name . $suffix);
+    }
+}

--- a/src/Ast/Selector/Combinator.php
+++ b/src/Ast/Selector/Combinator.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Selector;
+
+/**
+ * A combinator that defines the relationship between selectors in a
+ * {@see ComplexSelector}.
+ */
+final class Combinator
+{
+    /**
+     * Matches the right-hand selector if it's immediately adjacent to the
+     * left-hand selector in the DOM tree.
+     */
+    public const NEXT_SIBLING = '+';
+
+    /**
+     * Matches the right-hand selector if it's a direct child of the left-hand
+     * selector in the DOM tree.
+     */
+    public const CHILD = '>';
+
+    /**
+     * Matches the right-hand selector if it comes after the left-hand selector
+     * in the DOM tree.
+     */
+    public const FOLLOWING_SIBLING = '~';
+}

--- a/src/Ast/Selector/ComplexSelector.php
+++ b/src/Ast/Selector/ComplexSelector.php
@@ -1,0 +1,149 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Selector;
+
+use ScssPhp\ScssPhp\Util\EquatableUtil;
+use ScssPhp\ScssPhp\Visitor\SelectorVisitor;
+
+class ComplexSelector extends Selector
+{
+    /**
+     * The components of this selector.
+     *
+     * This is never empty.
+     *
+     * Descendant combinators aren't explicitly represented here. If two
+     * {@see CompoundSelector}s are adjacent to one another, there's an implicit
+     * descendant combinator between them.
+     *
+     * It's possible for multiple {@see Combinator}s to be adjacent to one another.
+     * This isn't valid CSS, but Sass supports it for CSS hack purposes.
+     *
+     * @var list<CompoundSelector|string>
+     * @phpstan-var list<CompoundSelector|Combinator::*>
+     * @readonly
+     */
+    private $components;
+
+    /**
+     * Whether a line break should be emitted *before* this selector.
+     *
+     * @var bool
+     * @readonly
+     */
+    private $lineBreak;
+
+    /**
+     * @var int|null
+     */
+    private $minSpecificity;
+
+    /**
+     * @var int|null
+     */
+    private $maxSpecificity;
+
+    /**
+     * @param list<CompoundSelector|string> $components
+     * @param bool                          $lineBreak
+     *
+     * @phpstan-param list<CompoundSelector|Combinator::*> $components
+     */
+    public function __construct(array $components, bool $lineBreak = false)
+    {
+        if ($components === []) {
+            throw new \InvalidArgumentException('components may not be empty.');
+        }
+
+        $this->components = $components;
+        $this->lineBreak = $lineBreak;
+    }
+
+    /**
+     * @return list<CompoundSelector|string>
+     * @phpstan-return list<CompoundSelector|Combinator::*>
+     */
+    public function getComponents(): array
+    {
+        return $this->components;
+    }
+
+    public function getLineBreak(): bool
+    {
+        return $this->lineBreak;
+    }
+
+    public function getMinSpecificity(): int
+    {
+        if ($this->minSpecificity === null) {
+            $this->computeSpecificity();
+            assert($this->minSpecificity !== null);
+        }
+
+        return $this->minSpecificity;
+    }
+
+    public function getMaxSpecificity(): int
+    {
+        if ($this->maxSpecificity === null) {
+            $this->computeSpecificity();
+            assert($this->maxSpecificity !== null);
+        }
+
+        return $this->maxSpecificity;
+    }
+
+    public function isInvisible(): bool
+    {
+        foreach ($this->components as $component) {
+            if ($component instanceof CompoundSelector && $component->isInvisible()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function accept(SelectorVisitor $visitor)
+    {
+        return $visitor->visitComplexSelector($this);
+    }
+
+    public function equals(object $other): bool
+    {
+        if (!$other instanceof ComplexSelector) {
+            return false;
+        }
+
+        return EquatableUtil::listEquals($this->components, $other->components);
+    }
+
+    /**
+     * Computes {@see minSpecificity} and {@see maxSpecificity}.
+     */
+    private function computeSpecificity(): void
+    {
+        $minSpecificity = 0;
+        $maxSpecificity = 0;
+
+        foreach ($this->components as $component) {
+            if ($component instanceof CompoundSelector) {
+                $minSpecificity += $component->getMinSpecificity();
+                $maxSpecificity += $component->getMaxSpecificity();
+            }
+        }
+
+        $this->minSpecificity = $minSpecificity;
+        $this->maxSpecificity = $maxSpecificity;
+    }
+}

--- a/src/Ast/Selector/CompoundSelector.php
+++ b/src/Ast/Selector/CompoundSelector.php
@@ -1,0 +1,122 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Selector;
+
+use ScssPhp\ScssPhp\Util\EquatableUtil;
+use ScssPhp\ScssPhp\Visitor\SelectorVisitor;
+
+/**
+ * A compound selector.
+ *
+ * A compound selector is composed of {@see SimpleSelector}s. It matches an element
+ * that matches all of the component simple selectors.
+ */
+final class CompoundSelector extends Selector
+{
+    /**
+     * The components of this selector.
+     *
+     * This is never empty.
+     *
+     * @var list<SimpleSelector>
+     */
+    private $components;
+
+    /**
+     * @var int|null
+     */
+    private $minSpecificity;
+
+    /**
+     * @var int|null
+     */
+    private $maxSpecificity;
+
+    /**
+     * @param list<SimpleSelector> $components
+     */
+    public function __construct(array $components)
+    {
+        if ($components === []) {
+            throw new \InvalidArgumentException('components may not be empty.');
+        }
+
+        $this->components = $components;
+    }
+
+    /**
+     * @return list<SimpleSelector>
+     */
+    public function getComponents(): array
+    {
+        return $this->components;
+    }
+
+    public function getMinSpecificity(): int
+    {
+        if ($this->minSpecificity === null) {
+            $this->computeSpecificity();
+            assert($this->minSpecificity !== null);
+        }
+
+        return $this->minSpecificity;
+    }
+
+    public function getMaxSpecificity(): int
+    {
+        if ($this->maxSpecificity === null) {
+            $this->computeSpecificity();
+            assert($this->maxSpecificity !== null);
+        }
+
+        return $this->maxSpecificity;
+    }
+
+    public function isInvisible(): bool
+    {
+        foreach ($this->components as $component) {
+            if ($component->isInvisible()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function accept(SelectorVisitor $visitor)
+    {
+        return $visitor->visitCompoundSelector($this);
+    }
+
+    public function equals(object $other): bool
+    {
+        return $other instanceof CompoundSelector && EquatableUtil::listEquals($this->components, $other->components);
+    }
+
+    /**
+     * Computes {@see minSpecificity} and {@see maxSpecificity}.
+     */
+    private function computeSpecificity(): void
+    {
+        $minSpecificity = 0;
+        $maxSpecificity = 0;
+
+        foreach ($this->components as $simple) {
+            $minSpecificity += $simple->getMinSpecificity();
+            $maxSpecificity += $simple->getMaxSpecificity();
+        }
+
+        $this->minSpecificity = $minSpecificity;
+        $this->maxSpecificity = $maxSpecificity;
+    }
+}

--- a/src/Ast/Selector/CompoundSelector.php
+++ b/src/Ast/Selector/CompoundSelector.php
@@ -12,6 +12,9 @@
 
 namespace ScssPhp\ScssPhp\Ast\Selector;
 
+use ScssPhp\ScssPhp\Exception\SassFormatException;
+use ScssPhp\ScssPhp\Logger\LoggerInterface;
+use ScssPhp\ScssPhp\Parser\SelectorParser;
 use ScssPhp\ScssPhp\Util\EquatableUtil;
 use ScssPhp\ScssPhp\Visitor\SelectorVisitor;
 
@@ -41,6 +44,20 @@ final class CompoundSelector extends Selector
      * @var int|null
      */
     private $maxSpecificity;
+
+    /**
+     * Parses a compound selector from $contents.
+     *
+     * If passed, $url is the name of the file from which $contents comes.
+     * $allowParent controls whether a {@see ParentSelector} is allowed in this
+     * selector.
+     *
+     * @throws SassFormatException if parsing fails.
+     */
+    public static function parse(string $contents, ?LoggerInterface $logger = null, ?string $url = null, bool $allowParent = true): CompoundSelector
+    {
+        return (new SelectorParser($contents, $logger, $url, $allowParent))->parseCompoundSelector();
+    }
 
     /**
      * @param list<SimpleSelector> $components

--- a/src/Ast/Selector/IDSelector.php
+++ b/src/Ast/Selector/IDSelector.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Selector;
+
+use ScssPhp\ScssPhp\Visitor\SelectorVisitor;
+
+/**
+ * An ID selector.
+ *
+ * This selects elements whose `id` attribute exactly matches the given name.
+ */
+final class IDSelector extends SimpleSelector
+{
+    /**
+     * The ID name this selects for.
+     *
+     * @var string
+     * @readonly
+     */
+    private $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getMinSpecificity(): int
+    {
+        return parent::getMinSpecificity() ** 2;
+    }
+
+    public function accept(SelectorVisitor $visitor)
+    {
+        return $visitor->visitIDSelector($this);
+    }
+
+    public function addSuffix(string $suffix): SimpleSelector
+    {
+        return new IDSelector($this->name . $suffix);
+    }
+
+    public function equals(object $other): bool
+    {
+        return $other instanceof IDSelector && $other->name === $this->name;
+    }
+}

--- a/src/Ast/Selector/ParentSelector.php
+++ b/src/Ast/Selector/ParentSelector.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Selector;
+
+use ScssPhp\ScssPhp\Visitor\SelectorVisitor;
+
+/**
+ * A selector that matches the parent in the Sass stylesheet.
+ *
+ * This is not a plain CSS selector—it should be removed before emitting a CSS
+ * document.
+ */
+final class ParentSelector extends SimpleSelector
+{
+    /**
+     * The suffix that will be added to the parent selector after it's been
+     * resolved.
+     *
+     * This is assumed to be a valid identifier suffix. It may be `null`,
+     * indicating that the parent selector will not be modified.
+     *
+     * @var string|null
+     * @readonly
+     */
+    private $suffix;
+
+    public function __construct(?string $suffix)
+    {
+        $this->suffix = $suffix;
+    }
+
+    public function getSuffix(): ?string
+    {
+        return $this->suffix;
+    }
+
+    public function equals(object $other): bool
+    {
+        return $other === $this;
+    }
+
+    public function accept(SelectorVisitor $visitor)
+    {
+        return $visitor->visitParentSelector($this);
+    }
+}

--- a/src/Ast/Selector/PlaceholderSelector.php
+++ b/src/Ast/Selector/PlaceholderSelector.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Selector;
+
+use ScssPhp\ScssPhp\Util\Character;
+use ScssPhp\ScssPhp\Visitor\SelectorVisitor;
+
+/**
+ * A placeholder selector.
+ *
+ * This doesn't match any elements. It's intended to be extended using
+ * `@extend`. It's not a plain CSS selector—it should be removed before
+ * emitting a CSS document.
+ */
+final class PlaceholderSelector extends SimpleSelector
+{
+    /**
+     * The name of the placeholder.
+     *
+     * @var string
+     * @readonly
+     */
+    private $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function isInvisible(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Returns whether this is a private selector (that is, whether it begins
+     * with `-` or `_`).
+     */
+    public function isPrivate(): bool
+    {
+        return Character::isPrivate($this->name);
+    }
+
+    public function accept(SelectorVisitor $visitor)
+    {
+        return $visitor->visitPlaceholderSelector($this);
+    }
+
+    public function addSuffix(string $suffix): SimpleSelector
+    {
+        return new PlaceholderSelector($this->name . $suffix);
+    }
+
+    public function equals(object $other): bool
+    {
+        return $other instanceof PlaceholderSelector && $other->name === $this->name;
+    }
+}

--- a/src/Ast/Selector/PseudoSelector.php
+++ b/src/Ast/Selector/PseudoSelector.php
@@ -1,0 +1,320 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Selector;
+
+use ScssPhp\ScssPhp\Util;
+use ScssPhp\ScssPhp\Visitor\SelectorVisitor;
+
+/**
+ * A pseudo-class or pseudo-element selector.
+ *
+ * The semantics of a specific pseudo selector depends on its name. Some
+ * selectors take arguments, including other selectors. Sass manually encodes
+ * logic for each pseudo selector that takes a selector as an argument, to
+ * ensure that extension and other selector operations work properly.
+ */
+final class PseudoSelector extends SimpleSelector
+{
+    /**
+     * The name of this selector.
+     *
+     * @var string
+     * @readonly
+     */
+    private $name;
+
+    /**
+     * Like {@see name}, but without any vendor prefixes.
+     *
+     * @var string
+     * @readonly
+     */
+    private $normalizedName;
+
+    /**
+     * @var bool
+     * @readonly
+     */
+    private $isClass;
+
+    /**
+     * @var bool
+     * @readonly
+     */
+    private $isSyntacticClass;
+
+    /**
+     * The non-selector argument passed to this selector.
+     *
+     * This is `null` if there's no argument. If {@see argument} and {@see selector} are
+     * both non-`null`, the selector follows the argument.
+     *
+     * @var string|null
+     * @readonly
+     */
+    private $argument;
+
+    /**
+     * The selector argument passed to this selector.
+     *
+     * This is `null` if there's no selector. If {@see argument} and {@see selector} are
+     * both non-`null`, the selector follows the argument.
+     *
+     * @var SelectorList|null
+     * @readonly
+     */
+    private $selector;
+
+    /**
+     * @var int|null
+     */
+    private $minSpecificity;
+
+    /**
+     * @var int|null
+     */
+    private $maxSpecificity;
+
+    public function __construct(string $name, bool $element = false, ?string $argument = null, ?SelectorList $selector = null)
+    {
+        $this->name = $name;
+        $this->isClass = !$element && !self::isFakePseudoElement($name);
+        $this->isSyntacticClass = !$element;
+        $this->argument = $argument;
+        $this->selector = $selector;
+        $this->normalizedName = Util::unvendor($name);
+    }
+
+    /**
+     * Returns whether $name is the name of a pseudo-element that can be written
+     * with pseudo-class syntax (`:before`, `:after`, `:first-line`, or
+     * `:first-letter`)
+     */
+    private static function isFakePseudoElement(string $name): bool
+    {
+        if ($name === '') {
+            return false;
+        }
+
+        switch ($name[0]) {
+            case 'a':
+            case 'A':
+                return strtolower($name) === 'after';
+
+            case 'b':
+            case 'B':
+                return strtolower($name) === 'before';
+
+            case 'f':
+            case 'F':
+                $lowerCasedName = strtolower($name);
+
+                return $lowerCasedName === 'first-line' || $lowerCasedName === 'first-letter';
+
+            default:
+                return false;
+        }
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getNormalizedName(): string
+    {
+        return $this->normalizedName;
+    }
+
+    /**
+     * Whether this is a pseudo-class selector.
+     *
+     * This is `true` if and only if {@see isElement} is `false`.
+     */
+    public function isClass(): bool
+    {
+        return $this->isClass;
+    }
+
+    /**
+     * Whether this is a pseudo-element selector.
+     *
+     * This is `true` if and only if {@see isClass} is `false`.
+     */
+    public function isElement(): bool
+    {
+        return !$this->isClass;
+    }
+
+    /**
+     * Whether this is syntactically a pseudo-class selector.
+     *
+     * This is the same as {@see isClass} unless this selector is a pseudo-element
+     * that was written syntactically as a pseudo-class (`:before`, `:after`,
+     * `:first-line`, or `:first-letter`).
+     *
+     * This is `true` if and only if {@see isSyntacticElement} is `false`.
+     */
+    public function isSyntacticClass(): bool
+    {
+        return $this->isSyntacticClass;
+    }
+
+    /**
+     * Whether this is syntactically a pseudo-element selector.
+     *
+     * This is `true` if and only if {@see isSyntacticClass} is `false`.
+     */
+    public function isSyntacticElement(): bool
+    {
+        return !$this->isSyntacticClass;
+    }
+
+    /**
+     * Whether this is a valid `:host` selector.
+     *
+     * @internal
+     */
+    public function isHost(): bool
+    {
+        return $this->isClass && $this->name === 'host';
+    }
+
+    /**
+     * Whether this is a valid `:host-context` selector.
+     *
+     * @internal
+     */
+    public function isHostContext(): bool
+    {
+        return $this->isClass && $this->name === 'host-context' && $this->selector !== null;
+    }
+
+    public function getArgument(): ?string
+    {
+        return $this->argument;
+    }
+
+    public function getSelector(): ?SelectorList
+    {
+        return $this->selector;
+    }
+
+    public function getMinSpecificity(): int
+    {
+        if ($this->minSpecificity === null) {
+            $this->computeSpecificity();
+            assert($this->minSpecificity !== null);
+        }
+
+        return $this->minSpecificity;
+    }
+
+    public function getMaxSpecificity(): int
+    {
+        if ($this->maxSpecificity === null) {
+            $this->computeSpecificity();
+            assert($this->maxSpecificity !== null);
+        }
+
+        return $this->maxSpecificity;
+    }
+
+    public function isInvisible(): bool
+    {
+        if ($this->selector === null) {
+            return false;
+        }
+
+        // We don't consider `:not(%foo)` to be invisible because, semantically, it
+        // means "doesn't match this selector that matches nothing", so it's
+        // equivalent to *. If the entire compound selector is composed of `:not`s
+        // with invisible lists, the serializer emits it as `*`.
+        return 'not' !== $this->name && $this->selector->isInvisible();
+    }
+
+    public function withSelector(SelectorList $selector): PseudoSelector
+    {
+        return new PseudoSelector($this->name, $this->isElement(), $this->argument, $selector);
+    }
+
+    public function addSuffix(string $suffix): SimpleSelector
+    {
+        if ($this->argument !== null || $this->selector !== null) {
+            parent::addSuffix($suffix);
+        }
+
+        return new PseudoSelector($this->name . $suffix, $this->isElement());
+    }
+
+    public function accept(SelectorVisitor $visitor)
+    {
+        return $visitor->visitPseudoSelector($this);
+    }
+
+    public function equals(object $other): bool
+    {
+        return $other instanceof PseudoSelector &&
+            $other->name === $this->name &&
+            $other->isClass === $this->isClass &&
+            $other->argument === $this->argument &&
+            ($this->selector === $other->selector || ($this->selector !== null && $other->selector !== null && $this->selector->equals($other->selector)));
+    }
+
+    /**
+     * Computes {@see minSpecificity} and {@see maxSpecificity}.
+     */
+    private function computeSpecificity(): void
+    {
+        if ($this->isElement()) {
+            $this->minSpecificity = 1;
+            $this->maxSpecificity = 1;
+
+            return;
+        }
+
+        $selector = $this->selector;
+
+        if ($selector === null) {
+            $this->minSpecificity = parent::getMinSpecificity();
+            $this->maxSpecificity = parent::getMaxSpecificity();
+
+            return;
+        }
+
+        if ($this->name === 'not') {
+            $minSpecificity = 0;
+            $maxSpecificity = 0;
+
+            foreach ($selector->getComponents() as $complex) {
+                $minSpecificity = max($minSpecificity, $complex->getMinSpecificity());
+                $maxSpecificity = max($maxSpecificity, $complex->getMaxSpecificity());
+            }
+
+            $this->minSpecificity = $minSpecificity;
+            $this->maxSpecificity = $maxSpecificity;
+        } else {
+            // This is higher than any selector's specificity can actually be.
+            $minSpecificity = parent::getMinSpecificity() ** 3;
+            $maxSpecificity = 0;
+
+            foreach ($selector->getComponents() as $complex) {
+                $minSpecificity = min($minSpecificity, $complex->getMinSpecificity());
+                $maxSpecificity = max($maxSpecificity, $complex->getMaxSpecificity());
+            }
+
+            $this->minSpecificity = $minSpecificity;
+            $this->maxSpecificity = $maxSpecificity;
+        }
+    }
+}

--- a/src/Ast/Selector/QualifiedName.php
+++ b/src/Ast/Selector/QualifiedName.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Selector;
+
+use ScssPhp\ScssPhp\Util\Equatable;
+
+/**
+ * A [qualified name][].
+ *
+ * [qualified name]: https://www.w3.org/TR/css3-namespace/#css-qnames
+ */
+class QualifiedName implements Equatable
+{
+    /**
+     * The identifier name.
+     *
+     * @var string
+     * @readonly
+     */
+    private $name;
+
+    /**
+     * The namespace name.
+     *
+     * If this is `null`, {@see name} belongs to the default namespace. If it's the
+     * empty string, {@see name} belongs to no namespace. If it's `*`, {@see name} belongs
+     * to any namespace. Otherwise, {@see name} belongs to the given namespace.
+     *
+     * @var string|null
+     * @readonly
+     */
+    private $namespace;
+
+    public function __construct(string $name, ?string $namespace = null)
+    {
+        $this->name = $name;
+        $this->namespace = $namespace;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getNamespace(): ?string
+    {
+        return $this->namespace;
+    }
+
+    public function __toString(): string
+    {
+        return $this->namespace === null ? $this->name : $this->namespace . '|' . $this->name;
+    }
+
+    public function equals(object $other): bool
+    {
+        return $other instanceof QualifiedName && $other->name === $this->name && $other->namespace === $this->namespace;
+    }
+}

--- a/src/Ast/Selector/Selector.php
+++ b/src/Ast/Selector/Selector.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Selector;
+
+use ScssPhp\ScssPhp\Serializer\Serializer;
+use ScssPhp\ScssPhp\Util\Equatable;
+use ScssPhp\ScssPhp\Visitor\SelectorVisitor;
+
+/**
+ * A node in the abstract syntax tree for a selector.
+ *
+ * This selector tree is mostly plain CSS, but also may contain a
+ * {@see ParentSelector} or a {@see PlaceholderSelector}.
+ *
+ * Selectors have structural equality semantics
+ */
+abstract class Selector implements Equatable
+{
+    /**
+     * Whether this selector, and complex selectors containing it, should not be
+     * emitted.
+     */
+    public function isInvisible(): bool
+    {
+        return false;
+    }
+
+    /**
+     * Calls the appropriate visit method on $visitor.
+     *
+     * @template T
+     *
+     * @param SelectorVisitor<T> $visitor
+     *
+     * @return T
+     *
+     * @internal
+     */
+    abstract public function accept(SelectorVisitor $visitor);
+
+    final public function __toString(): string
+    {
+        return Serializer::serializeSelector($this, true);
+    }
+}

--- a/src/Ast/Selector/SelectorList.php
+++ b/src/Ast/Selector/SelectorList.php
@@ -12,6 +12,9 @@
 
 namespace ScssPhp\ScssPhp\Ast\Selector;
 
+use ScssPhp\ScssPhp\Exception\SassFormatException;
+use ScssPhp\ScssPhp\Logger\LoggerInterface;
+use ScssPhp\ScssPhp\Parser\SelectorParser;
 use ScssPhp\ScssPhp\Util\EquatableUtil;
 use ScssPhp\ScssPhp\Value\ListSeparator;
 use ScssPhp\ScssPhp\Value\SassList;
@@ -35,6 +38,20 @@ final class SelectorList extends Selector
      * @readonly
      */
     private $components;
+
+    /**
+     * Parses a selector list from $contents.
+     *
+     * If passed, $url is the name of the file from which $contents comes.
+     * $allowParent and $allowPlaceholder control whether {@see ParentSelector}s or
+     * {@see PlaceholderSelector}s are allowed in this selector, respectively.
+     *
+     * @throws SassFormatException if parsing fails.
+     */
+    public static function parse(string $contents, ?LoggerInterface $logger = null, ?string $url = null, bool $allowParent = true, bool $allowPlaceholder = true): SelectorList
+    {
+        return (new SelectorParser($contents, $logger, $url, $allowParent, $allowPlaceholder))->parse();
+    }
 
     /**
      * @param list<ComplexSelector> $components

--- a/src/Ast/Selector/SelectorList.php
+++ b/src/Ast/Selector/SelectorList.php
@@ -1,0 +1,136 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Selector;
+
+use ScssPhp\ScssPhp\Util\EquatableUtil;
+use ScssPhp\ScssPhp\Value\ListSeparator;
+use ScssPhp\ScssPhp\Value\SassList;
+use ScssPhp\ScssPhp\Value\SassString;
+use ScssPhp\ScssPhp\Visitor\SelectorVisitor;
+
+/**
+ * A selector list.
+ *
+ * A selector list is composed of {@see ComplexSelector}s. It matches an element
+ * that matches any of the component selectors.
+ */
+final class SelectorList extends Selector
+{
+    /**
+     * The components of this selector.
+     *
+     * This is never empty.
+     *
+     * @var list<ComplexSelector>
+     * @readonly
+     */
+    private $components;
+
+    /**
+     * @param list<ComplexSelector> $components
+     */
+    public function __construct(array $components)
+    {
+        if ($components === []) {
+            throw new \InvalidArgumentException('components may not be empty.');
+        }
+
+        $this->components = $components;
+    }
+
+    /**
+     * @return list<ComplexSelector>
+     */
+    public function getComponents(): array
+    {
+        return $this->components;
+    }
+
+    public function isInvisible(): bool
+    {
+        foreach ($this->components as $component) {
+            if (!$component->isInvisible()) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Returns a SassScript list that represents this selector.
+     *
+     * This has the same format as a list returned by `selector-parse()`.
+     */
+    public function asSassList(): SassList
+    {
+        return new SassList(array_map(static function (ComplexSelector $complex) {
+            return new SassList(array_map(static function($component) {
+                return new SassString((string) $component, false);
+            }, $complex->getComponents()), ListSeparator::SPACE);
+        }, $this->components), ListSeparator::COMMA);
+    }
+
+    public function accept(SelectorVisitor $visitor)
+    {
+        return $visitor->visitSelectorList($this);
+    }
+
+    public function equals(object $other): bool
+    {
+        return $other instanceof SelectorList && EquatableUtil::listEquals($this->components, $other->components);
+    }
+
+    /**
+     * Whether this contains a {@see ParentSelector}.
+     */
+    private function containsParentSelector(): bool
+    {
+        foreach ($this->components as $component) {
+            if (self::complexContainsParentSelector($component)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns whether $complex contains a {@see ParentSelector}.
+     */
+    private static function complexContainsParentSelector(ComplexSelector $complex): bool
+    {
+        foreach ($complex->getComponents() as $component) {
+            if (!$component instanceof CompoundSelector) {
+                continue;
+            }
+
+            foreach ($component->getComponents() as $simple) {
+                if ($simple instanceof ParentSelector) {
+                    return true;
+                }
+
+                if (!$simple instanceof PseudoSelector) {
+                    continue;
+                }
+
+                $selector = $simple->getSelector();
+                if ($selector !== null && $selector->containsParentSelector()) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Ast/Selector/SimpleSelector.php
+++ b/src/Ast/Selector/SimpleSelector.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Selector;
+
+use ScssPhp\ScssPhp\Exception\SassScriptException;
+
+/**
+ * An abstract superclass for simple selectors.
+ */
+abstract class SimpleSelector extends Selector
+{
+    /**
+     * The minimum possible specificity that this selector can have.
+     *
+     * Pseudo selectors that contain selectors, like `:not()` and `:matches()`,
+     * can have a range of possible specificities.
+     *
+     * Specificity is represented in base 1000. The spec says this should be
+     * "sufficiently high"; it's extremely unlikely that any single selector
+     * sequence will contain 1000 simple selectors.
+     */
+    public function getMinSpecificity(): int
+    {
+        return 1000;
+    }
+
+    /**
+     * The maximum possible specificity that this selector can have.
+     *
+     * Pseudo selectors that contain selectors, like `:not()` and `:matches()`,
+     * can have a range of possible specificities.
+     */
+    public function getMaxSpecificity(): int
+    {
+        return $this->getMinSpecificity();
+    }
+
+    /**
+     * Returns a new {@see SimpleSelector} based on $this, as though it had been
+     * written with $suffix at the end.
+     *
+     * Assumes $suffix is a valid identifier suffix. If this wouldn't produce a
+     * valid SimpleSelector, throws a {@see SassScriptException}.
+     *
+     * @throws SassScriptException
+     */
+    public function addSuffix(string $suffix): SimpleSelector
+    {
+        throw new SassScriptException("Invalid parent selector \"$this\"");
+    }
+}

--- a/src/Ast/Selector/SimpleSelector.php
+++ b/src/Ast/Selector/SimpleSelector.php
@@ -12,13 +12,30 @@
 
 namespace ScssPhp\ScssPhp\Ast\Selector;
 
+use ScssPhp\ScssPhp\Exception\SassFormatException;
 use ScssPhp\ScssPhp\Exception\SassScriptException;
+use ScssPhp\ScssPhp\Logger\LoggerInterface;
+use ScssPhp\ScssPhp\Parser\SelectorParser;
 
 /**
  * An abstract superclass for simple selectors.
  */
 abstract class SimpleSelector extends Selector
 {
+    /**
+     * Parses a simple selector from $contents.
+     *
+     * If passed, $url is the name of the file from which $contents comes.
+     * $allowParent controls whether a {@see ParentSelector} is allowed in this
+     * selector.
+     *
+     * @throws SassFormatException if parsing fails.
+     */
+    public static function parse(string $contents, ?LoggerInterface $logger = null, ?string $url = null, bool $allowParent = true): SimpleSelector
+    {
+        return (new SelectorParser($contents, $logger, $url, $allowParent))->parseSimpleSelector();
+    }
+
     /**
      * The minimum possible specificity that this selector can have.
      *

--- a/src/Ast/Selector/TypeSelector.php
+++ b/src/Ast/Selector/TypeSelector.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Selector;
+
+use ScssPhp\ScssPhp\Visitor\SelectorVisitor;
+
+/**
+ * A type selector.
+ *
+ * This selects elements whose name equals the given name.
+ */
+final class TypeSelector extends SimpleSelector
+{
+    /**
+     * @var QualifiedName
+     * @readonly
+     */
+    private $name;
+
+    public function __construct(QualifiedName $name)
+    {
+        $this->name = $name;
+    }
+
+    public function getName(): QualifiedName
+    {
+        return $this->name;
+    }
+
+    public function getMinSpecificity(): int
+    {
+        return 1;
+    }
+
+    public function accept(SelectorVisitor $visitor)
+    {
+        return $visitor->visitTypeSelector($this);
+    }
+
+    public function addSuffix(string $suffix): SimpleSelector
+    {
+        return new TypeSelector(new QualifiedName($this->name->getName() . $suffix, $this->name->getNamespace()));
+    }
+
+    public function equals(object $other): bool
+    {
+        return $other instanceof TypeSelector && $other->name->equals($this->name);
+    }
+}

--- a/src/Ast/Selector/UniversalSelector.php
+++ b/src/Ast/Selector/UniversalSelector.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Selector;
+
+use ScssPhp\ScssPhp\Visitor\SelectorVisitor;
+
+/**
+ * Matches any element in the given namespace.
+ */
+final class UniversalSelector extends SimpleSelector
+{
+    /**
+     * The selector namespace.
+     *
+     * If this is `null`, this matches all elements in the default namespace. If
+     * it's the empty string, this matches all elements that aren't in any
+     * namespace. If it's `*`, this matches all elements in any namespace.
+     * Otherwise, it matches all elements in the given namespace.
+     *
+     * @var string|null
+     * @readonly
+     */
+    private $namespace;
+
+    public function __construct(?string $namespace = null)
+    {
+        $this->namespace = $namespace;
+    }
+
+    public function getNamespace(): ?string
+    {
+        return $this->namespace;
+    }
+
+    public function getMinSpecificity(): int
+    {
+        return 0;
+    }
+
+    public function accept(SelectorVisitor $visitor)
+    {
+        return $visitor->visitUniversalSelector($this);
+    }
+
+    public function equals(object $other): bool
+    {
+        return $other instanceof UniversalSelector && $other->namespace === $this->namespace;
+    }
+}

--- a/src/Parser/Parser.php
+++ b/src/Parser/Parser.php
@@ -43,11 +43,50 @@ class Parser
      */
     protected $sourceUrl;
 
+    /**
+     * Parses $text as a CSS identifier and returns the result.
+     *
+     * @throws SassFormatException if parsing fails.
+     */
+    public static function parseIdentifier(string $text, ?LoggerInterface $logger = null): string
+    {
+        return (new Parser($text, $logger))->doParseIdentifier();
+    }
+
+    /**
+     * Returns whether $text is a valid CSS identifier.
+     */
+    public static function isIdentifier(string $text, ?LoggerInterface $logger = null): bool
+    {
+        try {
+            self::parseIdentifier($text, $logger);
+
+            return true;
+        } catch (SassFormatException $e) {
+            return false;
+        }
+    }
+
     public function __construct(string $contents, ?LoggerInterface $logger = null, ?string $sourceUrl = null)
     {
         $this->scanner = new StringScanner($contents);
         $this->logger = $logger ?: new QuietLogger();
         $this->sourceUrl = $sourceUrl;
+    }
+
+    /**
+     * @throws SassFormatException
+     */
+    private function doParseIdentifier(): string
+    {
+        try {
+            $result = $this->identifier();
+            $this->scanner->expectDone();
+
+            return $result;
+        } catch (FormatException $e) {
+            throw $this->wrapException($e);
+        }
     }
 
     /**

--- a/src/Parser/SelectorParser.php
+++ b/src/Parser/SelectorParser.php
@@ -1,0 +1,557 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Parser;
+
+use ScssPhp\ScssPhp\Ast\Selector\AttributeOperator;
+use ScssPhp\ScssPhp\Ast\Selector\AttributeSelector;
+use ScssPhp\ScssPhp\Ast\Selector\ClassSelector;
+use ScssPhp\ScssPhp\Ast\Selector\Combinator;
+use ScssPhp\ScssPhp\Ast\Selector\ComplexSelector;
+use ScssPhp\ScssPhp\Ast\Selector\CompoundSelector;
+use ScssPhp\ScssPhp\Ast\Selector\IDSelector;
+use ScssPhp\ScssPhp\Ast\Selector\ParentSelector;
+use ScssPhp\ScssPhp\Ast\Selector\PlaceholderSelector;
+use ScssPhp\ScssPhp\Ast\Selector\PseudoSelector;
+use ScssPhp\ScssPhp\Ast\Selector\QualifiedName;
+use ScssPhp\ScssPhp\Ast\Selector\SelectorList;
+use ScssPhp\ScssPhp\Ast\Selector\SimpleSelector;
+use ScssPhp\ScssPhp\Ast\Selector\TypeSelector;
+use ScssPhp\ScssPhp\Ast\Selector\UniversalSelector;
+use ScssPhp\ScssPhp\Logger\LoggerInterface;
+use ScssPhp\ScssPhp\Util;
+use ScssPhp\ScssPhp\Util\Character;
+
+/**
+ * A parser for selectors.
+ *
+ * @internal
+ */
+final class SelectorParser extends Parser
+{
+    /**
+     * Pseudo-class selectors that take unadorned selectors as arguments.
+     */
+    private const SELECTOR_PSEUDO_CLASSES = ['not', 'is', 'matches', 'current', 'any', 'has', 'host', 'host-context'];
+
+    /**
+     * Pseudo-element selectors that take unadorned selectors as arguments.
+     */
+    private const SELECTOR_PSEUDO_ELEMENTS = ['slotted'];
+
+    /**
+     * @var bool
+     * @readonly
+     */
+    private $allowParent;
+
+    /**
+     * @var bool
+     * @readonly
+     */
+    private $allowPlaceholder;
+
+    public function __construct(string $contents, ?LoggerInterface $logger = null, ?string $url = null, bool $allowParent = true, bool $allowPlaceholder = true)
+    {
+        $this->allowParent = $allowParent;
+        $this->allowPlaceholder = $allowPlaceholder;
+        parent::__construct($contents, $logger, $url);
+    }
+
+    public function parse(): SelectorList
+    {
+        try {
+            $selector = $this->selectorList();
+
+            if (!$this->scanner->isDone()) {
+                $this->scanner->error('expected selector.');
+            }
+
+            return $selector;
+        } catch (FormatException $e) {
+            throw $this->wrapException($e);
+        }
+    }
+
+    public function parseCompoundSelector(): CompoundSelector
+    {
+        try {
+            $compound = $this->compoundSelector();
+
+            if (!$this->scanner->isDone()) {
+                $this->scanner->error('expected selector.');
+            }
+
+            return $compound;
+        } catch (FormatException $e) {
+            throw $this->wrapException($e);
+        }
+    }
+
+    public function parseSimpleSelector(): SimpleSelector
+    {
+        try {
+            $simple = $this->simpleSelector();
+
+            if (!$this->scanner->isDone()) {
+                $this->scanner->error('unexpected token.');
+            }
+
+            return $simple;
+        } catch (FormatException $e) {
+            throw $this->wrapException($e);
+        }
+    }
+
+    /**
+     * Consumes a selector list.
+     */
+    private function selectorList(): SelectorList
+    {
+        $previousLine = $this->scanner->getLine();
+        $components = [$this->complexSelector()];
+
+        $this->whitespace();
+        while ($this->scanner->scanChar(',')) {
+            $this->whitespace();
+            $next = $this->scanner->peekChar();
+
+            if ($next === ',') {
+                continue;
+            }
+
+            if ($this->scanner->isDone()) {
+                break;
+            }
+
+            $lineBreak = $this->scanner->getLine() !== $previousLine;
+
+            if ($lineBreak) {
+                $previousLine = $this->scanner->getLine();
+            }
+
+            $components[] = $this->complexSelector($lineBreak);
+        }
+
+        return new SelectorList($components);
+    }
+
+    /**
+     * Consumes a complex selector.
+     *
+     * If $lineBreak is `true`, that indicates that there was a line break
+     * before this selector.
+     */
+    private function complexSelector(bool $lineBreak = false): ComplexSelector
+    {
+        $components = [];
+
+        while (true) {
+            $this->whitespace();
+
+            $next = $this->scanner->peekChar();
+
+            switch ($next) {
+                case '+':
+                    $this->scanner->readChar();
+                    $components[] = Combinator::NEXT_SIBLING;
+                    break;
+
+                case '>':
+                    $this->scanner->readChar();
+                    $components[] = Combinator::CHILD;
+                    break;
+
+                case '~':
+                    $this->scanner->readChar();
+                    $components[] = Combinator::FOLLOWING_SIBLING;
+                    break;
+
+                case '[':
+                case '.':
+                case '#':
+                case '%':
+                case ':':
+                case '&':
+                case '*':
+                case '|':
+                    $components[] = $this->compoundSelector();
+
+                    if ($this->scanner->peekChar() === '&') {
+                        $this->scanner->error('"&" may only used at the beginning of a compound selector.');
+                    }
+                    break;
+
+                default:
+                    if ($next === null || !$this->lookingAtIdentifier()) {
+                        break 2;
+                    }
+                    $components[] = $this->compoundSelector();
+
+                    if ($this->scanner->peekChar() === '&') {
+                        $this->scanner->error('"&" may only used at the beginning of a compound selector.');
+                    }
+                    break;
+            }
+        }
+
+        if (\count($components) === 0) {
+            $this->scanner->error('expected selector.');
+        }
+
+        return new ComplexSelector($components, $lineBreak);
+    }
+
+    /**
+     * Consumes a compound selector.
+     */
+    private function compoundSelector(): CompoundSelector
+    {
+        $components = [$this->simpleSelector()];
+
+        while (Character::isSimpleSelectorStart($this->scanner->peekChar())) {
+            $components[] = $this->simpleSelector(false);
+        }
+
+        return new CompoundSelector($components);
+    }
+
+    /**
+     * Consumes a simple selector.
+     *
+     * If $allowParent is passed, it controls whether the parent selector `&` is
+     * allowed. Otherwise, it defaults to {@see allowParent}.
+     */
+    private function simpleSelector(?bool $allowParent = null): SimpleSelector
+    {
+        $start = $this->scanner->getPosition();
+        $allowParent = $allowParent ?? $this->allowParent;
+
+        switch ($this->scanner->peekChar()) {
+            case '[':
+                return $this->attributeSelector();
+
+            case '.':
+                return $this->classSelector();
+
+            case '#':
+                return $this->idSelector();
+
+            case '%':
+                $selector = $this->placeholderSelector();
+                if (!$this->allowPlaceholder) {
+                    $this->error("Placeholder selectors aren't allowed here.", $this->scanner->spanFrom($start));
+                }
+                return $selector;
+
+            case ':':
+                return $this->pseudoSelector();
+
+            case '&':
+                $selector = $this->parentSelector();
+                if (!$allowParent) {
+                    $this->error("Parent selectors aren't allowed here.", $this->scanner->spanFrom($start));
+                }
+                return $selector;
+
+            default:
+                return $this->typeOrUniversalSelector();
+        }
+    }
+
+    /**
+     * Consumes an attribute selector.
+     */
+    private function attributeSelector(): AttributeSelector
+    {
+        $this->scanner->expectChar('[');
+        $this->whitespace();
+
+        $name = $this->attributeName();
+        $this->whitespace();
+
+        if ($this->scanner->scanChar(']')) {
+            return AttributeSelector::create($name);
+        }
+
+        $operator = $this->attributeOperator();
+        $this->whitespace();
+
+        $next = $this->scanner->peekChar();
+        $value = $next === "'" || $next === '"' ? $this->string() : $this->identifier();
+        $this->whitespace();
+
+        $next = $this->scanner->peekChar();
+        $modifier = $next !== null && Character::isAlphabetic($next) ? $this->scanner->readChar() : null;
+
+        $this->scanner->expectChar(']');
+
+        return AttributeSelector::withOperator($name, $operator, $value, $modifier);
+    }
+
+    /**
+     * Consumes a qualified name as part of an attribute selector.
+     */
+    private function attributeName(): QualifiedName
+    {
+        if ($this->scanner->scanChar('*')) {
+            $this->scanner->expectChar('|');
+
+            return new QualifiedName($this->identifier(), '*');
+        }
+
+        $nameOrNamespace = $this->identifier();
+
+        if ($this->scanner->peekChar() !== '|' || $this->scanner->peekChar(1) === '=') {
+            return new QualifiedName($nameOrNamespace);
+        }
+
+        $this->scanner->readChar();
+
+        return new QualifiedName($this->identifier(), $nameOrNamespace);
+    }
+
+    /**
+     * Consumes an attribute selector's operator.
+     *
+     * @phpstan-return AttributeOperator::*
+     */
+    private function attributeOperator(): string
+    {
+        $start = $this->scanner->getPosition();
+
+        switch ($this->scanner->readChar()) {
+            case '=':
+                return AttributeOperator::EQUAL;
+
+            case '~':
+                $this->scanner->expectChar('=');
+                return AttributeOperator::INCLUDE;
+
+            case '|':
+                $this->scanner->expectChar('=');
+                return AttributeOperator::DASH;
+
+            case '^':
+                $this->scanner->expectChar('=');
+                return AttributeOperator::PREFIX;
+
+            case '$':
+                $this->scanner->expectChar('=');
+                return AttributeOperator::SUFFIX;
+
+            case '*':
+                $this->scanner->expectChar('=');
+                return AttributeOperator::SUBSTRING;
+
+            default:
+                $this->scanner->error('Expected "]".', $start);
+        }
+    }
+
+    /**
+     * Consumes a class selector.
+     */
+    private function classSelector(): ClassSelector
+    {
+        $this->scanner->expectChar('.');
+        $name = $this->identifier();
+
+        return new ClassSelector($name);
+    }
+
+    /**
+     * Consumes an ID selector.
+     */
+    private function idSelector(): IDSelector
+    {
+        $this->scanner->expectChar('#');
+        $name = $this->identifier();
+
+        return new IDSelector($name);
+    }
+
+    /**
+     * Consumes a placeholder selector.
+     */
+    private function placeholderSelector(): PlaceholderSelector
+    {
+        $this->scanner->expectChar('%');
+        $name = $this->identifier();
+
+        return new PlaceholderSelector($name);
+    }
+
+    /**
+     * Consumes a parent selector.
+     */
+    private function parentSelector(): ParentSelector
+    {
+        $this->scanner->expectChar('&');
+        $suffix = $this->lookingAtIdentifierBody() ? $this->identifierBody() : null;
+
+        return new ParentSelector($suffix);
+    }
+
+    /**
+     * Consumes a pseudo selector.
+     */
+    private function pseudoSelector(): PseudoSelector
+    {
+        $this->scanner->expectChar(':');
+        $element = $this->scanner->scanChar(':');
+        $name = $this->identifier();
+
+        if (!$this->scanner->scanChar('(')) {
+            return new PseudoSelector($name, $element);
+        }
+        $this->whitespace();
+
+        $unvendored = Util::unvendor($name);
+        $argument = null;
+        $selector = null;
+
+        if ($element) {
+            if (\in_array($unvendored, self::SELECTOR_PSEUDO_ELEMENTS, true)) {
+                $selector = $this->selectorList();
+            } else {
+                $argument = $this->declarationValue(true);
+            }
+        } elseif (\in_array($unvendored, self::SELECTOR_PSEUDO_CLASSES, true)) {
+            $selector = $this->selectorList();
+        } elseif ($unvendored === 'nth-child' || $unvendored === 'nth-last-child') {
+            $argument = $this->aNPlusB();
+            $this->whitespace();
+
+            if (Character::isWhitespace($this->scanner->peekChar(-1)) && $this->scanner->peekChar() !== ')') {
+                $this->expectIdentifier('of');
+                $argument .= ' of';
+                $this->whitespace();
+
+                $selector = $this->selectorList();
+            }
+        } else {
+            $argument = rtrim($this->declarationValue(true));
+        }
+
+        $this->scanner->expectChar(')');
+
+        return new PseudoSelector($name, $element, $argument, $selector);
+    }
+
+    /**
+     * Consumes an [`An+B` production][An+B] and returns its text.
+     *
+     * [An+B]: https://drafts.csswg.org/css-syntax-3/#anb-microsyntax
+     */
+    private function aNPlusB(): string
+    {
+        $buffer = '';
+
+        switch ($this->scanner->peekChar()) {
+            case 'e':
+            case 'E':
+                $this->expectIdentifier('even');
+                return 'even';
+
+            case 'o':
+            case 'O':
+                $this->expectIdentifier('odd');
+                return 'odd';
+
+            case '+':
+            case '-':
+                $buffer .= $this->scanner->readChar();
+                break;
+        }
+
+        $first = $this->scanner->peekChar();
+
+        if ($first !== null && Character::isDigit($first)) {
+            while (Character::isDigit($this->scanner->peekChar())) {
+                $buffer .= $this->scanner->readChar();
+            }
+            $this->whitespace();
+
+            if (!$this->scanIdentChar('n')) {
+                return $buffer;
+            }
+        } else {
+            $this->expectIdentChar('n');
+        }
+        $buffer .= 'n';
+        $this->whitespace();
+
+        $next = $this->scanner->peekChar();
+        if ($next !== '+' && $next !== '-') {
+            return $buffer;
+        }
+        $buffer .= $this->scanner->readChar();
+        $this->whitespace();
+
+        $last = $this->scanner->peekChar();
+        if ($last === null || !Character::isDigit($last)) {
+            $this->scanner->error('Expected a number.');
+        }
+        while (Character::isDigit($this->scanner->peekChar())) {
+            $buffer .= $this->scanner->readChar();
+        }
+
+        return $buffer;
+    }
+
+    /**
+     * Consumes a type selector or a universal selector.
+     *
+     * These are combined because either one could start with `*`.
+     */
+    private function typeOrUniversalSelector(): SimpleSelector
+    {
+        $first = $this->scanner->peekChar();
+
+        if ($first === '*') {
+            $this->scanner->readChar();
+
+            if (!$this->scanner->scanChar('|')) {
+                return new UniversalSelector();
+            }
+
+            if ($this->scanner->scanChar('*')) {
+                return new UniversalSelector('*');
+            }
+
+            return new TypeSelector(new QualifiedName($this->identifier(), '*'));
+        }
+
+        if ($first === '|') {
+            $this->scanner->readChar();
+
+            if ($this->scanner->scanChar('*')) {
+                return new UniversalSelector('');
+            }
+
+            return new TypeSelector(new QualifiedName($this->identifier(), ''));
+        }
+
+        $nameOrNamespace = $this->identifier();
+
+        if (!$this->scanner->scanChar('|')) {
+            return new TypeSelector(new QualifiedName($nameOrNamespace));
+        }
+
+        if ($this->scanner->scanChar('*')) {
+            return new UniversalSelector($nameOrNamespace);
+        }
+
+        return new TypeSelector(new QualifiedName($this->identifier(), $nameOrNamespace));
+    }
+}

--- a/src/Serializer/Serializer.php
+++ b/src/Serializer/Serializer.php
@@ -12,6 +12,7 @@
 
 namespace ScssPhp\ScssPhp\Serializer;
 
+use ScssPhp\ScssPhp\Ast\Selector\Selector;
 use ScssPhp\ScssPhp\Exception\SassScriptException;
 use ScssPhp\ScssPhp\Value\Value;
 
@@ -34,6 +35,22 @@ final class Serializer
     {
         $visitor = new SerializeVisitor($inspect, $quote);
         $value->accept($visitor);
+
+        return (string) $visitor->getBuffer();
+    }
+
+    /**
+     * Converts $selector to a CSS string.
+     *
+     * If $inspect is `true`, this will emit an unambiguous representation of the
+     * source structure. Note however that, although this will be valid SCSS, it
+     * may not be valid CSS. If $inspect is `false` and $selector can't be
+     * represented in plain CSS, throws a {@see SassScriptException}.
+     */
+    public static function serializeSelector(Selector $selector, bool $inspect = false): string
+    {
+        $visitor = new SerializeVisitor($inspect);
+        $selector->accept($visitor); // TODO
 
         return (string) $visitor->getBuffer();
     }

--- a/src/Util/Character.php
+++ b/src/Util/Character.php
@@ -116,6 +116,15 @@ final class Character
     }
 
     /**
+     *  Returns whether $character can start a simple selector other than a type
+     * selector.
+     */
+    public static function isSimpleSelectorStart(?string $character): bool
+    {
+        return $character === '*' || $character === '[' || $character === '.' || $character === '#' || $character === '%' || $character === ':';
+    }
+
+    /**
      * Returns whether $identifier is module-private.
      *
      * Assumes $identifier is a valid Sass identifier.

--- a/src/Util/EquatableUtil.php
+++ b/src/Util/EquatableUtil.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Util;
+
+/**
+ * @internal
+ */
+final class EquatableUtil
+{
+    /**
+     * Checks whether 2 lists are equals, using the Equatable semantic to compare objects if possible.
+     *
+     * @param list<mixed> $list1
+     * @param list<mixed> $list2
+     */
+    public static function listEquals(array $list1, array $list2): bool
+    {
+        if (\count($list1) !== \count($list2)) {
+            return false;
+        }
+
+        foreach ($list1 as $i => $item1) {
+            $item2 = $list2[$i];
+
+            if ($item1 === $item2) {
+                continue;
+            }
+
+            if ($item1 instanceof Equatable && $item2 instanceof Equatable && $item1->equals($item2)) {
+                continue;
+            }
+
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Visitor/SelectorVisitor.php
+++ b/src/Visitor/SelectorVisitor.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Visitor;
+
+use ScssPhp\ScssPhp\Ast\Selector\AttributeSelector;
+use ScssPhp\ScssPhp\Ast\Selector\ClassSelector;
+use ScssPhp\ScssPhp\Ast\Selector\ComplexSelector;
+use ScssPhp\ScssPhp\Ast\Selector\CompoundSelector;
+use ScssPhp\ScssPhp\Ast\Selector\IDSelector;
+use ScssPhp\ScssPhp\Ast\Selector\ParentSelector;
+use ScssPhp\ScssPhp\Ast\Selector\PlaceholderSelector;
+use ScssPhp\ScssPhp\Ast\Selector\PseudoSelector;
+use ScssPhp\ScssPhp\Ast\Selector\SelectorList;
+use ScssPhp\ScssPhp\Ast\Selector\TypeSelector;
+use ScssPhp\ScssPhp\Ast\Selector\UniversalSelector;
+
+/**
+ * An interface for visitors that traverse selectors.
+ *
+ * @internal
+ *
+ * @template T
+ */
+interface SelectorVisitor
+{
+    /**
+     * @return T
+     */
+    public function visitAttributeSelector(AttributeSelector $attribute);
+
+    /**
+     * @return T
+     */
+    public function visitClassSelector(ClassSelector $klass);
+
+    /**
+     * @return T
+     */
+    public function visitComplexSelector(ComplexSelector $complex);
+
+    /**
+     * @return T
+     */
+    public function visitCompoundSelector(CompoundSelector $compound);
+
+    /**
+     * @return T
+     */
+    public function visitIDSelector(IDSelector $id);
+
+    /**
+     * @return T
+     */
+    public function visitParentSelector(ParentSelector $parent);
+
+    /**
+     * @return T
+     */
+    public function visitPlaceholderSelector(PlaceholderSelector $placeholder);
+
+    /**
+     * @return T
+     */
+    public function visitPseudoSelector(PseudoSelector $pseudo);
+
+    /**
+     * @return T
+     */
+    public function visitSelectorList(SelectorList $list);
+
+    /**
+     * @return T
+     */
+    public function visitTypeSelector(TypeSelector $type);
+
+    /**
+     * @return T
+     */
+    public function visitUniversalSelector(UniversalSelector $universal);
+}

--- a/tests/Parser/SelectorParserTest.php
+++ b/tests/Parser/SelectorParserTest.php
@@ -1,0 +1,109 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Tests\Parser;
+
+use PHPUnit\Framework\TestCase;
+use ScssPhp\ScssPhp\Ast\Selector\CompoundSelector;
+use ScssPhp\ScssPhp\Ast\Selector\SelectorList;
+use ScssPhp\ScssPhp\Ast\Selector\SimpleSelector;
+
+class SelectorParserTest extends TestCase
+{
+    /**
+     * @dataProvider provideSimpleSelectors
+     */
+    public function testSimpleSelector(string $selector)
+    {
+        $this->assertInstanceOf(SimpleSelector::class, SimpleSelector::parse($selector));
+    }
+
+    /**
+     * @dataProvider provideSimpleSelectors
+     * @dataProvider provideCompoundSelectors
+     */
+    public function testCompoundSelector(string $selector)
+    {
+        $this->assertInstanceOf(CompoundSelector::class, CompoundSelector::parse($selector));
+    }
+
+    /**
+     * @dataProvider provideSimpleSelectors
+     * @dataProvider provideCompoundSelectors
+     * @dataProvider provideSelectorLists
+     */
+    public function testSelectorList(string $selector)
+    {
+        $this->assertInstanceOf(SelectorList::class, SelectorList::parse($selector));
+    }
+
+    public static function provideSimpleSelectors(): iterable
+    {
+        yield ['b'];
+        yield ['a|b'];
+        yield ['|b'];
+        yield ['*|b'];
+        yield ['*'];
+        yield ['a|*'];
+        yield ['|*'];
+        yield ['*|*'];
+        yield ['.foo'];
+        yield ['#bar'];
+        yield ['[a]'];
+        yield ['[*|a]'];
+        yield ['[c|a]'];
+        yield ['[a=b]'];
+        yield ['[a=\'b\']'];
+        yield ['[a="b"]'];
+        yield ['[a|=b]'];
+        yield ['[a~=b]'];
+        yield ['[a*=b]'];
+        yield ['[a^=b]'];
+        yield ['[a$=b]'];
+        yield ['%a'];
+        yield ['&'];
+        yield ['&a'];
+        yield ['&2'];
+        yield [':before'];
+        yield ['::before'];
+        yield ['::slotted(.foo bar)'];
+        yield [':not(.foo bar)'];
+        yield [':where(.foo bar)'];
+        yield [':nth-child(n)'];
+        yield [':nth-child(2n)'];
+        yield [':nth-child(2n+5)'];
+        yield [':nth-child(-2n+5)'];
+        yield [':nth-child(odd)'];
+        yield [':nth-child(even)'];
+        yield [':nth-child(2n of .foo, bar)'];
+        yield [':last-child'];
+    }
+
+    public static function provideCompoundSelectors(): iterable
+    {
+        yield ['a.b'];
+        yield ['a#b'];
+        yield ['a#b::before:hover'];
+    }
+
+    public static function provideSelectorLists(): iterable
+    {
+        yield ['a b'];
+        yield ['a > .b'];
+        yield ['a ~ .b'];
+        yield ['a + .b'];
+        yield ['a, .b'];
+        yield ["a,\n.b"];
+        yield ['a,'];
+        yield ['a, , .b'];
+    }
+}


### PR DESCRIPTION
Note that the selector AST currently misses the `unify()` method that is present in `SelectorList` and `SimpleSelector`. Implementing the selector unification algorithm will be done separately (the algo of SimpleSelector is easy, but SelectorList is much more complex).