### PR TITLE
Implement the AtRootQueryParser ported from dart-sass

### DIFF
--- a/src/Ast/Sass/AtRootQuery.php
+++ b/src/Ast/Sass/AtRootQuery.php
@@ -1,0 +1,134 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Sass;
+
+use ScssPhp\ScssPhp\Exception\SassFormatException;
+use ScssPhp\ScssPhp\Logger\LoggerInterface;
+use ScssPhp\ScssPhp\Parser\AtRootQueryParser;
+
+/**
+ * A query for the `@at-root` rule.
+ *
+ * @internal
+ */
+class AtRootQuery
+{
+    /**
+     * Whether the query includes or excludes rules with the specified names.
+     *
+     * @var bool
+     * @readonly
+     */
+    private $include;
+
+    /**
+     * The names of the rules included or excluded by this query.
+     *
+     * There are two special names. "all" indicates that all rules are included
+     * or excluded, and "rule" indicates style rules are included or excluded.
+     *
+     * @var string[]
+     * @readonly
+     */
+    private $names;
+
+    /**
+     * Whether this includes or excludes *all* rules.
+     *
+     * @var bool
+     * @readonly
+     */
+    private $all;
+
+    /**
+     * Whether this includes or excludes style rules.
+     *
+     * @var bool
+     * @readonly
+     */
+    private $rule;
+
+    /**
+     * Parses an at-root query from $contents.
+     *
+     * If passed, $url is the name of the file from which $contents comes.
+     *
+     * @throws SassFormatException if parsing fails
+     */
+    public static function parse(string $contents, ?LoggerInterface $logger = null, ?string $url = null): AtRootQuery
+    {
+        return (new AtRootQueryParser($contents, $logger, $url))->parse();
+    }
+
+    /**
+     * @param string[] $names
+     * @param bool     $include
+     */
+    public static function create(array $names, bool $include): AtRootQuery
+    {
+        return new AtRootQuery($names, $include, \in_array('all', $names, true), \in_array('rule', $names, true));
+    }
+
+    /**
+     * The default at-root query
+     */
+    public static function getDefault(): AtRootQuery
+    {
+        return new AtRootQuery([], false, false, true);
+    }
+
+    /**
+     * @param string[] $names
+     * @param bool     $include
+     * @param bool     $all
+     * @param bool     $rule
+     */
+    private function __construct(array $names, bool $include, bool $all, bool $rule)
+    {
+        $this->include = $include;
+        $this->names = $names;
+        $this->all = $all;
+        $this->rule = $rule;
+    }
+
+    public function getInclude(): bool
+    {
+        return $this->include;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getNames(): array
+    {
+        return $this->names;
+    }
+
+    /**
+     * Whether this excludes style rules.
+     *
+     * Note that this takes {@see include} into account.
+     */
+    public function excludesStyleRules(): bool
+    {
+        return ($this->all || $this->rule) !== $this->include;
+    }
+
+    /**
+     * Returns whether $this excludes an at-rule with the given $name.
+     */
+    public function excludesName(string $name): bool
+    {
+        return ($this->all || \in_array($name, $this->names, true)) !== $this->include;
+    }
+}

--- a/src/Parser/AtRootQueryParser.php
+++ b/src/Parser/AtRootQueryParser.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Parser;
+
+use ScssPhp\ScssPhp\Ast\Sass\AtRootQuery;
+use ScssPhp\ScssPhp\Exception\SassFormatException;
+
+/**
+ * A parser for `@at-root` queries.
+ *
+ * @internal
+ */
+final class AtRootQueryParser extends Parser
+{
+    /**
+     * @throws SassFormatException
+     */
+    public function parse(): AtRootQuery
+    {
+        try {
+            $this->scanner->expectChar('(');
+            $this->whitespace();
+            $include = $this->scanIdentifier('with');
+            if (!$include) {
+                $this->expectIdentifier('without', '"with" or "without"');
+            }
+            $this->whitespace();
+            $this->scanner->expectChar(':');
+            $this->whitespace();
+
+            $atRules = [];
+
+            do {
+                $atRules[] = strtolower($this->identifier());
+                $this->whitespace();
+            } while ($this->lookingAtIdentifier());
+
+            $this->scanner->expectChar(')');
+            $this->scanner->expectDone();
+
+            return AtRootQuery::create($atRules, $include);
+        } catch (FormatException $e) {
+            throw $this->wrapException($e);
+        }
+    }
+}

--- a/tests/Parser/AtRootQueryParserTest.php
+++ b/tests/Parser/AtRootQueryParserTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Tests\Parser;
+
+use ScssPhp\ScssPhp\Ast\Sass\AtRootQuery;
+use PHPUnit\Framework\TestCase;
+use ScssPhp\ScssPhp\Exception\SassFormatException;
+
+class AtRootQueryParserTest extends TestCase
+{
+    public function testWithSingle()
+    {
+        $query = AtRootQuery::parse('(with: a)');
+
+        $this->assertTrue($query->getInclude());
+        $this->assertEquals(['a'], $query->getNames());
+    }
+
+    public function testWithMultiple()
+    {
+        $query = AtRootQuery::parse('(with: a b c)');
+
+        $this->assertTrue($query->getInclude());
+        $this->assertEquals(['a', 'b', 'c'], $query->getNames());
+    }
+
+    public function testWithoutSingle()
+    {
+        $query = AtRootQuery::parse('(without: a)');
+
+        $this->assertFalse($query->getInclude());
+        $this->assertEquals(['a'], $query->getNames());
+    }
+
+    /**
+     * @dataProvider provideInvalidQueries
+     */
+    public function testInvalidQuery(string $query)
+    {
+        $this->expectException(SassFormatException::class);
+
+        AtRootQuery::parse($query);
+    }
+
+    public static function provideInvalidQueries(): iterable
+    {
+        yield ['with: a'];
+        yield ['(with: a'];
+        yield ['(wit: a)'];
+        yield ['(with a)'];
+        yield ['(with: 2)'];
+    }
+}


### PR DESCRIPTION
Continuing my work porting the various parsers. In Sass, the queries of the `@at-root` rule are parsed after resolving interpolation, and so handled by a secondary parser.