### PR TITLE
Implement selector manipulation algorithms ported from dart-sass

### DIFF
--- a/src/Ast/Selector/ComplexSelector.php
+++ b/src/Ast/Selector/ComplexSelector.php
@@ -12,6 +12,7 @@
 
 namespace ScssPhp\ScssPhp\Ast\Selector;
 
+use ScssPhp\ScssPhp\Extend\ExtendUtil;
 use ScssPhp\ScssPhp\Util\EquatableUtil;
 use ScssPhp\ScssPhp\Visitor\SelectorVisitor;
 
@@ -78,6 +79,15 @@ class ComplexSelector extends Selector
         return $this->components;
     }
 
+    /**
+     * @return CompoundSelector|string
+     * @phpstan-return CompoundSelector|Combinator::*
+     */
+    public function getLastComponent()
+    {
+        return $this->components[\count($this->components) - 1];
+    }
+
     public function getLineBreak(): bool
     {
         return $this->lineBreak;
@@ -117,6 +127,17 @@ class ComplexSelector extends Selector
     public function accept(SelectorVisitor $visitor)
     {
         return $visitor->visitComplexSelector($this);
+    }
+
+    /**
+     * Whether this is a superselector of $other.
+     *
+     * That is, whether this matches every element that $other matches, as well
+     * as possibly additional elements.
+     */
+    public function isSuperselector(ComplexSelector $other): bool
+    {
+        return ExtendUtil::complexIsSuperselector($this->components, $other->components);
     }
 
     public function equals(object $other): bool

--- a/src/Ast/Selector/CompoundSelector.php
+++ b/src/Ast/Selector/CompoundSelector.php
@@ -13,6 +13,7 @@
 namespace ScssPhp\ScssPhp\Ast\Selector;
 
 use ScssPhp\ScssPhp\Exception\SassFormatException;
+use ScssPhp\ScssPhp\Extend\ExtendUtil;
 use ScssPhp\ScssPhp\Logger\LoggerInterface;
 use ScssPhp\ScssPhp\Parser\SelectorParser;
 use ScssPhp\ScssPhp\Util\EquatableUtil;
@@ -113,6 +114,17 @@ final class CompoundSelector extends Selector
     public function accept(SelectorVisitor $visitor)
     {
         return $visitor->visitCompoundSelector($this);
+    }
+
+    /**
+     * Whether this is a superselector of $other.
+     *
+     * That is, whether this matches every element that $other matches, as well
+     * as possibly additional elements.
+     */
+    public function isSuperselector(CompoundSelector $other): bool
+    {
+        return ExtendUtil::compoundIsSuperselector($this, $other);
     }
 
     public function equals(object $other): bool

--- a/src/Ast/Selector/CompoundSelector.php
+++ b/src/Ast/Selector/CompoundSelector.php
@@ -80,6 +80,11 @@ final class CompoundSelector extends Selector
         return $this->components;
     }
 
+    public function getLastComponent(): SimpleSelector
+    {
+        return $this->components[\count($this->components) - 1];
+    }
+
     public function getMinSpecificity(): int
     {
         if ($this->minSpecificity === null) {

--- a/src/Ast/Selector/IDSelector.php
+++ b/src/Ast/Selector/IDSelector.php
@@ -54,6 +54,18 @@ final class IDSelector extends SimpleSelector
         return new IDSelector($this->name . $suffix);
     }
 
+    public function unify(array $compound): ?array
+    {
+        // A given compound selector may only contain one ID.
+        foreach ($compound as $simple) {
+            if ($simple instanceof IDSelector && !$simple->equals($this)) {
+                return null;
+            }
+        }
+
+        return parent::unify($compound);
+    }
+
     public function equals(object $other): bool
     {
         return $other instanceof IDSelector && $other->name === $this->name;

--- a/src/Ast/Selector/ParentSelector.php
+++ b/src/Ast/Selector/ParentSelector.php
@@ -53,4 +53,9 @@ final class ParentSelector extends SimpleSelector
     {
         return $visitor->visitParentSelector($this);
     }
+
+    public function unify(array $compound): ?array
+    {
+        throw new \LogicException("& doesn't support unification.");
+    }
 }

--- a/src/Ast/Selector/SelectorList.php
+++ b/src/Ast/Selector/SelectorList.php
@@ -13,6 +13,7 @@
 namespace ScssPhp\ScssPhp\Ast\Selector;
 
 use ScssPhp\ScssPhp\Exception\SassFormatException;
+use ScssPhp\ScssPhp\Extend\ExtendUtil;
 use ScssPhp\ScssPhp\Logger\LoggerInterface;
 use ScssPhp\ScssPhp\Parser\SelectorParser;
 use ScssPhp\ScssPhp\Util\EquatableUtil;
@@ -101,6 +102,17 @@ final class SelectorList extends Selector
     public function accept(SelectorVisitor $visitor)
     {
         return $visitor->visitSelectorList($this);
+    }
+
+    /**
+     * Whether this is a superselector of $other.
+     *
+     * That is, whether this matches every element that $other matches, as well
+     * as possibly additional elements.
+     */
+    public function isSuperselector(SelectorList $other): bool
+    {
+        return ExtendUtil::listIsSuperselector($this->components, $other->components);
     }
 
     public function equals(object $other): bool

--- a/src/Ast/Selector/SelectorList.php
+++ b/src/Ast/Selector/SelectorList.php
@@ -13,10 +13,12 @@
 namespace ScssPhp\ScssPhp\Ast\Selector;
 
 use ScssPhp\ScssPhp\Exception\SassFormatException;
+use ScssPhp\ScssPhp\Exception\SassScriptException;
 use ScssPhp\ScssPhp\Extend\ExtendUtil;
 use ScssPhp\ScssPhp\Logger\LoggerInterface;
 use ScssPhp\ScssPhp\Parser\SelectorParser;
 use ScssPhp\ScssPhp\Util\EquatableUtil;
+use ScssPhp\ScssPhp\Util\ListUtil;
 use ScssPhp\ScssPhp\Value\ListSeparator;
 use ScssPhp\ScssPhp\Value\SassList;
 use ScssPhp\ScssPhp\Value\SassString;
@@ -132,6 +134,85 @@ final class SelectorList extends Selector
     }
 
     /**
+     * Returns a new list with all {@see ParentSelector}s replaced with $parent.
+     *
+     * If $implicitParent is true, this treats [ComplexSelector]s that don't
+     * contain an explicit {@see ParentSelector} as though they began with one.
+     *
+     * The given $parent may be `null`, indicating that this has no parents. If
+     * so, this list is returned as-is if it doesn't contain any explicit
+     * {@see ParentSelector}s. If it does, this throws a {@see SassScriptException}.
+     */
+    public function resolveParentSelectors(?SelectorList $parent, bool $implicitParent = true): SelectorList
+    {
+        if ($parent === null) {
+            if (!$this->containsParentSelector()) {
+                return $this;
+            }
+
+            throw new SassScriptException('Top-level selectors may not contain the parent selector "&".');
+        }
+
+        return new SelectorList(ListUtil::flattenVertically(array_map(function (ComplexSelector $complex) use ($parent, $implicitParent) {
+            if (!self::complexContainsParentSelector($complex)) {
+                if (!$implicitParent) {
+                    return [$complex];
+                }
+
+                return array_map(function (ComplexSelector $parentComplex) use ($complex) {
+                    return new ComplexSelector(
+                        array_merge($parentComplex->getComponents(), $complex->getComponents()),
+                        $complex->getLineBreak() || $parentComplex->getLineBreak()
+                    );
+                }, $parent->getComponents());
+            }
+
+            $newComplexes = [[]];
+            $lineBreaks = [false];
+
+            foreach ($complex->getComponents() as $component) {
+                if ($component instanceof CompoundSelector) {
+                    $resolved = self::resolveParentSelectorsCompound($component, $parent);
+                    if ($resolved === null) {
+                        foreach ($newComplexes as &$newComplex) {
+                            $newComplex[] = $component;
+                        }
+                        unset($newComplex);
+                        continue;
+                    }
+
+                    $previousComplexes = $newComplexes;
+                    $previousLineBreaks = $lineBreaks;
+
+                    $newComplexes = [];
+                    $lineBreaks = [];
+                    $i = 0;
+
+                    foreach ($previousComplexes as $newComplex) {
+                        $lineBreak = $previousLineBreaks[$i++];
+
+                        foreach ($resolved as $resolvedComplex) {
+                            $newComplexes[] = array_merge($newComplex, $resolvedComplex->getComponents());
+                            $lineBreaks[] = $lineBreak || $resolvedComplex->getLineBreak();
+                        }
+                    }
+                } else {
+                    foreach ($newComplexes as &$newComplex) {
+                        $newComplex[] = $component;
+                    }
+                    unset($newComplex);
+                }
+            }
+
+            $i = 0;
+
+            return array_map(function ($newComplex) use ($lineBreaks, &$i) {
+                return new ComplexSelector($newComplex, $lineBreaks[$i++]);
+            }, $newComplexes);
+        }, $this->components)));
+    }
+
+    /**
      * Whether this is a superselector of $other.
      *
      * That is, whether this matches every element that $other matches, as well
@@ -188,5 +269,91 @@ final class SelectorList extends Selector
         }
 
         return false;
+    }
+
+    /**
+     * Returns a new {@see CompoundSelector} based on $compound with all
+     * {@see ParentSelector}s replaced with $parent.
+     *
+     * Returns `null` if $compound doesn't contain any {@see ParentSelector}s.
+     *
+     * @return list<ComplexSelector>|null
+     */
+    private static function resolveParentSelectorsCompound(CompoundSelector $compound, SelectorList $parent): ?array
+    {
+        $containsSelectorPseudo = false;
+        foreach ($compound->getComponents() as $simple) {
+            if (!$simple instanceof PseudoSelector) {
+                continue;
+            }
+            $selector = $simple->getSelector();
+
+            if ($selector !== null && $selector->containsParentSelector()) {
+                $containsSelectorPseudo = true;
+                break;
+            }
+        }
+
+        if (!$containsSelectorPseudo && !$compound->getComponents()[0] instanceof ParentSelector) {
+            return null;
+        }
+
+        if ($containsSelectorPseudo) {
+            $resolvedMembers = array_map(function (SimpleSelector $simple) use ($parent): SimpleSelector {
+                if (!$simple instanceof PseudoSelector) {
+                    return $simple;
+                }
+
+                $selector = $simple->getSelector();
+                if ($selector === null) {
+                    return $simple;
+                }
+                if (!$selector->containsParentSelector()) {
+                    return $simple;
+                }
+
+                return $simple->withSelector($selector->resolveParentSelectors($parent, false));
+            }, $compound->getComponents());
+        } else {
+            $resolvedMembers = $compound->getComponents();
+        }
+
+        $parentSelector = $compound->getComponents()[0];
+
+        if ($parentSelector instanceof ParentSelector) {
+            if (\count($compound->getComponents()) === 1 && $parentSelector->getSuffix() === null) {
+                return $parent->getComponents();
+            }
+        } else {
+            return [
+                new ComplexSelector([new CompoundSelector($resolvedMembers)]),
+            ];
+        }
+
+        return array_map(function (ComplexSelector $complex) use ($parentSelector, $resolvedMembers) {
+            $lastComponent = $complex->getLastComponent();
+
+            if (!$lastComponent instanceof CompoundSelector) {
+                throw new SassScriptException("Parent \"$complex\" is incompatible with this selector.");
+            }
+
+            $last = $lastComponent;
+            $suffix = $parentSelector->getSuffix();
+
+            if ($suffix !== null) {
+                $last = new CompoundSelector(array_merge(
+                    array_slice($last->getComponents(), 0, -1),
+                    [$last->getLastComponent()->addSuffix($suffix)],
+                    array_slice($resolvedMembers, 1)
+                ));
+            } else {
+                $last = new CompoundSelector(array_merge($last->getComponents(), array_slice($resolvedMembers, 1)));
+            }
+
+            $components = array_slice($complex->getComponents(), 0, -1);
+            $components[] = $last;
+
+            return new ComplexSelector($components, $complex->getLineBreak());
+        }, $parent->getComponents());
     }
 }

