### PR TITLE
Implement the keyframe selector parser ported from dart-sass

### DIFF
--- a/src/Parser/KeyframeSelectorParser.php
+++ b/src/Parser/KeyframeSelectorParser.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Parser;
+
+use ScssPhp\ScssPhp\Exception\SassFormatException;
+use ScssPhp\ScssPhp\Util\Character;
+
+/**
+ * A parser for `@keyframes` block selectors.
+ */
+class KeyframeSelectorParser extends Parser
+{
+    /**
+     * @return string[]
+     *
+     * @throws SassFormatException
+     */
+    public function parse(): array
+    {
+        try {
+            $selectors = [];
+
+            do {
+                $this->whitespace();
+                if ($this->lookingAtIdentifier()) {
+                    if ($this->scanIdentifier('from')) {
+                        $selectors[] = 'from';
+                    } else {
+                        $this->expectIdentifier('to', '"to" or "from"');
+                        $selectors[] = 'to';
+                    }
+                } else {
+                    $selectors[] = $this->percentage();
+                }
+                $this->whitespace();
+            } while ($this->scanner->scanChar(','));
+            $this->scanner->expectDone();
+
+            return $selectors;
+        } catch (FormatException $e) {
+            throw $this->wrapException($e);
+        }
+    }
+
+    private function percentage(): string
+    {
+        $buffer = '';
+
+        if ($this->scanner->scanChar('+')) {
+            $buffer .= '+';
+        }
+
+        $second = $this->scanner->peekChar();
+
+        if (!Character::isDigit($second) && $second !== '.') {
+            $this->scanner->error('Expected number.');
+        }
+
+        while (Character::isDigit($this->scanner->peekChar())) {
+            $buffer .= $this->scanner->readChar();
+        }
+
+        if ($this->scanner->peekChar() === '.') {
+            $buffer .= $this->scanner->readChar();
+
+            while (Character::isDigit($this->scanner->peekChar())) {
+                $buffer .= $this->scanner->readChar();
+            }
+        }
+
+        if ($this->scanIdentChar('e')) {
+            $buffer .= 'e';
+            $next = $this->scanner->peekChar();
+
+            if ($next === '+' || $next === '-') {
+                $buffer .= $this->scanner->readChar();
+            }
+
+            if (!Character::isDigit($this->scanner->peekChar())) {
+                $this->scanner->error('Expected digit.');
+            }
+
+            while (Character::isDigit($this->scanner->peekChar())) {
+                $buffer .= $this->scanner->readChar();
+            }
+        }
+
+        $this->scanner->expectChar('%');
+        $buffer .= '%';
+
+        return $buffer;
+    }
+}

--- a/tests/Parser/KeyframeSelectorParserTest.php
+++ b/tests/Parser/KeyframeSelectorParserTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace ScssPhp\ScssPhp\Tests\Parser;
+
+use ScssPhp\ScssPhp\Parser\KeyframeSelectorParser;
+use PHPUnit\Framework\TestCase;
+
+class KeyframeSelectorParserTest extends TestCase
+{
+    /**
+     * @dataProvider provideSelectors
+     */
+    public function testParse(array $expected, string $selector)
+    {
+        $this->assertEquals($expected, (new KeyframeSelectorParser($selector))->parse());
+    }
+
+    public static function provideSelectors(): iterable
+    {
+        yield [['from'], 'from'];
+        yield [['from', '5%', 'to'], 'from, 5% ,to'];
+        yield [['3.5%'], '3.5%'];
+        yield [['+2.5%'], '+2.5%'];
+        yield [['+2.5e5%'], '+2.5e5%'];
+        yield [['+2.5e5%'], '+2.5E5%'];
+        yield [['2.5e+5%'], '2.5E+5%'];
+        yield [['2.5e-5%'], '2.5e-5%'];
+    }
+}


### PR DESCRIPTION
By writing unit tests for it, I discovered a bug in the dart-sass implementation (already fixed in my PHP code, but not yet upstreamed)