--- a/src/Ast/Selector/SelectorList.php
+++ b/src/Ast/Selector/SelectorList.php
@@ -105,6 +105,33 @@ final class SelectorList extends Selector
     }
 
     /**
+     * Returns a {@see SelectorList} that matches only elements that are matched by
+     * both this and $other.
+     *
+     * If no such list can be produced, returns `null`.
+     */
+    public function unify(SelectorList $other): ?SelectorList
+    {
+        $contents = [];
+
+        foreach ($this->components as $complex1) {
+            foreach ($other->components as $complex2) {
+                $unified = ExtendUtil::unifyComplex([$complex1->getComponents(), $complex2->getComponents()]);
+
+                if ($unified === null) {
+                    continue;
+                }
+
+                foreach ($unified as $complex) {
+                    $contents[] = new ComplexSelector($complex);
+                }
+            }
+        }
+
+        return \count($contents) === 0 ? null : new SelectorList($contents);
+    }
+
+    /**
      * Whether this is a superselector of $other.
      *
      * That is, whether this matches every element that $other matches, as well

--- a/src/Ast/Selector/TypeSelector.php
+++ b/src/Ast/Selector/TypeSelector.php
@@ -12,6 +12,7 @@
 
 namespace ScssPhp\ScssPhp\Ast\Selector;
 
+use ScssPhp\ScssPhp\Extend\ExtendUtil;
 use ScssPhp\ScssPhp\Visitor\SelectorVisitor;
 
 /**
@@ -50,6 +51,25 @@ final class TypeSelector extends SimpleSelector
     public function addSuffix(string $suffix): SimpleSelector
     {
         return new TypeSelector(new QualifiedName($this->name->getName() . $suffix, $this->name->getNamespace()));
+    }
+
+    public function unify(array $compound): ?array
+    {
+        $first = $compound[0] ?? null;
+
+        if ($first instanceof UniversalSelector || $first instanceof TypeSelector) {
+            $unified = ExtendUtil::unifyUniversalAndElement($this, $first);
+
+            if ($unified === null) {
+                return null;
+            }
+
+            $compound[0] = $unified;
+
+            return $compound;
+        }
+
+        return array_merge([$this], $compound);
     }
 
     public function equals(object $other): bool

--- a/src/Extend/ExtendUtil.php
+++ b/src/Extend/ExtendUtil.php
@@ -1,0 +1,496 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Extend;
+
+use ScssPhp\ScssPhp\Ast\Selector\Combinator;
+use ScssPhp\ScssPhp\Ast\Selector\ComplexSelector;
+use ScssPhp\ScssPhp\Ast\Selector\CompoundSelector;
+use ScssPhp\ScssPhp\Ast\Selector\IDSelector;
+use ScssPhp\ScssPhp\Ast\Selector\PlaceholderSelector;
+use ScssPhp\ScssPhp\Ast\Selector\PseudoSelector;
+use ScssPhp\ScssPhp\Ast\Selector\SelectorList;
+use ScssPhp\ScssPhp\Ast\Selector\SimpleSelector;
+use ScssPhp\ScssPhp\Ast\Selector\TypeSelector;
+use ScssPhp\ScssPhp\Util\EquatableUtil;
+
+/**
+ * @internal
+ */
+final class ExtendUtil
+{
+    /**
+     * Names of pseudo selectors that take selectors as arguments, and that are
+     * subselectors of their arguments.
+     *
+     * For example, `.foo` is a superselector of `:matches(.foo)`.
+     */
+    private const SUBSELECTOR_PSEUDOS = [
+        'is',
+        'matches',
+        'any',
+        'nth-child',
+        'nth-last-child',
+    ];
+
+    /**
+     * Returns whether $list1 is a superselector of $list2.
+     *
+     * That is, whether $list1 matches every element that $list2 matches, as well
+     * as possibly additional elements.
+     *
+     * @param list<ComplexSelector> $list1
+     * @param list<ComplexSelector> $list2
+     *
+     * @return bool
+     */
+    public static function listIsSuperselector(array $list1, array $list2): bool
+    {
+        foreach ($list2 as $complex1) {
+            foreach ($list1 as $complex2) {
+                if ($complex2->isSuperselector($complex1)) {
+                    continue 2;
+                }
+            }
+
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Like {@see complexIsSuperselector}, but compares $complex1 and $complex2 as
+     * though they shared an implicit base {@see SimpleSelector}.
+     *
+     * For example, `B` is not normally a superselector of `B A`, since it doesn't
+     * match elements that match `A`. However, it *is* a parent superselector,
+     * since `B X` is a superselector of `B A X`.
+     *
+     * @param list<CompoundSelector|string> $complex1
+     * @param list<CompoundSelector|string> $complex2
+     *
+     * @return bool
+     *
+     * @phpstan-param list<CompoundSelector|Combinator::*> $complex1
+     * @phpstan-param list<CompoundSelector|Combinator::*> $complex2
+     */
+    public static function complexIsParentSuperselector(array $complex1, array $complex2): bool
+    {
+        if (\is_string($complex1[0])) {
+            return false;
+        }
+        if (\is_string($complex2[0])) {
+            return false;
+        }
+
+        if (\count($complex1) > \count($complex2)) {
+            return false;
+        }
+
+        $base = new CompoundSelector([new PlaceholderSelector('<temp>')]);
+        $complex1[] = $base;
+        $complex2[] = $base;
+
+        return self::complexIsSuperselector($complex1, $complex2);
+    }
+
+    /**
+     * Returns whether $complex1 is a superselector of $complex2.
+     *
+     * That is, whether $complex1 matches every element that $complex2 matches, as well
+     * as possibly additional elements.
+     *
+     * @param list<CompoundSelector|string> $complex1
+     * @param list<CompoundSelector|string> $complex2
+     *
+     * @return bool
+     *
+     * @phpstan-param list<CompoundSelector|Combinator::*> $complex1
+     * @phpstan-param list<CompoundSelector|Combinator::*> $complex2
+     */
+    public static function complexIsSuperselector(array $complex1, array $complex2): bool
+    {
+        // Selectors with trailing operators are neither superselectors nor
+        // subselectors.
+        if (\is_string($complex1[\count($complex1) - 1])) {
+            return false;
+        }
+        if (\is_string($complex2[\count($complex2) - 1])) {
+            return false;
+        }
+
+        $i1 = 0;
+        $i2 = 0;
+
+        while (true) {
+            $remaining1 = \count($complex1) - $i1;
+            $remaining2 = \count($complex2) - $i2;
+
+            if ($remaining1 === 0 || $remaining2 === 0) {
+                return false;
+            }
+
+            // More complex selectors are never superselectors of less complex ones.
+            if ($remaining1 > $remaining2) {
+                return false;
+            }
+
+            // Selectors with leading operators are neither superselectors nor
+            // subselectors.
+            if (\is_string($complex1[$i1])) {
+                return false;
+            }
+            if (\is_string($complex2[$i2])) {
+                return false;
+            }
+
+            $compound1 = $complex1[$i1];
+
+            if ($remaining1 === 1) {
+                return self::compoundIsSuperselector($compound1, $complex2[\count($complex2) - 1], array_slice($complex2, $i2, -1));
+            }
+
+            // Find the first index where `complex2.sublist(i2, afterSuperselector)` is
+            // a subselector of $compound1. We stop before the superselector would
+            // encompass all of $complex2 because we know $complex1 has more than one
+            // element, and consuming all of $complex2 wouldn't leave anything for the
+            // rest of $complex1 to match.
+            $afterSuperselector = $i2 + 1;
+            for (; $afterSuperselector < \count($complex2); $afterSuperselector++) {
+                $compound2 = $complex2[$afterSuperselector - 1];
+
+                if ($compound2 instanceof CompoundSelector) {
+                    if (self::compoundIsSuperselector($compound1, $compound2, array_slice($complex2, $i2 + 1, max(0, ($afterSuperselector - 1) - ($i2 + 1))))) {
+                        break;
+                    }
+                }
+            }
+
+            if ($afterSuperselector === \count($complex2)) {
+                return false;
+            }
+
+            $combinator1 = $complex1[$i1 + 1];
+            $combinator2 = $complex2[$afterSuperselector];
+
+            if (\is_string($combinator1)) { // Combinator
+                if (!\is_string($combinator2)) {
+                    return false;
+                }
+
+                // `.foo ~ .bar` is a superselector of `.foo + .bar`, but otherwise the
+                // combinators must match.
+                if ($combinator1 === Combinator::FOLLOWING_SIBLING) {
+                    if ($combinator2 === Combinator::CHILD) {
+                        return false;
+                    }
+                } elseif ($combinator1 !== $combinator2) {
+                    return false;
+                }
+
+                // `.foo > .baz` is not a superselector of `.foo > .bar > .baz` or
+                // `.foo > .bar .baz`, despite the fact that `.baz` is a superselector of
+                // `.bar > .baz` and `.bar .baz`. Same goes for `+` and `~`.
+                if ($remaining1 === 3 && $remaining2 > 3) {
+                    return false;
+                }
+
+                $i1 += 2;
+                $i2 = $afterSuperselector + 1;
+            } elseif (\is_string($combinator2)) {
+                if ($combinator2 !== Combinator::CHILD) {
+                    return false;
+                }
+
+                $i1++;
+                $i2 = $afterSuperselector + 1;
+            } else {
+                $i1++;
+                $i2 = $afterSuperselector;
+            }
+        }
+    }
+
+    /**
+     * Returns whether $compound1 is a superselector of $compound2.
+     *
+     * That is, whether $compound1 matches every element that $compound2 matches, as well
+     * as possibly additional elements.
+     *
+     * If $parents is passed, it represents the parents of $compound2. This is
+     * relevant for pseudo selectors with selector arguments, where we may need to
+     * know if the parent selectors in the selector argument match $parents.
+     *
+     * @param CompoundSelector                   $compound1
+     * @param CompoundSelector                   $compound2
+     * @param list<CompoundSelector|string>|null $parents
+     *
+     * @return bool
+     *
+     * @phpstan-param list<CompoundSelector|Combinator::*>|null $parents
+     */
+    public static function compoundIsSuperselector(CompoundSelector $compound1, CompoundSelector $compound2, ?array $parents = null): bool
+    {
+        // Every selector in `$compound1->getComponents()` must have a matching selector in
+        // `$compound2->getComponents()`.
+        foreach ($compound1->getComponents() as $simple1) {
+            if ($simple1 instanceof PseudoSelector && $simple1->getSelector() !== null) {
+                if (!self::selectorPseudoIsSuperselector($simple1, $compound2, $parents)) {
+                    return false;
+                }
+            } elseif (!self::simpleIsSuperselectorOfCompound($simple1, $compound2)) {
+                return false;
+            }
+        }
+
+        // $compound1 can't be a superselector of a selector with non-selector
+        // pseudo-elements that $compound2 doesn't share.
+        foreach ($compound2->getComponents() as $simple2) {
+            if ($simple2 instanceof PseudoSelector && $simple2->isElement() && $simple2->getSelector() === null && !self::simpleIsSuperselectorOfCompound($simple2, $compound1)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Returns whether $simple is a superselector of $compound.
+     *
+     * That is, whether $simple matches every element that $compound matches, as
+     * well as possibly additional elements.
+     */
+    private static function simpleIsSuperselectorOfCompound(SimpleSelector $simple, CompoundSelector $compound): bool
+    {
+        foreach ($compound->getComponents() as $theirSimple) {
+            if ($simple->equals($theirSimple)) {
+                return true;
+            }
+
+            // Some selector pseudoclasses can match normal selectors.
+            if (!$theirSimple instanceof PseudoSelector) {
+                continue;
+            }
+            $selector = $theirSimple->getSelector();
+            if ($selector === null) {
+                continue;
+            }
+            if (!\in_array($theirSimple->getNormalizedName(), self::SUBSELECTOR_PSEUDOS, true)) {
+                return false;
+            }
+
+            foreach ($selector->getComponents() as $complex) {
+                if (\count($complex->getComponents()) !== 1) {
+                    continue 2;
+                }
+
+                $innerCompound = $complex->getComponents()[0];
+                assert($innerCompound instanceof CompoundSelector);
+
+                if (!EquatableUtil::listContains($innerCompound->getComponents(), $simple)) {
+                    continue 2;
+                }
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns whether $pseudo1 is a superselector of $compound2.
+     *
+     * That is, whether $pseudo1 matches every element that $compound2 matches, as well
+     * as possibly additional elements.
+     *
+     * This assumes that $pseudo1's `selector` argument is not `null`.
+     *
+     * If $parents is passed, it represents the parents of $compound2. This is
+     * relevant for pseudo selectors with selector arguments, where we may need to
+     * know if the parent selectors in the selector argument match $parents.
+     *
+     * @phpstan-param list<CompoundSelector|Combinator::*>|null $parents
+     */
+    private static function selectorPseudoIsSuperselector(PseudoSelector $pseudo1, CompoundSelector $compound2, ?array $parents): bool
+    {
+        $selector1 = $pseudo1->getSelector();
+
+        if ($selector1 === null) {
+            throw new \InvalidArgumentException("Selector $pseudo1 must have a selector argument.");
+        }
+
+        switch ($pseudo1->getNormalizedName()) {
+            case 'is':
+            case 'matches':
+            case 'any':
+                $selectors = self::selectorPseudoArgs($compound2, $pseudo1->getName());
+
+                foreach ($selectors as $selector2) {
+                    if ($selector1->isSuperselector($selector2)) {
+                        return true;
+                    }
+                }
+
+                $compoundWithParents = $parents;
+                $compoundWithParents[] = $compound2;
+
+                foreach ($selector1->getComponents() as $complex1) {
+                    if (self::complexIsSuperselector($complex1->getComponents(), $compoundWithParents)) {
+                        return true;
+                    }
+                }
+
+                return false;
+
+            case 'has':
+            case 'host':
+            case 'host-context':
+                $selectors = self::selectorPseudoArgs($compound2, $pseudo1->getName());
+
+                foreach ($selectors as $selector2) {
+                    if ($selector1->isSuperselector($selector2)) {
+                        return true;
+                    }
+                }
+
+                return false;
+
+            case 'slotted':
+                $selectors = self::selectorPseudoArgs($compound2, $pseudo1->getName(), false);
+
+                foreach ($selectors as $selector2) {
+                    if ($selector1->isSuperselector($selector2)) {
+                        return true;
+                    }
+                }
+
+                return false;
+
+            case 'not':
+                foreach ($selector1->getComponents() as $complex) {
+                    foreach ($compound2->getComponents() as $simple2) {
+                        if ($simple2 instanceof TypeSelector) {
+                            $compound1 = $complex->getLastComponent();
+
+                            if (!$compound1 instanceof CompoundSelector) {
+                                continue;
+                            }
+
+                            foreach ($compound1->getComponents() as $simple1) {
+                                if ($simple1 instanceof TypeSelector && !$simple1->equals($simple2)) {
+                                    continue 3;
+                                }
+                            }
+                        } elseif ($simple2 instanceof IDSelector) {
+                            $compound1 = $complex->getLastComponent();
+
+                            if (!$compound1 instanceof CompoundSelector) {
+                                continue;
+                            }
+
+                            foreach ($compound1->getComponents() as $simple1) {
+                                if ($simple1 instanceof IDSelector && !$simple1->equals($simple2)) {
+                                    continue 3;
+                                }
+                            }
+                        } elseif ($simple2 instanceof PseudoSelector && $simple2->getName() === $pseudo1->getName()) {
+                            $selector2 = $simple2->getSelector();
+                            if ($selector2 === null) {
+                                continue;
+                            }
+
+                            if (self::listIsSuperselector($selector2->getComponents(), [$complex])) {
+                                continue 2;
+                            }
+                        }
+                    }
+
+                    return false;
+                }
+
+                return true;
+
+            case 'current':
+                $selectors = self::selectorPseudoArgs($compound2, $pseudo1->getName());
+
+                foreach ($selectors as $selector2) {
+                    if ($selector1->equals($selector2)) {
+                        return true;
+                    }
+                }
+
+                return false;
+
+            case 'nth-child':
+            case 'nth-last-child':
+                foreach ($compound2->getComponents() as $pseudo2) {
+                    if (!$pseudo2 instanceof PseudoSelector) {
+                        continue;
+                    }
+
+                    if ($pseudo2->getName() !== $pseudo1->getName()) {
+                        continue;
+                    }
+
+                    if ($pseudo2->getArgument() !== $pseudo1->getArgument()) {
+                        continue;
+                    }
+
+                    $selector2 = $pseudo2->getSelector();
+
+                    if ($selector2 === null) {
+                        continue;
+                    }
+
+                    if ($selector1->isSuperselector($selector2)) {
+                        return true;
+                    }
+                }
+
+                return false;
+
+            default:
+                throw new \LogicException('unreachache');
+        }
+    }
+
+    /**
+     * Returns all the selector arguments of pseudo selectors in $compound with
+     * the given $name.
+     *
+     * @return SelectorList[]
+     */
+    private static function selectorPseudoArgs(CompoundSelector $compound, string $name, bool $isClass = true): array
+    {
+        $selectors = [];
+
+        foreach ($compound->getComponents() as $simple) {
+            if (!$simple instanceof PseudoSelector) {
+                continue;
+            }
+
+            if ($simple->isClass() !== $isClass || $simple->getName() !== $name) {
+                continue;
+            }
+
+            if ($simple->getSelector() === null) {
+                continue;
+            }
+
+            $selectors[] = $simple->getSelector();
+        }
+
+        return $selectors;
+    }
+}

--- a/src/Extend/ExtendUtil.php
+++ b/src/Extend/ExtendUtil.php
@@ -18,10 +18,13 @@ use ScssPhp\ScssPhp\Ast\Selector\CompoundSelector;
 use ScssPhp\ScssPhp\Ast\Selector\IDSelector;
 use ScssPhp\ScssPhp\Ast\Selector\PlaceholderSelector;
 use ScssPhp\ScssPhp\Ast\Selector\PseudoSelector;
+use ScssPhp\ScssPhp\Ast\Selector\QualifiedName;
 use ScssPhp\ScssPhp\Ast\Selector\SelectorList;
 use ScssPhp\ScssPhp\Ast\Selector\SimpleSelector;
 use ScssPhp\ScssPhp\Ast\Selector\TypeSelector;
+use ScssPhp\ScssPhp\Ast\Selector\UniversalSelector;
 use ScssPhp\ScssPhp\Util\EquatableUtil;
+use ScssPhp\ScssPhp\Util\ListUtil;
 
 /**
  * @internal
@@ -41,6 +44,793 @@ final class ExtendUtil
         'nth-child',
         'nth-last-child',
     ];
+
+    /**
+     * @param list<list<CompoundSelector|string>> $complexes
+     *
+     * @return list<list<CompoundSelector|string>>|null
+     *
+     * @phpstan-param list<list<CompoundSelector|Combinator::*>> $complexes
+     * @phpstan-return list<list<CompoundSelector|Combinator::*>>|null
+     */
+    public static function unifyComplex(array $complexes): ?array
+    {
+        assert(!empty($complexes));
+
+        if (\count($complexes) === 1) {
+            return $complexes;
+        }
+
+        $unifiedBase = null;
+
+        foreach ($complexes as $complex) {
+            $base = $complex[\count($complex) - 1];
+
+            if (!$base instanceof CompoundSelector) {
+                return null;
+            }
+
+            if ($unifiedBase === null) {
+                $unifiedBase = $base->getComponents();
+            } else {
+                foreach ($base->getComponents() as $simple) {
+                    $unifiedBase = $simple->unify($unifiedBase);
+
+                    if ($unifiedBase === null) {
+                        return null;
+                    }
+                }
+            }
+        }
+
+        $complexesWithoutBases = array_map(static function (array $complex) {
+            return array_slice($complex, 0, \count($complex) - 1);
+        }, $complexes);
+
+        $complexesWithoutBases[\count($complexesWithoutBases) - 1][] = new CompoundSelector($unifiedBase);
+
+        return self::weave($complexesWithoutBases);
+    }
+
+    /**
+     * Returns a {@see CompoundSelector} that matches only elements that are matched by
+     * both $compound1 and $compound2.
+     *
+     * If no such selector can be produced, returns `null`.
+     *
+     * @param list<SimpleSelector> $compound1
+     * @param list<SimpleSelector> $compound2
+     *
+     * @return CompoundSelector|null
+     */
+    public static function unifyCompound(array $compound1, array $compound2): ?CompoundSelector
+    {
+        $result = $compound2;
+
+        foreach ($compound1 as $simple) {
+            $unified = $simple->unify($result);
+
+            if ($unified === null) {
+                return null;
+            }
+
+            $result = $unified;
+        }
+
+        return new CompoundSelector($result);
+    }
+
+    /**
+     * Returns a {@see SimpleSelector} that matches only elements that are matched by
+     * both $selector1 and $selector2, which must both be either
+     * {@see UniversalSelector}s or {@see TypeSelector}s.
+     *
+     * If no such selector can be produced, returns `null`.
+     */
+    public static function unifyUniversalAndElement(SimpleSelector $selector1, SimpleSelector $selector2): ?SimpleSelector
+    {
+        $name1 = null;
+        if ($selector1 instanceof UniversalSelector) {
+            $namespace1 = $selector1->getNamespace();
+        } elseif ($selector1 instanceof TypeSelector) {
+            $namespace1 = $selector1->getName()->getNamespace();
+            $name1 = $selector1->getName()->getName();
+        } else {
+            throw new \InvalidArgumentException('selector1 must be a UniversalSelector or a TypeSelector');
+        }
+
+        $name2 = null;
+        if ($selector2 instanceof UniversalSelector) {
+            $namespace2 = $selector2->getNamespace();
+        } elseif ($selector2 instanceof TypeSelector) {
+            $namespace2 = $selector2->getName()->getNamespace();
+            $name2 = $selector2->getName()->getName();
+        } else {
+            throw new \InvalidArgumentException('selector2 must be a UniversalSelector or a TypeSelector');
+        }
+
+        if ($namespace1 === $namespace2 || $namespace2 === '*') {
+            $namespace = $namespace1;
+        } elseif ($namespace1 === '*') {
+            $namespace = $namespace2;
+        } else {
+            return null;
+        }
+
+        if ($name1 === $name2 || $name2 === null) {
+            $name = $name1;
+        } elseif ($name1 === null) {
+            $name = $name2;
+        } else {
+            return null;
+        }
+
+        if ($name === null) {
+            return new UniversalSelector($namespace);
+        }
+
+        return new TypeSelector(new QualifiedName($name, $namespace));
+    }
+
+    /**
+     * Expands "parenthesized selectors" in $complexes.
+     *
+     * That is, if we have `.A .B {@extend .C}` and `.D .C {...}`, this
+     * conceptually expands into `.D .C, .D (.A .B)`, and this function translates
+     * `.D (.A .B)` into `.D .A .B, .A .D .B`. For thoroughness, `.A.D .B` would
+     * also be required, but including merged selectors results in exponential
+     * output for very little gain.
+     *
+     * The selector `.D (.A .B)` is represented as the list `[[.D], [.A, .B]]`.
+     *
+     * @param list<list<CompoundSelector|string>> $complexes
+     *
+     * @return list<list<CompoundSelector|string>>
+     *
+     * @phpstan-param list<list<CompoundSelector|Combinator::*>> $complexes
+     * @phpstan-return list<list<CompoundSelector|Combinator::*>>
+     */
+    public static function weave(array $complexes): array
+    {
+        $prefixes = [$complexes[0]];
+
+        foreach (array_slice($complexes, 1) as $complex) {
+            if ($complex === []) {
+                continue;
+            }
+
+            $target = $complex[\count($complex) - 1];
+
+            if (\count($complex) === 1) {
+                foreach ($prefixes as $i => $prefix) {
+                    $prefixes[$i][] = $target;
+                }
+
+                continue;
+            }
+
+            $parents = array_slice($complex, 0, \count($complex) - 1);
+            $newPrefixes = [];
+
+            foreach ($prefixes as $prefix) {
+                $parentPrefixes = self::weaveParents($prefix, $parents);
+
+                if ($parentPrefixes === null) {
+                    continue;
+                }
+
+                foreach ($parentPrefixes as $parentPrefix) {
+                    $parentPrefix[] = $target;
+                    $newPrefixes[] = $parentPrefix;
+                }
+            }
+
+            $prefixes = $newPrefixes;
+        }
+
+        return $prefixes;
+    }
+
+    /**
+     * Interweaves $parents1 and $parents2 as parents of the same target selector.
+     *
+     * Returns all possible orderings of the selectors in the inputs (including
+     * using unification) that maintain the relative ordering of the input. For
+     * example, given `.foo .bar` and `.baz .bang`, this would return `.foo .bar
+     * .baz .bang`, `.foo .bar.baz .bang`, `.foo .baz .bar .bang`, `.foo .baz
+     * .bar.bang`, `.foo .baz .bang .bar`, and so on until `.baz .bang .foo .bar`.
+     *
+     * Semantically, for selectors A and B, this returns all selectors `AB_i`
+     * such that the union over all i of elements matched by `AB_i X` is
+     * identical to the intersection of all elements matched by `A X` and all
+     * elements matched by `B X`. Some `AB_i` are elided to reduce the size of
+     * the output.
+     *
+     * @param list<CompoundSelector|string> $parents1
+     * @param list<CompoundSelector|string> $parents2
+     *
+     * @return list<list<CompoundSelector|string>>|null
+     *
+     * @phpstan-param list<CompoundSelector|Combinator::*> $parents1
+     * @phpstan-param list<CompoundSelector|Combinator::*> $parents2
+     * @phpstan-return list<list<CompoundSelector|Combinator::*>>|null
+     */
+    private static function weaveParents(array $parents1, array $parents2): ?array
+    {
+        $queue1 = $parents1;
+        $queue2 = $parents2;
+
+        $initialCombinators = self::mergeInitialCombinators($queue1, $queue2);
+        if ($initialCombinators === null) {
+            return null;
+        }
+        $finalCombinators = self::mergeFinalCombinators($queue1, $queue2);
+        if ($finalCombinators === null) {
+            return null;
+        }
+
+        // Make sure there's at most one `:root` in the output.
+        $root1 = self::firstIfRoot($queue1);
+        $root2 = self::firstIfRoot($queue2);
+
+        if ($root1 !== null && $root2 !== null) {
+            $root = self::unifyCompound($root1->getComponents(), $root2->getComponents());
+
+            if ($root === null) {
+                return null;
+            }
+
+            array_unshift($queue1, $root);
+            array_unshift($queue2, $root);
+        } elseif ($root1 !== null) {
+            array_unshift($queue2, $root1);
+        } elseif ($root2 !== null) {
+            array_unshift($queue1, $root2);
+        }
+
+        $groups1 = self::groupSelectors($queue1);
+        $groups2 = self::groupSelectors($queue2);
+
+        /** @phpstan-var list<list<CompoundSelector|Combinator::*>> $lcs */
+        $lcs = ListUtil::longestCommonSubsequence($groups2, $groups1, function ($group1, $group2) {
+            if (EquatableUtil::listEquals($group1, $group2)) {
+                return $group1;
+            }
+
+            if (!$group1[0] instanceof CompoundSelector || !$group2[0] instanceof CompoundSelector) {
+                return null;
+            }
+
+            if (self::complexIsParentSuperselector($group1, $group2)) {
+                return $group2;
+            }
+
+            if (self::complexIsParentSuperselector($group2, $group1)) {
+                return $group1;
+            }
+
+            if (!self::mustUnify($group1, $group2)) {
+                return null;
+            }
+
+            $unified = self::unifyComplex([$group1, $group2]);
+
+            if ($unified === null) {
+                return null;
+            }
+            if (\count($unified) > 1) {
+                return null;
+            }
+
+            return $unified[0];
+        });
+
+        $choices = [[$initialCombinators]];
+
+        foreach ($lcs as $group) {
+            $newChoice = [];
+            /** @phpstan-var list<list<list<CompoundSelector|Combinator::*>>> $chunks */
+            $chunks = self::chunks($groups1, $groups2, function ($sequence) use ($group) {
+                /** @phpstan-var list<list<CompoundSelector|Combinator::*>> $sequence */
+                return self::complexIsParentSuperselector($sequence[0], $group);
+            });
+            foreach ($chunks as $chunk) {
+                $flattened = [];
+                foreach ($chunk as $chunkGroup) {
+                    $flattened = array_merge($flattened, $chunkGroup);
+                }
+                $newChoice[] = $flattened;
+            }
+
+            /** @phpstan-var list<list<CompoundSelector|Combinator::*>> $groups1 */
+            /** @phpstan-var list<list<CompoundSelector|Combinator::*>> $groups2 */
+            $choices[] = $newChoice;
+            $choices[] = [$group];
+            array_shift($groups1);
+            array_shift($groups2);
+        }
+
+        $newChoice = [];
+        /** @phpstan-var list<list<list<CompoundSelector|Combinator::*>>> $chunks */
+        $chunks = self::chunks($groups1, $groups2, function ($sequence) {
+            return count($sequence) === 0;
+        });
+        foreach ($chunks as $chunk) {
+            $flattened = [];
+            foreach ($chunk as $chunkGroup) {
+                $flattened = array_merge($flattened, $chunkGroup);
+            }
+            $newChoice[] = $flattened;
+        }
+
+        $choices[] = $newChoice;
+
+        foreach ($finalCombinators as $finalCombinator) {
+            $choices[] = $finalCombinator;
+        }
+
+        $choices = array_filter($choices, function ($choice) {
+            return $choice !== [];
+        });
+
+        /** @phpstan-var list<list<list<CompoundSelector|Combinator::*>>> $paths */
+        $paths = self::paths($choices);
+
+        return array_map(function (array $path) {
+            $result = [];
+
+            foreach ($path as $group) {
+                $result = array_merge($result, $group);
+            }
+
+            return $result;
+        }, $paths);
+    }
+
+    /**
+     * If the first element of $queue has a `::root` selector, removes and returns
+     * that element.
+     *
+     * @param list<CompoundSelector|string> $queue
+     *
+     * @return CompoundSelector|null
+     *
+     * @phpstan-param list<CompoundSelector|Combinator::*> $queue
+     */
+    private static function firstIfRoot(array &$queue): ?CompoundSelector
+    {
+        if (empty($queue)) {
+            return null;
+        }
+
+        $first = $queue[0];
+
+        if ($first instanceof CompoundSelector) {
+            if (!self::hasRoot($first)) {
+                return null;
+            }
+
+            array_shift($queue);
+
+            return $first;
+        }
+
+        return null;
+    }
+
+    /**
+     * Extracts leading  {@see Combinator}s from $components1 and $components2 and
+     * merges them together into a single list of combinators.
+     *
+     * If there are no combinators to be merged, returns an empty list. If the
+     * combinators can't be merged, returns `null`.
+     *
+     * @param list<CompoundSelector|string> $components1
+     * @param list<CompoundSelector|string> $components2
+     *
+     * @return list<string>|null
+     *
+     * @phpstan-param list<CompoundSelector|Combinator::*> $components1
+     * @phpstan-param list<CompoundSelector|Combinator::*> $components2
+     * @phpstan-return list<Combinator::*>|null
+     */
+    private static function mergeInitialCombinators(array &$components1, array &$components2): ?array
+    {
+        $combinators1 = [];
+
+        while ($components1 && \is_string($components1[0])) {
+            $combinators1[] = $components1[0];
+            array_shift($components1);
+        }
+
+        $combinators2 = [];
+
+        while ($components2 && \is_string($components2[0])) {
+            $combinators2[] = $components2[0];
+            array_shift($components2);
+        }
+
+        // If neither sequence of combinators is a subsequence of the other, they
+        // cannot be merged successfully.
+        $lcs = ListUtil::longestCommonSubsequence($combinators1, $combinators2);
+
+        if ($lcs === $combinators1) {
+            return $combinators2;
+        }
+
+        if ($lcs === $combinators2) {
+            return $combinators1;
+        }
+
+        return null;
+    }
+
+    /**
+     * Extracts trailing {@see Combinator}s, and the selectors to which they apply, from
+     * $components1 and $components2 and merges them together into a single list.
+     *
+     * If there are no combinators to be merged, returns an empty list. If the
+     * sequences can't be merged, returns `null`.
+     *
+     * @param list<CompoundSelector|string>             $components1
+     * @param list<CompoundSelector|string>             $components2
+     * @param list<list<list<CompoundSelector|string>>> $result
+     *
+     * @return list<list<list<CompoundSelector|string>>>|null
+     *
+     * @phpstan-param list<CompoundSelector|Combinator::*> $components1
+     * @phpstan-param list<CompoundSelector|Combinator::*> $components2
+     * @phpstan-param list<list<list<CompoundSelector|Combinator::*>>> $result
+     * @phpstan-return list<list<list<CompoundSelector|Combinator::*>>>|null
+     */
+    private static function mergeFinalCombinators(array &$components1, array &$components2, array $result = []): ?array
+    {
+        if ((\count($components1) === 0 || !\is_string($components1[\count($components1) - 1]))
+            && (\count($components2) === 0 || !\is_string($components2[\count($components2) - 1]))
+        ) {
+            return $result;
+        }
+
+        /**
+         * @var list<string> $combinators1
+         * @phpstan-var list<Combinator::*> $combinators1
+         */
+        $combinators1 = [];
+
+        while ($components1 && \is_string($components1[\count($components1) - 1])) {
+            $combinators1[] = $components1[\count($components1) - 1];
+            array_pop($components1);
+        }
+
+        /**
+         * @var list<string> $combinators2
+         * @phpstan-var list<Combinator::*> $combinators2
+         */
+        $combinators2 = [];
+
+        while ($components2 && \is_string($components2[\count($components2) - 1])) {
+            $combinators2[] = $components2[\count($components2) - 1];
+            array_pop($components2);
+        }
+
+        if (\count($combinators1) > 1 || \count($combinators2) > 1) {
+            $lcs = ListUtil::longestCommonSubsequence($combinators1, $combinators2);
+
+            if ($lcs === $combinators1) {
+                array_unshift($result, [array_reverse($combinators2)]);
+            } elseif ($lcs === $combinators2) {
+                array_unshift($result, [array_reverse($combinators1)]);
+            } else {
+                return null;
+            }
+
+            return $result;
+        }
+
+        // This code looks complicated, but it's actually just a bunch of special
+        // cases for interactions between different combinators.
+        $combinator1 = $combinators1[0] ?? null;
+        $combinator2 = $combinators2[0] ?? null;
+
+        if ($combinator1 !== null && $combinator2 !== null) {
+            $compound1 = array_pop($components1);
+            assert($compound1 instanceof CompoundSelector);
+            $compound2 = array_pop($components2);
+            assert($compound2 instanceof CompoundSelector);
+
+            if ($combinator1 === Combinator::FOLLOWING_SIBLING && $combinator2 === Combinator::FOLLOWING_SIBLING) {
+                if ($compound1->isSuperselector($compound2)) {
+                    array_unshift($result, [[$compound2, Combinator::FOLLOWING_SIBLING]]);
+                } elseif ($compound2->isSuperselector($compound1)) {
+                    array_unshift($result, [[$compound1, Combinator::FOLLOWING_SIBLING]]);
+                } else {
+                    $choices = [
+                        [$compound1, Combinator::FOLLOWING_SIBLING, $compound2, Combinator::FOLLOWING_SIBLING],
+                        [$compound2, Combinator::FOLLOWING_SIBLING, $compound1, Combinator::FOLLOWING_SIBLING],
+                    ];
+
+                    $unified = self::unifyCompound($compound1->getComponents(), $compound2->getComponents());
+
+                    if ($unified !== null) {
+                        $choices[] = [$unified, Combinator::FOLLOWING_SIBLING];
+                    }
+
+                    array_unshift($result, $choices);
+                }
+            } elseif (($combinator1 === Combinator::FOLLOWING_SIBLING && $combinator2 === Combinator::NEXT_SIBLING) || ($combinator1 === Combinator::NEXT_SIBLING && $combinator2 === Combinator::FOLLOWING_SIBLING)) {
+                $followingSiblingSelector = $combinator1 === Combinator::FOLLOWING_SIBLING ? $compound1 : $compound2;
+                $nextSiblingSelector = $combinator1 === Combinator::FOLLOWING_SIBLING ? $compound2 : $compound1;
+
+                if ($followingSiblingSelector->isSuperselector($nextSiblingSelector)) {
+                    array_unshift($result, [[$nextSiblingSelector, Combinator::NEXT_SIBLING]]);
+                } else {
+                    $unified = self::unifyCompound($compound1->getComponents(), $compound2->getComponents());
+
+                    $choices = [
+                        [$followingSiblingSelector, Combinator::FOLLOWING_SIBLING, $nextSiblingSelector, Combinator::NEXT_SIBLING],
+                    ];
+
+                    if ($unified !== null) {
+                        $choices[] = [$unified, Combinator::NEXT_SIBLING];
+                    }
+
+                    array_unshift($result, $choices);
+                }
+            } elseif ($combinator1 === Combinator::CHILD && ($combinator2 === Combinator::NEXT_SIBLING || $combinator2 === Combinator::FOLLOWING_SIBLING)) {
+                array_unshift($result, [[$compound2, $combinator2]]);
+                $components1[] = $compound1;
+                $components1[] = Combinator::CHILD;
+            } elseif ($combinator2 === Combinator::CHILD && ($combinator1 === Combinator::NEXT_SIBLING || $combinator1 === Combinator::FOLLOWING_SIBLING)) {
+                array_unshift($result, [[$compound1, $combinator1]]);
+                $components2[] = $compound2;
+                $components2[] = Combinator::CHILD;
+            } elseif ($combinator1 === $combinator2) {
+                $unified = self::unifyCompound($compound1->getComponents(), $compound2->getComponents());
+
+                if ($unified === null) {
+                    return null;
+                }
+
+                array_unshift($result, [[$unified, $combinator1]]);
+            } else {
+                return null;
+            }
+
+            return self::mergeFinalCombinators($components1, $components2, $result);
+        }
+
+        if ($combinator1 !== null) {
+            $compound1 = array_pop($components1);
+            assert($compound1 instanceof CompoundSelector);
+
+            if ($combinator1 === Combinator::CHILD && \count($components2) > 0) {
+                $compound2 = $components2[\count($components2) - 1];
+                assert($compound2 instanceof CompoundSelector);
+
+                if ($compound2->isSuperselector($compound1)) {
+                    array_pop($components2);
+                }
+            }
+
+            array_unshift($result, [[$compound1, $combinator1]]);
+
+            return self::mergeFinalCombinators($components1, $components2, $result);
+        }
+
+        $compound2 = array_pop($components2);
+        assert($compound2 instanceof CompoundSelector);
+        assert($combinator2 !== null);
+
+        if ($combinator2 === Combinator::CHILD && \count($components1) > 0) {
+            $compound1 = $components1[\count($components1) - 1];
+            assert($compound1 instanceof CompoundSelector);
+
+            if ($compound1->isSuperselector($compound2)) {
+                array_pop($components1);
+            }
+        }
+
+        array_unshift($result, [[$compound2, $combinator2]]);
+
+        return self::mergeFinalCombinators($components2, $components1, $result);
+    }
+
+    /**
+     * Returns whether $complex1 and $complex2 need to be unified to produce a
+     * valid combined selector.
+     *
+     * This is necessary when both selectors contain the same unique simple
+     * selector, such as an ID.
+     *
+     * @param list<CompoundSelector|string> $complex1
+     * @param list<CompoundSelector|string> $complex2
+     *
+     * @return bool
+     *
+     * @phpstan-param list<CompoundSelector|Combinator::*> $complex1
+     * @phpstan-param list<CompoundSelector|Combinator::*> $complex2
+     */
+    private static function mustUnify(array $complex1, array $complex2): bool
+    {
+        $uniqueSelectors = [];
+        foreach ($complex1 as $component) {
+            if ($component instanceof CompoundSelector) {
+                foreach ($component->getComponents() as $simple) {
+                    if (self::isUnique($simple)) {
+                        $uniqueSelectors[] = $simple;
+                    }
+                }
+            }
+        }
+
+        if (\count($uniqueSelectors) === 0) {
+            return false;
+        }
+
+        foreach ($complex2 as $component) {
+            if ($component instanceof CompoundSelector) {
+                foreach ($component->getComponents() as $simple) {
+                    if (self::isUnique($simple) && EquatableUtil::listContains($uniqueSelectors, $simple)) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns whether a {@see CompoundSelector} may contain only one simple selector of
+     * the same type as $simple.
+     */
+    private static function isUnique(SimpleSelector $simple): bool
+    {
+        return $simple instanceof IDSelector || ($simple instanceof PseudoSelector && $simple->isElement());
+    }
+
+    /**
+     * Returns all orderings of initial subsequences of $queue1 and $queue2.
+     *
+     * The $done callback is used to determine the extent of the initial
+     * subsequences. It's called with each queue until it returns `true`.
+     *
+     * This destructively removes the initial subsequences of $queue1 and
+     * $queue2.
+     *
+     * For example, given `(A B C | D E)` and `(1 2 | 3 4 5)` (with `|` denoting
+     * the boundary of the initial subsequence), this would return `[(A B C 1 2),
+     * (1 2 A B C)]`. The queues would then contain `(D E)` and `(3 4 5)`.
+     *
+     * @template T
+     *
+     * @param list<T>                 $queue1
+     * @param list<T>                 $queue2
+     * @param callable(list<T>): bool $done
+     *
+     * @return list<list<T>>
+     */
+    private static function chunks(array &$queue1, array &$queue2, callable $done): array
+    {
+        $chunk1 = [];
+        while (!$done($queue1)) {
+            $element = array_shift($queue1);
+            if ($element === null) {
+                throw new \LogicException('Cannot remove an element from an empty queue');
+            }
+
+            $chunk1[] = $element;
+        }
+
+        $chunk2 = [];
+        while (!$done($queue2)) {
+            $element = array_shift($queue2);
+            if ($element === null) {
+                throw new \LogicException('Cannot remove an element from an empty queue');
+            }
+
+            $chunk2[] = $element;
+        }
+
+        if (empty($chunk1) && empty($chunk2)) {
+            return [];
+        }
+
+        if (empty($chunk1)) {
+            return [$chunk2];
+        }
+
+        if (empty($chunk2)) {
+            return [$chunk1];
+        }
+
+        return [
+            array_merge($chunk1, $chunk2),
+            array_merge($chunk2, $chunk1),
+        ];
+    }
+
+    /**
+     * Returns a list of all possible paths through the given lists.
+     *
+     * For example, given `[[1, 2], [3, 4], [5]]`, this returns:
+     *
+     * ```
+     * [[1, 3, 5],
+     *  [2, 3, 5],
+     *  [1, 4, 5],
+     *  [2, 4, 5]]
+     * ```
+     *
+     * @template T
+     *
+     * @param array<list<T>> $choices
+     *
+     * @return list<list<T>>
+     */
+    public static function paths(array $choices): array
+    {
+        return array_reduce($choices, function (array $paths, array $choice) {
+            $newPaths = [];
+
+            foreach ($choice as $option) {
+                foreach ($paths as $path) {
+                    $path[] = $option;
+                    $newPaths[] = $path;
+                }
+            }
+
+            return $newPaths;
+        }, [[]]);
+    }
+
+    /**
+     * @param iterable<CompoundSelector|string> $complex
+     *
+     * @return list<list<CompoundSelector|string>>
+     *
+     * @phpstan-param iterable<CompoundSelector|Combinator::*> $complex
+     * @phpstan-return list<list<CompoundSelector|Combinator::*>>
+     */
+    private static function groupSelectors(iterable $complex): array
+    {
+        $groups = [];
+        $group = null;
+
+        foreach ($complex as $current) {
+            if ($group === null) {
+                $group = [$current];
+                continue;
+            }
+
+            if (\is_string($current) || \is_string($group[\count($group) - 1])) {
+                $group[] = $current;
+            } else {
+                $groups[] = $group;
+                $group = [$current];
+            }
+        }
+
+        if ($group !== null) {
+            $groups[] = $group;
+        }
+
+        return $groups;
+    }
+
+    /**
+     * Returns whether or not $compound contains a `:root` selector.
+     */
+    private static function hasRoot(CompoundSelector $compound): bool
+    {
+        foreach ($compound->getComponents() as $simple) {
+            if ($simple instanceof PseudoSelector && $simple->isClass() && $simple->getNormalizedName() === 'root') {
+                return true;
+            }
+        }
+
+        return false;
+    }
 
     /**
      * Returns whether $list1 is a superselector of $list2.

--- a/src/Serializer/Serializer.php
+++ b/src/Serializer/Serializer.php
@@ -50,7 +50,7 @@ final class Serializer
     public static function serializeSelector(Selector $selector, bool $inspect = false): string
     {
         $visitor = new SerializeVisitor($inspect);
-        $selector->accept($visitor); // TODO
+        $selector->accept($visitor);
 
         return (string) $visitor->getBuffer();
     }

--- a/src/Util/EquatableUtil.php
+++ b/src/Util/EquatableUtil.php
@@ -18,6 +18,55 @@ namespace ScssPhp\ScssPhp\Util;
 final class EquatableUtil
 {
     /**
+     * @param list<mixed> $list
+     */
+    public static function listContains(array $list, Equatable $item): bool
+    {
+        foreach ($list as $listItem) {
+            if (!\is_object($listItem)) {
+                continue;
+            }
+
+            if ($item === $listItem) {
+                return true;
+            }
+
+            if ($item->equals($listItem)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Checks whether 2 values are equals, using the Equatable semantic to compare objects if possible.
+     *
+     * When compared values don't implement {@see Equatable}, they are compared
+     * using `===`.
+     * Values implementing {@see Equatable} are still compared with `===` first to
+     * optimize comparisons to the same object, as an object is always expected to
+     * be equal to itself.
+     *
+     * @param mixed $item1
+     * @param mixed $item2
+     *
+     * @return bool
+     */
+    public static function equals($item1, $item2): bool
+    {
+        if ($item1 === $item2) {
+            return true;
+        }
+
+        if ($item1 instanceof Equatable && $item2 instanceof Equatable) {
+            return $item1->equals($item2);
+        }
+
+        return false;
+    }
+
+    /**
      * Checks whether 2 lists are equals, using the Equatable semantic to compare objects if possible.
      *
      * @param list<mixed> $list1
@@ -32,11 +81,7 @@ final class EquatableUtil
         foreach ($list1 as $i => $item1) {
             $item2 = $list2[$i];
 
-            if ($item1 === $item2) {
-                continue;
-            }
-
-            if ($item1 instanceof Equatable && $item2 instanceof Equatable && $item1->equals($item2)) {
+            if (self::equals($item1, $item2)) {
                 continue;
             }
 

--- a/src/Util/ListUtil.php
+++ b/src/Util/ListUtil.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2018-2020 Anthon Pang
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Util;
+
+/**
+ * @internal
+ */
+final class ListUtil
+{
+    /**
+     * Returns the longest common subsequence between $list1 and $list2.
+     *
+     * If there are more than one equally long common subsequence, returns the one
+     * which starts first in $list1.
+     *
+     * If $select is passed, it's used to check equality between elements in each
+     * list. If it returns `null`, the elements are considered unequal; otherwise,
+     * it should return the element to include in the return value.
+     *
+     * @template T
+     *
+     * @param list<T>                         $list1
+     * @param list<T>                         $list2
+     * @param (callable(T, T): (T|null))|null $select
+     *
+     * @return list<T>
+     */
+    public static function longestCommonSubsequence(array $list1, array $list2, ?callable $select = null): array
+    {
+        if ($select === null) {
+            $select = function ($element1, $element2) {
+                return EquatableUtil::equals($element1, $element2) ? $element1 : null;
+            };
+        }
+
+        $lengths = array_fill(0, \count($list1) + 1, array_fill(0, \count($list2) + 1, 0));
+        $selections = array_fill(0, \count($list1) + 1, array_fill(0, \count($list2) + 1, null));
+
+        for ($i = 0; $i < \count($list1); $i++) {
+            for ($j = 0; $j < \count($list2); $j++) {
+                $selection = $select($list1[$i], $list2[$j]);
+                $selections[$i][$j] = $selection;
+                $lengths[$i + 1][$j + 1] = $selection === null
+                    ? max($lengths[$i + 1][$j], $lengths[$i][$j + 1])
+                    : $lengths[$i][$j] + 1;
+            }
+        }
+
+        $backtrack = function (int $i, int $j) use ($selections, $lengths, &$backtrack): array {
+            if ($i === -1 || $j === -1) {
+                return [];
+            }
+
+            $selection = $selections[$i][$j];
+
+            if ($selection !== null) {
+                $selected = $backtrack($i - 1, $j - 1);
+                $selected[] = $selection;
+
+                return $selected;
+            }
+
+            return $lengths[$i + 1][$j] > $lengths[$i][$j + 1]
+                ? $backtrack($i, $j - 1)
+                : $backtrack($i - 1, $j);
+        };
+
+        return $backtrack(\count($list1) - 1, \count($list2) - 1);
+    }
+}

--- a/src/Util/ListUtil.php
+++ b/src/Util/ListUtil.php
@@ -18,6 +18,44 @@ namespace ScssPhp\ScssPhp\Util;
 final class ListUtil
 {
     /**
+     * Flattens the first level of nested arrays in $queues.
+     *
+     * The return value is ordered first by index in the nested iterable, then by
+     * the index *of* that iterable in $queues. For example,
+     * `flattenVertically([["1a", "1b"], ["2a", "2b"]])` returns `["1a", "2a",
+     * "1b", "2b"]`.
+     *
+     * @template T
+     *
+     * @param list<list<T>> $queues
+     *
+     * @return list<T>
+     */
+    public static function flattenVertically(array $queues): array
+    {
+        if (\count($queues) === 1) {
+            return $queues[0];
+        }
+
+        $result = [];
+
+        while (!empty($queues)) {
+            foreach ($queues as $i => &$queue) {
+                $item = array_shift($queue);
+
+                if ($item === null) {
+                    unset($queues[$i]);
+                } else {
+                    $result[] = $item;
+                }
+            }
+            unset($queue);
+        }
+
+        return $result;
+    }
+
+    /**
      * Returns the longest common subsequence between $list1 and $list2.
      *
      * If there are more than one equally long common subsequence, returns the one

--- a/tests/Extend/NestingTest.php
+++ b/tests/Extend/NestingTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Tests\Extend;
+
+use PHPUnit\Framework\TestCase;
+use ScssPhp\ScssPhp\Ast\Selector\SelectorList;
+
+/**
+ * Selector nesting tests, taken from sass-spec
+ * TODO Remove those tests once the compiler uses this implementation of selectors, as sass-spec covers that logic
+ */
+class NestingTest extends TestCase
+{
+    /**
+     * @dataProvider provideNestingTests
+     */
+    public function testNest(string $expected, string $parent, string $child)
+    {
+        $parentSelector = SelectorList::parse($parent);
+        $childSelector = SelectorList::parse($child);
+
+        $this->assertSame($expected, (string) $childSelector->resolveParentSelectors($parentSelector));
+    }
+
+    /**
+     * Provide selector nesting tests taken from sass-spec in spec/core_functions/selector/nest.hrx
+     */
+    public static function provideNestingTests(): iterable
+    {
+        yield ['c d', 'c', 'd'];
+        yield ['c', 'c', '&'];
+        yield ['c.d', 'c', '&.d'];
+        yield ['cd', 'c', '&d'];
+        yield ['d c.e', 'c', 'd &.e'];
+        yield ['e c d.f', 'c d', 'e &.f'];
+        yield [':is(c)', 'c', ':is(&)'];
+        yield [':matches(c)', 'c', ':matches(&)'];
+        yield [':matches(c d)', 'c d', ':matches(&)'];
+        yield ['c.d c.e', 'c', '&.d &.e'];
+        yield ['c.d, c e', 'c', '&.d, e'];
+        yield ['c e, d e', 'c, d', 'e'];
+        yield ['c d, c e', 'c', 'd, e'];
+        yield ['c, d', 'c, d', '&'];
+        yield ['c.e, d.e', 'c, d', '&.e'];
+        yield ['ce, de', 'c, d', '&e'];
+        yield ['e c.f, e d.f', 'c, d', 'e &.f'];
+        yield [':is(c, d)', 'c, d', ':is(&)'];
+        yield [':matches(c, d)', 'c, d', ':matches(&)'];
+        yield ['c.e c.f, c.e d.f, d.e c.f, d.e d.f', 'c, d', '&.e &.f'];
+        yield ['c.e, c f, d.e, d f', 'c, d', '&.e, f'];
+    }
+}

--- a/tests/Extend/SuperselectorTest.php
+++ b/tests/Extend/SuperselectorTest.php
@@ -1,0 +1,261 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Tests\Extend;
+
+use PHPUnit\Framework\TestCase;
+use ScssPhp\ScssPhp\Ast\Selector\SelectorList;
+
+/**
+ * Selector comparison tests, taken from sass-spec
+ * TODO Remove those tests once the compiler uses this implementation of selectors, as sass-spec covers that logic
+ */
+class SuperselectorTest extends TestCase
+{
+    /**
+     * @dataProvider provideSuperselectorTests
+     */
+    public function testIsSuperselector(bool $expected, string $super, string $sub)
+    {
+        $firstSelector = SelectorList::parse($super);
+        $secondSelector = SelectorList::parse($sub);
+
+        $this->assertSame($expected, $firstSelector->isSuperselector($secondSelector));
+    }
+
+    /**
+     * Provide selector unification tests taken from sass-spec in spec/core_functions/selector/is_superselector/
+     */
+    public static function provideSuperselectorTests(): iterable
+    {
+        // simple/pseudo/selector_arg/any
+        yield [true, ':any(c d, e f, g h)', 'c d.i, e j f'];
+        yield [false, ':any(c d.i, e j f)', 'c d, e f, g h'];
+        yield [true, ':-pfx-any(c d, e f, g h)', 'c d.i, e j f'];
+        yield [false, ':-pfx-any(c d.i, e j f)', 'c d, e f, g h'];
+        // simple/pseudo/selector_arg/current
+        yield [false, ':current(c d, e f, g h)', ':current(c d.i, e j f)'];
+        yield [false, ':current(c d.i, e j f)', ':current(c d, e f, g h)'];
+        yield [true, ':current(c d, e f)', ':current(c d, e f)'];
+        yield [false, ':current(c d, e f)', 'c d, e f'];
+        yield [false, ':-pfx-current(c d, e f, g h)', ':-pfx-current(c d.i, e j f)'];
+        yield [false, ':-pfx-current(c d.i, e j f)', ':-pfx-current(c d, e f, g h)'];
+        yield [true, ':-pfx-current(c d, e f)', ':-pfx-current(c d, e f)'];
+        // simple/pseudo/selector_arg/has
+        yield [true, ':has(c d, e f, g h)', ':has(c d.i, e j f)'];
+        yield [false, ':has(c d.i, e j f)', ':has(c d, e f, g h)'];
+        yield [false, ':has(c d, e f, g h)', 'c d.i, e j f'];
+        yield [true, ':-pfx-has(c d, e f, g h)', ':-pfx-has(c d.i, e j f)'];
+        yield [false, ':-pfx-has(c d.i, e j f)', ':-pfx-has(c d, e f, g h)'];
+        // simple/pseudo/selector_arg/host
+        yield [true, ':host(c d, e f, g h)', ':host(c d.i, e j f)'];
+        yield [false, ':host(c d.i, e j f)', ':host(c d, e f, g h)'];
+        yield [false, ':host(c d, e f, g h)', 'c d, e f, g h'];
+        yield [true, ':-pfx-host(c d, e f, g h)', ':-pfx-host(c d.i, e j f)'];
+        yield [false, ':-pfx-host(c d.i, e j f)', ':-pfx-host(c d, e f, g h)'];
+        // simple/pseudo/selector_arg/host-context
+        yield [true, ':host-context(c d, e f, g h)', ':host-context(c d.i, e j f)'];
+        yield [false, ':host-context(c d.i, e j f)', ':host-context(c d, e f, g h)'];
+        yield [false, ':host-context(c d, e f, g h)', 'c d, e f, g h'];
+        yield [true, ':-pfx-host-context(c d, e f, g h)', ':-pfx-host-context(c d.i, e j f)'];
+        yield [false, ':-pfx-host-context(c d.i, e j f)', ':-pfx-host-context(c d, e f, g h)'];
+        // simple/pseudo/selector_arg/is
+        yield [true, ':is(c)', 'c'];
+        yield [false, ':is(c)', 'd'];
+        yield [true, ':is(c.e)', 'c.d.e'];
+        yield [false, ':is(c.d.e)', 'c e'];
+        yield [true, ':is(c e)', 'c d e'];
+        yield [false, ':is(c d e)', 'c e'];
+        yield [true, ':is(c d, e f, g h)', 'c d, e f'];
+        yield [false, ':is(c d, e f)', 'c d, e f, g h'];
+        yield [true, ':is(c d, e f, g h)', ':is(c d.i, e j f)'];
+        yield [false, ':is(c d.i, e j f)', ':is(c d, e f, g h)'];
+        yield [true, ':-pfx-is(c d, e f, g h)', 'c d.i, e j f'];
+        yield [false, ':pfx-is(c d.i, e j f)', 'c d, e f, g h'];
+        yield [false, ':is(c, d)', ':any(c, d)'];
+        yield [false, ':is(c, d)', ':-pfx-is(c, d)'];
+        // simple/pseudo/selector_arg/matches
+        yield [true, ':matches(c)', 'c'];
+        yield [false, ':matches(c)', 'd'];
+        yield [true, ':matches(c.e)', 'c.d.e'];
+        yield [false, ':matches(c.d.e)', 'c e'];
+        yield [true, ':matches(c e)', 'c d e'];
+        yield [false, ':matches(c d e)', 'c e'];
+        yield [true, ':matches(c d, e f, g h)', 'c d, e f'];
+        yield [false, ':matches(c d, e f)', 'c d, e f, g h'];
+        yield [true, ':matches(c d, e f, g h)', ':matches(c d.i, e j f)'];
+        yield [false, ':matches(c d.i, e j f)', ':matches(c d, e f, g h)'];
+        yield [true, ':-pfx-matches(c d, e f, g h)', 'c d.i, e j f'];
+        yield [false, ':pfx-matches(c d.i, e j f)', 'c d, e f, g h'];
+        yield [false, ':matches(c, d)', ':any(c, d)'];
+        yield [false, ':matches(c, d)', ':-pfx-matches(c, d)'];
+        // simple/pseudo/selector_arg/not
+        yield [false, ':not(c d, e f, g h)', ':not(c d.i, e j f)'];
+        yield [true, ':not(c d.i, e j f)', ':not(c d, e f, g h)'];
+        yield [false, ':not(c d, e f, g h)', 'c d, e f, g h'];
+        yield [true, ':not(c.d)', 'e'];
+        yield [true, ':not(#c.d)', '#e'];
+        yield [false, ':not(c d):not(e f):not(g h)', ':not(c d.i, e j f)'];
+        yield [true, ':not(c d.i):not(e j f)', ':not(c d, e f, g h)'];
+        yield [false, ':not(c d, e f, g h)', ':not(c d.i):not(e j f)'];
+        yield [true, ':not(c d.i, e j f)', ':not(c d):not(e f):not(g h)'];
+        yield [false, ':-pfx-not(c d, e f, g h)', ':-pfx-not(c d.i, e j f)'];
+        yield [true, ':-pfx-not(c d.i, e j f)', ':-pfx-not(c d, e f, g h)'];
+        // simple/pseudo/selector_arg/nth_child
+        yield [true, ':nth-child(n+1 of c d, e f, g h)', ':nth-child(n+1 of c d.i, e j f)'];
+        yield [false, ':nth-child(n+1 of c d.i, e j f)', ':nth-child(n+1 of c d, e f, g h)'];
+        yield [false, ':nth-child(n+1 of c)', ':nth-child(n+2 of c)'];
+        yield [true, 'c', ':nth-child(n+1 of c)'];
+        yield [false, ':nth-child(n+1 of c d, e f, g h)', 'c d, e f, g h'];
+        yield [true, ':-pfx-nth-child(n+1 of c d, e f, g h)', ':-pfx-nth-child(n+1 of c d.i, e j f)'];
+        yield [false, ':-pfx-nth-child(n+1 of c d.i, e j f)', ':-pfx-nth-child(n+1 of c d, e f, g h)'];
+        // simple/pseudo/selector_arg/nth_last_child
+        yield [true, ':nth-last-child(n+1 of c d, e f, g h)', ':nth-last-child(n+1 of c d.i, e j f)'];
+        yield [false, ':nth-last-child(n+1 of c d.i, e j f)', ':nth-last-child(n+1 of c d, e f, g h)'];
+        yield [false, ':nth-last-child(n+1 of c)', ':nth-last-child(n+2 of c)'];
+        yield [true, 'c', ':nth-last-child(n+1 of c)'];
+        yield [false, ':nth-last-child(n+1 of c d, e f, g h)', 'c d, e f, g h'];
+        yield [true, ':-pfx-nth-last-child(n+1 of c d, e f, g h)', ':-pfx-nth-last-child(n+1 of c d.i, e j f)'];
+        yield [false, ':-pfx-nth-last-child(n+1 of c d.i, e j f)', ':-pfx-nth-last-child(n+1 of c d, e f, g h)'];
+        // simple/pseudo/selector_arg/slotted
+        yield [true, '::slotted(c d, e f, g h)', '::slotted(c d.i, e j f)'];
+        yield [false, '::slotted(c d.i, e j f)', '::slotted(c d, e f, g h)'];
+        yield [false, '::slotted(c d, e f, g h)', 'c d, e f, g h'];
+        yield [true, '::-pfx-slotted(c d, e f, g h)', '::-pfx-slotted(c d.i, e j f)'];
+        yield [false, '::-pfx-slotted(c d.i, e j f)', '::-pfx-slotted(c d, e f, g h)'];
+        // simple/pseudo/arg
+        yield [true, ':c(@#$)', ':c(@#$)'];
+        yield [false, ':c(@#$)', ':d(@#$)'];
+        yield [false, ':c(@#$)', ':c(*&^)'];
+        yield [false, ':c(@#$)', ':c'];
+        yield [true, '::c(@#$)', '::c(@#$)'];
+        yield [false, '::c(@#$)', ':d(@#$)'];
+        yield [false, '::c(@#$)', '::c(*&^)'];
+        yield [false, '::c(@#$)', '::c'];
+        // simple/pseudo/no_arg
+        yield [true, ':c', ':c'];
+        yield [false, ':c', ':d'];
+        yield [false, ':c', '::c'];
+        yield [true, '::c', '::c'];
+        yield [false, '::c', '::d'];
+        yield [false, '::c', ':c'];
+        // simple/attribute
+        yield [true, '[c=d]', '[c=d]'];
+        yield [false, '[c=d]', '[e=d]'];
+        yield [false, '[c=d]', '[c=e]'];
+        yield [false, '[c=d]', '[c^=d]'];
+        // simple/class
+        yield [true, '.c', '.c'];
+        yield [false, '.c', '.d'];
+        // simple/id
+        yield [true, '#c', '#c'];
+        yield [false, '#c', '#d'];
+        // simple/placeholder
+        yield [true, '%c', '%c'];
+        yield [false, '%c', '%d'];
+        // simple/type
+        yield [true, 'c', 'c'];
+        yield [false, 'c', 'd'];
+        yield [false, 'c', '*'];
+        yield [true, 'c|d', 'c|d'];
+        yield [false, 'c|d', 'e|d'];
+        yield [false, 'c|d', 'd'];
+        yield [false, 'c|d', '|d'];
+        yield [false, 'c|d', '*|d'];
+        yield [false, '|c', 'd|c'];
+        yield [false, '|c', 'c'];
+        yield [true, '|c', '|c'];
+        yield [false, '|c', '*|c'];
+        yield [true, '*|c', '*|c'];
+        // simple/universal
+        yield [true, '*', '*'];
+        yield [false, 'c|*', 'e|d'];
+        yield [false, 'c|*', 'd'];
+        yield [false, 'c|*', '|d'];
+        yield [false, 'c|*', 'd|*'];
+        yield [false, 'c|*', '*'];
+        yield [false, 'c|*', '|*'];
+        yield [false, 'c|*', '*|*'];
+        yield [false, 'c|*', '.d'];
+        yield [false, '|*', 'c|d'];
+        yield [false, '|*', 'd'];
+        yield [false, '|*', 'c|*'];
+        yield [false, '|*', '*'];
+        yield [true, '|*', '|*'];
+        yield [false, '|*', '*|*'];
+        yield [false, '|*', '.d'];
+        yield [true, '*|*', '*|*'];
+        // complex
+        yield [true, 'c', 'd c'];
+        yield [false, 'c d', 'd'];
+        yield [true, 'c d', 'c d'];
+        yield [true, 'c d', 'c.e d.f'];
+        yield [false, 'c.e d.f', 'c d'];
+        yield [true, 'c', 'd e c'];
+        yield [true, 'd c', 'd e c'];
+        yield [true, 'e c', 'd e c'];
+        yield [false, 'f c', 'd e c'];
+        yield [true, 'd c', 'd > c'];
+        yield [false, 'd > c', 'd c'];
+        yield [true, 'd c', 'd > e > c'];
+        yield [true, 'e c', 'd > e > c'];
+        yield [false, 'f c', 'd > e > c'];
+        yield [true, 'c', 'd ~ c'];
+        yield [false, 'c ~ d', 'd'];
+        yield [true, 'c ~ d', 'c ~ d'];
+        yield [true, 'c ~ d', 'c.e ~ d.f'];
+        yield [false, 'c.e ~ d.f', 'c ~ d'];
+        yield [true, 'c', 'd ~ e ~ c'];
+        yield [false, 'f ~ c', 'd ~ e ~ c'];
+        yield [true, 'd ~ c', 'd + c'];
+        yield [false, 'd + c', 'd ~ c'];
+        yield [false, 'f ~ c', 'd + e + c'];
+        yield [true, 'c', 'd + c'];
+        yield [false, 'c + d', 'd'];
+        yield [true, 'c + d', 'c + d'];
+        yield [true, 'c + d', 'c.e + d.f'];
+        yield [false, 'c.e + d.f', 'c + d'];
+        yield [true, 'c', 'd + e + c'];
+        yield [false, 'd + c', 'd + e + c'];
+        yield [false, 'f + c', 'd + e + c'];
+        yield [true, 'c', 'd > c'];
+        yield [false, 'c > d', 'd'];
+        yield [true, 'c > d', 'c > d'];
+        yield [true, 'c > d', 'c.e > d.f'];
+        yield [false, 'c.e > d.f', 'c > d'];
+        yield [true, 'c', 'd > e > c'];
+        yield [false, 'd > c', 'd > e > c'];
+        yield [false, 'f > c', 'd > e > c'];
+        // compound
+        yield [true, 'c', 'c.d'];
+        yield [true, 'c.e', 'c:d.e'];
+        yield [false, 'c.d', 'c'];
+        yield [true, '::d', 'c::d'];
+        yield [false, 'c', 'c::d'];
+        yield [true, '::d:e', '::d:e'];
+        yield [false, 'c', 'c:before'];
+        yield [false, 'c', 'c:after'];
+        yield [false, 'c', 'c:first-line'];
+        yield [false, 'c', 'c:first-letter'];
+        // list
+        yield [false, 'c', 'c, d'];
+        yield [true, 'c, d', 'c'];
+        yield [true, 'c, d', 'c, d'];
+        yield [true, 'c, d', 'c.e, d.f'];
+        yield [false, 'c.e, d.f', 'c, d'];
+        yield [true, '.c', 'd.c, e.c'];
+        yield [true, 'c, d, e', 'd'];
+        yield [true, 'c, d, e', 'e, c'];
+        yield [true, 'c, d, e', 'd, c, e'];
+        yield [false, 'c, d, e', 'c, f'];
+    }
+}

--- a/tests/Extend/UnificationTest.php
+++ b/tests/Extend/UnificationTest.php
@@ -1,0 +1,270 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Tests\Extend;
+
+use PHPUnit\Framework\TestCase;
+use ScssPhp\ScssPhp\Ast\Selector\SelectorList;
+
+/**
+ * Selector unification tests, taken from sass-spec
+ * TODO Remove those tests once the compiler uses this implementation of selectors, as sass-spec covers that logic
+ */
+class UnificationTest extends TestCase
+{
+    /**
+     * @dataProvider provideUnificationTests
+     */
+    public function testUnify($expected, $first, $second)
+    {
+        $firstSelector = SelectorList::parse($first);
+        $secondSelector = SelectorList::parse($second);
+        $unified = $firstSelector->unify($secondSelector);
+
+        if ($expected === null) {
+            $this->assertNull($unified);
+        } else {
+            $this->assertInstanceOf(SelectorList::class, $unified);
+            $this->assertEquals($expected, (string) $unified);
+        }
+    }
+
+    /**
+     * Provide selector unification tests taken from sass-spec in spec/core_functions/selector/unify/
+     */
+    public static function provideUnificationTests(): iterable
+    {
+        // complex/combinators
+        yield ['.e .c > .d.f', '.c > .d', '.e .f'];
+        yield ['.c > .s1.s2', '.c > .s1', '.c .s2'];
+        yield ['.c.s1-1 > .s1-2.s2', '.c.s1-1 > .s1-2', '.c .s2'];
+        yield ['.c.s2-1 .c.s1-1 > .s1-2.s2-2', '.c.s1-1 > .s1-2', '.c.s2-1 .s2-2'];
+        yield ['.e.c > .d.f', '.c > .d', '.e > .f'];
+        yield ['.c.s1-1 > .s1-2.s2', '.c.s1-1 > .s1-2', '.c > .s2'];
+        yield ['.c.s2-1.s1-1 > .s1-2.s2-2', '.c.s1-1 > .s1-2', '.c.s2-1 > .s2-2'];
+        yield [null, '#s1-1 > .s1-2', '#s2-1 > .s2-2'];
+        yield ['.c > .c ~ .s1.s2', '.c > .s1', '.c ~ .s2'];
+        yield ['.c > .c + .s1.s2', '.c > .s1', '.c + .s2'];
+        yield ['.c .c ~ .s1.s2', '.c ~ .s1', '.c .s2'];
+        yield ['.c > .c ~ .s1.s2', '.c ~ .s1', '.c > .s2'];
+        yield ['.c ~ .e ~ .d.f, .e ~ .c ~ .d.f, .e.c ~ .d.f', '.c ~ .d', '.e ~ .f'];
+        yield ['.c ~ .s1.s2', '.c ~ .s1', '.c ~ .s2'];
+        yield ['.c.s1-1 ~ .s1-2.s2', '.c.s1-1 ~ .s1-2', '.c ~ .s2'];
+        yield ['.c.s1-1 ~ .c.s2-1 ~ .s1-2.s2-2, .c.s2-1 ~ .c.s1-1 ~ .s1-2.s2-2, .c.s2-1.s1-1 ~ .s1-2.s2-2', '.c.s1-1 ~ .s1-2', '.c.s2-1 ~ .s2-2'];
+        yield ['#s1-1 ~ #s2-1 ~ .s1-2.s2-2, #s2-1 ~ #s1-1 ~ .s1-2.s2-2', '#s1-1 ~ .s1-2', '#s2-1 ~ .s2-2'];
+        yield ['.c ~ .e + .d.f, .e.c + .d.f', '.c ~ .d', '.e + .f'];
+        yield ['.c + .s1.s2', '.c ~ .s1', '.c + .s2'];
+        yield ['.c.s1-1 ~ .c + .s1-2.s2, .c.s1-1 + .s1-2.s2', '.c.s1-1 ~ .s1-2', '.c + .s2'];
+        yield ['.c.s1-1 ~ .c.s2-1 + .s1-2.s2-2, .c.s2-1.s1-1 + .s1-2.s2-2', '.c.s1-1 ~ .s1-2', '.c.s2-1 + .s2-2'];
+        yield ['#s1-1 ~ #s2-1 + .s1-2.s2-2', '#s1-1 ~ .s1-2', '#s2-1 + .s2-2'];
+        yield ['.c .c + .s1.s2', '.c + .s1', '.c .s2'];
+        yield ['.c > .c + .s1.s2', '.c + .s1', '.c > .s2'];
+        yield ['.e ~ .c + .d.f, .e.c + .d.f', '.c + .d', '.e ~ .f'];
+        yield ['.c + .s1.s2', '.c + .s1', '.c ~ .s2'];
+        yield ['.c.s1-1 + .s1-2.s2', '.c.s1-1 + .s1-2', '.c ~ .s2'];
+        yield ['.c.s2-1 ~ .c.s1-1 + .s1-2.s2-2, .c.s2-1.s1-1 + .s1-2.s2-2', '.c.s1-1 + .s1-2', '.c.s2-1 ~ .s2-2'];
+        yield ['#s2-1 ~ #s1-1 + .s1-2.s2-2', '#s1-1 + .s1-2', '#s2-1 ~ .s2-2'];
+        yield ['.e.c + .d.f', '.c + .d', '.e + .f'];
+        yield ['.c.s1-1 + .s1-2.s2', '.c.s1-1 + .s1-2', '.c + .s2'];
+        yield ['.c.s2-1.s1-1 + .s1-2.s2-2', '.c.s1-1 + .s1-2', '.c.s2-1 + .s2-2'];
+        yield [null, '#s1-1 + .s1-2', '#s2-1 + .s2-2'];
+        yield ['> .c.d', '> .c', '.d'];
+        yield ['~ .c.d', '.c', '~ .d'];
+        yield ['+ .c.d', '+ .c', '+ .d'];
+        yield ['> + ~ > > .c.d', '+ ~ > .c', '> + ~ > > .d'];
+        yield ['+ > ~ ~ > .c.d', '+ ~ > .c', '+ > ~ ~ > .d'];
+        yield [null, '+ ~ > .c', '+ > ~ ~ .d'];
+        yield ['.f .c > .g ~ .d + .e.h, .f .c > .g.d + .e.h', '.c > .d + .e', '.f .g ~ .h'];
+        yield ['.c .e + ~ > .d.f, .e .c + ~ > .d.f', '.c + ~ > .d', '.e + ~ > .f'];
+        yield ['.c .e > + ~ > > .d.f, .e .c > + ~ > > .d.f', '.c + ~ > .d', '.e > + ~ > > .f'];
+        yield ['.c .e + > ~ ~ > .d.f, .e .c + > ~ ~ > .d.f', '.c + ~ > .d', '.e + > ~ ~ > .f'];
+        yield [null, '.c + ~ > .d', '.e + > ~ ~ .f'];
+        // complex/distinct
+        yield ['.c .e .d.f, .e .c .d.f', '.c .d', '.e .f'];
+        yield ['.c .d .f .g .e.h, .f .g .c .d .e.h', '.c .d .e', '.f .g .h'];
+        // complex/identical
+        yield ['.c .s1.s2', '.c .s1', '.c .s2'];
+        yield ['.c .s1-1 .s2-1 .s1-2.s2-2, .c .s2-1 .s1-1 .s1-2.s2-2', '.c .s1-1 .s1-2', '.c .s2-1 .s2-2'];
+        yield ['.s1-1 .s2-1 .d .s1-2.s2-2, .s2-1 .s1-1 .d .s1-2.s2-2', '.s1-1 .d .s1-2', '.s2-1 .d .s2-2'];
+        // complex/lcs
+        yield ['.e .c .d .e .s1.s2', '.c .d .e .s1', '.e .c .d .s2'];
+        yield ['.f .g .c .d .e .f .g .s1.s2', '.c .d .e .f .g .s1', '.f .g .c .d .e .s2'];
+        yield ['.s1-1 .s2-1 .c .d .s1-2 .s2-2 .e .s1-3.s2-3, .s2-1 .s1-1 .c .d .s1-2 .s2-2 .e .s1-3.s2-3, .s1-1 .s2-1 .c .d .s2-2 .s1-2 .e .s1-3.s2-3, .s2-1 .s1-1 .c .d .s2-2 .s1-2 .e .s1-3.s2-3', '.s1-1 .c .d .s1-2 .e .s1-3', '.s2-1 .c .d .s2-2 .e .s2-3'];
+        yield ['.s1-1 .c .s2-1 .d .s1-2 .e .s2-2 .s1-3.s2-3', '.s1-1 .c .d .s1-2 .e .s1-3', '.c .s2-1 .d .e .s2-2 .s2-3'];
+        // complex/overlap
+        yield ['.c.s1-1 .c.s2-1 .s1-2.s2-2, .c.s2-1 .c.s1-1 .s1-2.s2-2', '.c.s1-1 .s1-2', '.c.s2-1 .s2-2'];
+        yield ['#s1-1.c #s2-1.c .s1-2.s2-2, #s2-1.c #s1-1.c .s1-2.s2-2', '#s1-1.c .s1-2', '#s2-1.c .s2-2'];
+        yield ['#c.s2-1.s1-1 .s1-2.s2-2', '#c.s1-1 .s1-2', '#c.s2-1 .s2-2'];
+        yield ['::s1-1.c ::s2-1.c .s1-2.s2-2, ::s2-1.c ::s1-1.c .s1-2.s2-2', '::s1-1.c .s1-2', '::s2-1.c .s2-2'];
+        yield ['.s2-1.s1-1::c .s1-2.s2-2', '.s1-1::c .s1-2', '.s2-1::c .s2-2'];
+        // complex/root
+        yield [':root .d .c.e', ':root .c', '.d .e'];
+        yield [':root .c .d.e', '.c .d', ':root .e'];
+        yield [null, 'c:root .d', 'e:root .f'];
+        yield ['c:root .d.e', 'c:root .d', ':root .e'];
+        yield ['.e.c:root .d.f', '.c:root .d', '.e:root .f'];
+        // complex/superselector
+        yield ['.c.s1-1 .s1-2.s2', '.c.s1-1 .s1-2', '.c .s2'];
+        yield ['.c.s1-1 .s1-2 .s2-1 .s1-3.s2-2, .c.s1-1 .s2-1 .s1-2 .s1-3.s2-2', '.c.s1-1 .s1-2 .s1-3', '.c .s2-1 .s2-2'];
+        yield ['.s1-1 .s2-1 .c.s1-2 .s1-3.s2-2, .s2-1 .s1-1 .c.s1-2 .s1-3.s2-2', '.s1-1 .c.s1-2 .s1-3', '.s2-1 .c .s2-2'];
+        // simple/attribute
+        yield ['[c]', '[c]', '[c]'];
+        yield ['[c][d]', '[c]', '[d]'];
+        // simple/class
+        yield ['.c', '.c', '.c'];
+        yield ['.c.d', '.c', '.d'];
+        // simple/different_types
+        yield ['c#d', 'c', '#d'];
+        // simple/id
+        yield ['#c', '#c', '#c'];
+        yield [null, '#c', '#d'];
+        // simple/placeholder
+        yield ['%c', '%c', '%c'];
+        yield ['%c%d', '%c', '%d'];
+        // simple/pseudo
+        yield [':c', ':c', ':c'];
+        yield [':c:d', ':c', ':d'];
+        yield ['::c', '::c', '::c'];
+        yield [null, '::c', '::d'];
+        yield [':before', ':before', '::before'];
+        yield [':after', ':after', '::after'];
+        yield [':first-line', ':first-line', '::first-line'];
+        yield [':first-letter', ':first-letter', '::first-letter'];
+        yield [':c(@#$)', ':c(@#$)', ':c(@#$)'];
+        yield [':c(@#$):c(*&^)', ':c(@#$)', ':c(*&^)'];
+        yield ['::c(@#$)', '::c(@#$)', '::c(@#$)'];
+        yield [null, '::c(@#$)', '::c(*&^)'];
+        yield [':is(.c)', ':is(.c)', ':is(.c)'];
+        yield [':is(.c):is(.d)', ':is(.c)', ':is(.d)'];
+        yield [':matches(.c)', ':matches(.c)', ':matches(.c)'];
+        yield [':matches(.c):matches(.d)', ':matches(.c)', ':matches(.d)'];
+        yield [':host', ':host', ':host'];
+        yield [':host:host(.c)', ':host', ':host(.c)'];
+        yield [':host:host-context(.c)', ':host', ':host-context(.c)'];
+        yield [':host-context(.c):host', ':host-context(.c)', ':host'];
+        yield [':is(.c):host', ':host', ':is(.c)'];
+        yield [':is(.c):host', ':is(.c)', ':host'];
+        yield [null, ':host', ':hover'];
+        yield [null, ':hover', ':host'];
+        yield [null, ':host', '.c'];
+        yield [null, '.c', ':host'];
+        yield [null, ':host', '*'];
+        yield [null, '*', ':host'];
+        yield [':is(.c):host:is(.d)', ':host', ':is(.c):is(.d)'];
+        yield [':is(.c):is(.d):host', ':is(.c):is(.d)', ':host'];
+        yield [null, ':host', '.c:is(.d)'];
+        yield [null, '.c:is(.d)', ':host'];
+        yield [null, ':host', ':host.c'];
+        yield [null, ':host.c', ':host'];
+        yield [':is(.d):host(.c)', ':host(.c)', ':is(.d)'];
+        yield [':is(.c):host(.d)', ':is(.c)', ':host(.d)'];
+        yield [null, ':host(.c)', '.d'];
+        yield [null, '.c', ':host(.d)'];
+        yield [':is(.d):host-context(.c)', ':host-context(.c)', ':is(.d)'];
+        yield [':is(.c):host-context(.d)', ':is(.c)', ':host-context(.d)'];
+        yield [null, ':host-context(.c)', '.d'];
+        yield [null, '.c', ':host-context(.d)'];
+        // simple/type
+        yield [null, 'c', 'd|c'];
+        yield [null, 'c', '|c'];
+        yield ['c', 'c', 'c'];
+        yield [null, 'c', 'd'];
+        yield ['c', 'c', '*|c'];
+        yield [null, 'c', '*|d'];
+        yield ['c|d', 'c|d', 'c|d'];
+        yield [null, 'c|d', 'e|d'];
+        yield [null, 'c|d', 'c|e'];
+        yield [null, 'c|d', '|d'];
+        yield [null, 'c|d', 'd'];
+        yield ['c|d', 'c|d', '*|d'];
+        yield [null, 'c|d', '*|e'];
+        yield [null, '|c', 'e|c'];
+        yield ['|c', '|c', '|c'];
+        yield [null, '|c', '|d'];
+        yield [null, '|c', 'c'];
+        yield ['|c', '|c', '*|c'];
+        yield [null, '|c', '*|d'];
+        yield ['d|c', '*|c', 'd|c'];
+        yield [null, '*|c', 'd|e'];
+        yield ['|c', '*|c', '|c'];
+        yield [null, '*|c', '|d'];
+        yield ['c', '*|c', 'c'];
+        yield [null, '*|c', 'd'];
+        yield ['*|c', '*|c', '*|c'];
+        yield [null, '*|c', '*|d'];
+        yield [null, 'c', 'e|*'];
+        yield [null, 'c', '|*'];
+        yield ['c', 'c', '*'];
+        yield ['c', 'c', '*|*'];
+        yield ['c|d', 'c|d', 'c|*'];
+        yield [null, 'c|d', 'e|*'];
+        yield [null, 'c|d', '|*'];
+        yield [null, 'c|d', '*'];
+        yield ['c|d', 'c|d', '*|*'];
+        yield [null, '|c', 'e|*'];
+        yield ['|c', '|c', '|*'];
+        yield [null, '|c', '*'];
+        yield ['|c', '|c', '*|*'];
+        yield ['d|c', '*|c', 'd|*'];
+        yield ['|c', '*|c', '|*'];
+        yield ['c', '*|c', '*'];
+        yield ['*|c', '*|c', '*|*'];
+        // simple/universal
+        yield [null, '*', 'c|d'];
+        yield [null, '*', '|c'];
+        yield ['c', '*', 'c'];
+        yield ['c', '*', '*|c'];
+        yield ['c|d', 'c|*', 'c|d'];
+        yield [null, 'c|*', 'd|e'];
+        yield [null, 'c|*', '|d'];
+        yield [null, 'c|*', 'd'];
+        yield ['c|d', 'c|*', '*|d'];
+        yield [null, '|*', 'c|d'];
+        yield ['|c', '|*', '|c'];
+        yield [null, '|*', 'c'];
+        yield ['|c', '|*', '*|c'];
+        yield ['c|d', '*|*', 'c|d'];
+        yield ['|c', '*|*', '|c'];
+        yield ['c', '*|*', 'c'];
+        yield ['*|c', '*|*', '*|c'];
+        yield [null, '*', 'e|*'];
+        yield [null, '*', '|*'];
+        yield ['*', '*', '*'];
+        yield ['*', '*', '*|*'];
+        yield ['c|*', 'c|*', 'c|*'];
+        yield [null, 'c|*', '|*'];
+        yield [null, 'c|*', '*'];
+        yield ['c|*', 'c|*', '*|*'];
+        yield [null, '|*', 'e|*'];
+        yield ['|*', '|*', '|*'];
+        yield [null, '|*', '*'];
+        yield ['|*', '|*', '*|*'];
+        yield ['c|*', '*|*', 'c|*'];
+        yield ['|*', '*|*', '|*'];
+        yield ['*', '*|*', '*'];
+        yield ['*|*', '*|*', '*|*'];
+        // chooses_superselector
+        yield ['d c.e', 'c', 'd c.e'];
+        yield ['d c.e', 'd c.e', 'c'];
+        yield ['c.e d.f', 'c d', 'c.e .f'];
+        yield ['c.e d.f', 'c.e .f', 'c d'];
+        // compound
+        yield ['.c.d.e.f', '.c.d', '.e.f'];
+        yield ['.c.d.e', '.c.d', '.d.e'];
+        yield ['.c.d', '.c.d', '.c.d'];
+        yield ['d.c', '.c', 'd'];
+        yield ['.d::c', '::c', '.d'];
+        yield ['.d:c', ':c', '.d'];
+        yield [':d::c', '::c', ':d'];
+        yield [':c::d', ':c', '::d'];
+    }
+}


### PR DESCRIPTION
This implements 3 algorithms ported from dart-sass in the Selector API (not yet used by the Compiler):

- `is-superselector()`
- `selector-unify()` (which depends heavily on the previous one)
- the resolution of parent selectors, which is the basis of `selector-nest()` (`selector-nest()` allows passing an arbitrary amount of selectors, which is just a matter of calling that resolution in a loop)

As this logic is not yet used by the compiler, I extracted test cases for them from sass-spec, to allow testing my implementation (and finding cases where I made mistakes in the process of porting the code...)