### PR TITLE
Implement the CSS AST and its serialization

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2001,6 +2001,11 @@ parameters:
 			path: src/Parser/StylesheetParser.php
 
 		-
+			message: "#^Negated boolean expression is always true\\.$#"
+			count: 1
+			path: src/Serializer/SerializeVisitor.php
+
+		-
 			message: "#^Method ScssPhp\\\\ScssPhp\\\\SourceMap\\\\SourceMapGenerator\\:\\:generateJson\\(\\) should return string but returns string\\|false\\.$#"
 			count: 1
 			path: src/SourceMap/SourceMapGenerator.php

--- a/src/Ast/Css/CssAtRule.php
+++ b/src/Ast/Css/CssAtRule.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Css;
+
+/**
+ * An unknown plain CSS at-rule.
+ *
+ * @internal
+ */
+interface CssAtRule extends CssParentNode
+{
+    /**
+     * The name of this rule.
+     *
+     * @return CssValue<string>
+     */
+    public function getName(): CssValue;
+
+    /**
+     * The value of this rule.
+     *
+     * @return CssValue<string>|null
+     */
+    public function getValue(): ?CssValue;
+}

--- a/src/Ast/Css/CssComment.php
+++ b/src/Ast/Css/CssComment.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Css;
+
+/**
+ * A plain CSS comment.
+ *
+ * This is always a multi-line comment.
+ */
+interface CssComment extends CssNode
+{
+    /**
+     * The contents of this comment, including `/*` and `* /`.
+     */
+    public function getText(): string;
+
+    /**
+     * Whether this comment starts with `/*!` and so should be preserved even in
+     * compressed mode.
+     */
+    public function isPreserved(): bool;
+}

--- a/src/Ast/Css/CssDeclaration.php
+++ b/src/Ast/Css/CssDeclaration.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Css;
+
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+use ScssPhp\ScssPhp\Value\Value;
+
+/**
+ * A plain CSS declaration (that is, a `name: value` pair).
+ *
+ * @internal
+ */
+interface CssDeclaration extends CssNode
+{
+    /**
+     * The name of this declaration.
+     *
+     * @return CssValue<string>
+     */
+    public function getName(): CssValue;
+
+    /**
+     * The value of this declaration.
+     *
+     * @return CssValue<Value>
+     */
+    public function getValue(): CssValue;
+
+    /**
+     * The span for {@see getValue} that should be emitted to the source map.
+     *
+     * When the declaration's expression is just a variable, this is the span
+     * where that variable was declared whereas `$this->getValue()->getSpan()` is the span where
+     * the variable was used. Otherwise, this is identical to `$this->getValue()->getSpan()`.
+     */
+    public function getValueSpanForMap(): FileSpan;
+
+    /**
+     * Returns whether this is a CSS Custom Property declaration.
+     */
+    public function isCustomProperty(): bool;
+
+    /**
+     * Whether this was originally parsed as a custom property declaration, as
+     * opposed to using something like `#{--foo}: ...` to cause it to be parsed
+     * as a normal Sass declaration.
+     *
+     * If this is `true`, {@see isCustomProperty} will also be `true` and {@see getValue} will
+     * contain a {@see SassString}.
+     */
+    public function isParsedAsCustomProperty(): bool;
+}

--- a/src/Ast/Css/CssImport.php
+++ b/src/Ast/Css/CssImport.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Css;
+
+/**
+ * A plain CSS `@import`.
+ *
+ * @internal
+ */
+interface CssImport extends CssNode
+{
+    /**
+     * The URL being imported.
+     *
+     * This includes quotes.
+     *
+     * @return CssValue<string>
+     */
+    public function getUrl(): CssValue;
+
+    /**
+     * The supports condition attached to this import.
+     *
+     * @return CssValue<string>|null
+     */
+    public function getSupports(): ?CssValue;
+
+    /**
+     * The media query attached to this import.
+     *
+     * @return list<CssMediaQuery>|null
+     */
+    public function getMedia(): ?array;
+}

--- a/src/Ast/Css/CssKeyframeBlock.php
+++ b/src/Ast/Css/CssKeyframeBlock.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Css;
+
+/**
+ * A block within a `@keyframes` rule.
+ *
+ * For example, `10% {opacity: 0.5}`.
+ *
+ * @internal
+ */
+interface CssKeyframeBlock extends CssParentNode
+{
+    /**
+     * The selector for this block.
+     *
+     * @return CssValue<list<string>>
+     */
+    public function getSelector(): CssValue;
+}

--- a/src/Ast/Css/CssMediaRule.php
+++ b/src/Ast/Css/CssMediaRule.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Css;
+
+/**
+ * A plain CSS `@media` rule.
+ *
+ * @internal
+ */
+interface CssMediaRule extends CssParentNode
+{
+    /**
+     * The queries for this rule.
+     *
+     * This is never empty.
+     *
+     * @return list<CssMediaQuery>
+     */
+    public function getQueries(): array;
+}

--- a/src/Ast/Css/CssNode.php
+++ b/src/Ast/Css/CssNode.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Css;
+
+use ScssPhp\ScssPhp\Ast\AstNode;
+use ScssPhp\ScssPhp\Visitor\CssVisitor;
+
+/**
+ * A statement in a plain CSS syntax tree.
+ *
+ * @internal
+ */
+interface CssNode extends AstNode
+{
+    /**
+     * Whether this was generated from the last node in a nested Sass tree that
+     * got flattened during evaluation.
+     */
+    public function isGroupEnd(): bool;
+
+    /**
+     * Calls the appropriate visit method on $visitor.
+     *
+     * @template T
+     *
+     * @param CssVisitor<T> $visitor
+     *
+     * @return T
+     */
+    public function accept($visitor);
+}

--- a/src/Ast/Css/CssParentNode.php
+++ b/src/Ast/Css/CssParentNode.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Css;
+
+/**
+ * A {@see CssNode} that can have child statements.
+ *
+ * @internal
+ */
+interface CssParentNode extends CssNode
+{
+    /**
+     * The child statements of this node.
+     *
+     * @return list<CssNode>
+     */
+    public function getChildren(): array;
+
+    /**
+     * Whether the rule has no children and should be emitted without curly
+     * braces.
+     *
+     * This implies `children.isEmpty`, but the reverse is not true—for a rule
+     * like `@foo {}`, {@see getChildren} is empty but {@see isChildless} is `false`.
+     */
+    public function isChildless(): bool;
+}

--- a/src/Ast/Css/CssStyleRule.php
+++ b/src/Ast/Css/CssStyleRule.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Css;
+
+use ScssPhp\ScssPhp\Ast\Selector\SelectorList;
+
+/**
+ * A plain CSS style rule.
+*  *
+*  * This applies style declarations to elements that match a given selector.
+*  * Note that this isn't *strictly* plain CSS, since {@see getSelector} may still
+*  * contain placeholder selectors.
+ */
+interface CssStyleRule extends CssParentNode
+{
+    /**
+     * The selector for this rule.
+     *
+     * @return CssValue<SelectorList>
+     */
+    public function getSelector(): CssValue;
+
+    /**
+     * The selector for this rule, before any extensions were applied.
+     */
+    public function getOriginalSelector(): SelectorList;
+}

--- a/src/Ast/Css/CssStylesheet.php
+++ b/src/Ast/Css/CssStylesheet.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Css;
+
+/**
+ * A plain CSS stylesheet.
+ *
+ * This is the root plain CSS node. It contains top-level statements.
+ *
+ * @internal
+ */
+interface CssStylesheet extends CssParentNode
+{
+}

--- a/src/Ast/Css/CssSupportsRule.php
+++ b/src/Ast/Css/CssSupportsRule.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Css;
+
+/**
+ * A plain CSS `@supports` rule.
+ *
+ * @internal
+ */
+interface CssSupportsRule extends CssParentNode
+{
+    /**
+     * The supports condition.
+     *
+     * @return CssValue<string>
+     */
+    public function getCondition(): CssValue;
+}

--- a/src/Ast/Css/CssValue.php
+++ b/src/Ast/Css/CssValue.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Css;
+
+use ScssPhp\ScssPhp\Ast\AstNode;
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+
+/**
+ * A value in a plain CSS tree.
+ *
+ * This is used to associate a span with a value that doesn't otherwise track
+ * its span.
+ *
+ * @template T
+ */
+class CssValue implements AstNode
+{
+    /**
+     * @phpstan-var T
+     */
+    protected $value;
+
+    /**
+     * @var FileSpan
+     * @readonly
+     */
+    private $span;
+
+    /**
+     * @param T $value
+     */
+    public function __construct($value, FileSpan $span)
+    {
+        $this->value = $value;
+        $this->span = $span;
+    }
+
+    /**
+     * @return T
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    public function getSpan(): FileSpan
+    {
+        return $this->span;
+    }
+}

--- a/src/Ast/Css/ModifiableCssAtRule.php
+++ b/src/Ast/Css/ModifiableCssAtRule.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Css;
+
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+
+/**
+ * A modifiable version of {@see CssAtRule} for use in the evaluation step.
+ *
+ * @internal
+ */
+final class ModifiableCssAtRule extends ModifiableCssParentNode implements CssAtRule
+{
+    /**
+     * @var CssValue<string>
+     */
+    private $name;
+
+    /**
+     * @var CssValue<string>|null
+     */
+    private $value;
+
+    /**
+     * @var bool
+     * @readonly
+     */
+    private $childless;
+
+    /**
+     * @var FileSpan
+     * @readonly
+     */
+    private $span;
+
+    /**
+     * @param CssValue<string>      $name
+     * @param CssValue<string>|null $value
+     * @param bool                  $childless
+     * @param FileSpan              $span
+     */
+    public function __construct(CssValue $name, FileSpan $span, bool $childless = false, ?CssValue $value = null)
+    {
+        parent::__construct();
+
+        $this->name = $name;
+        $this->value = $value;
+        $this->childless = $childless;
+        $this->span = $span;
+    }
+
+    public function getName(): CssValue
+    {
+        return $this->name;
+    }
+
+    public function getValue(): ?CssValue
+    {
+        return $this->value;
+    }
+
+    public function isChildless(): bool
+    {
+        return $this->childless;
+    }
+
+    public function getSpan(): FileSpan
+    {
+        return $this->span;
+    }
+
+    public function accept($visitor)
+    {
+        return $visitor->visitCssAtRule($this);
+    }
+
+    /**
+     * @phpstan-return ModifiableCssAtRule
+     */
+    public function copyWithoutChildren(): ModifiableCssParentNode
+    {
+        return new ModifiableCssAtRule($this->name, $this->span, $this->childless, $this->value);
+    }
+
+    public function addChild(ModifiableCssNode $child): void
+    {
+        if ($this->childless) {
+            throw new \LogicException('Cannot add a child in a childless at-rule.');
+        }
+
+        parent::addChild($child);
+    }
+}

--- a/src/Ast/Css/ModifiableCssComment.php
+++ b/src/Ast/Css/ModifiableCssComment.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Css;
+
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+
+/**
+ * A modifiable version of {@see CssComment} for use in the evaluation step.
+ *
+ * @internal
+ */
+final class ModifiableCssComment extends ModifiableCssNode implements CssComment
+{
+    /**
+     * @var string
+     * @readonly
+     */
+    private $text;
+
+    /**
+     * @var FileSpan
+     * @readonly
+     */
+    private $span;
+
+    public function __construct(string $text, FileSpan $span)
+    {
+        $this->text = $text;
+        $this->span = $span;
+    }
+
+    public function getText(): string
+    {
+        return $this->text;
+    }
+
+    public function getSpan(): FileSpan
+    {
+        return $this->span;
+    }
+
+    public function isPreserved(): bool
+    {
+        return $this->text[2] === '!';
+    }
+
+    public function accept($visitor)
+    {
+        return $visitor->visitCssComment($this);
+    }
+}

--- a/src/Ast/Css/ModifiableCssDeclaration.php
+++ b/src/Ast/Css/ModifiableCssDeclaration.php
@@ -1,0 +1,115 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Css;
+
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+use ScssPhp\ScssPhp\Value\SassString;
+use ScssPhp\ScssPhp\Value\Value;
+
+/**
+ * A modifiable version of {@see CssDeclaration} for use in the evaluation step.
+ *
+ * @internal
+ */
+final class ModifiableCssDeclaration extends ModifiableCssNode implements CssDeclaration
+{
+    /**
+     * @var CssValue<string>
+     * @readonly
+     */
+    private $name;
+
+    /**
+     * @var CssValue<Value>
+     * @readonly
+     */
+    private $value;
+
+    /**
+     * @var bool
+     * @readonly
+     */
+    private $parsedAsCustomProperty;
+
+    /**
+     * @var FileSpan
+     * @readonly
+     */
+    private $valueSpanForMap;
+
+    /**
+     * @var FileSpan
+     * @readonly
+     */
+    private $span;
+
+    /**
+     * @param CssValue<string> $name
+     * @param CssValue<Value>  $value
+     * @param bool             $parsedAsCustomProperty
+     * @param FileSpan         $valueSpanForMap
+     * @param FileSpan         $span
+     */
+    public function __construct(CssValue $name, CssValue $value, FileSpan $span, bool $parsedAsCustomProperty, ?FileSpan $valueSpanForMap = null) {
+        $this->name = $name;
+        $this->value = $value;
+        $this->parsedAsCustomProperty = $parsedAsCustomProperty;
+        $this->valueSpanForMap = $valueSpanForMap ?? $value->getSpan();
+        $this->span = $span;
+
+        if ($parsedAsCustomProperty) {
+            if (!$this->isCustomProperty()) {
+                throw new \InvalidArgumentException('parsedAsCustomProperty must be false if name doesn\'t begin with "--".');
+            }
+
+            if (!$value->getValue() instanceof SassString) {
+                throw new \InvalidArgumentException(sprintf('If parsedAsCustomProperty is true, value must contain a SassString (was %s).', get_class($value->getValue())));
+            }
+        }
+    }
+
+    public function getName(): CssValue
+    {
+        return $this->name;
+    }
+
+    public function getValue(): CssValue
+    {
+        return $this->value;
+    }
+
+    public function isParsedAsCustomProperty(): bool
+    {
+        return $this->parsedAsCustomProperty;
+    }
+
+    public function getValueSpanForMap(): FileSpan
+    {
+        return $this->valueSpanForMap;
+    }
+
+    public function getSpan(): FileSpan
+    {
+        return $this->span;
+    }
+
+    public function isCustomProperty(): bool
+    {
+        return 0 === strpos($this->name->getValue(), '--');
+    }
+
+    public function accept($visitor)
+    {
+        return $visitor->visitCssDeclaration($this);
+    }
+}

--- a/src/Ast/Css/ModifiableCssImport.php
+++ b/src/Ast/Css/ModifiableCssImport.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Css;
+
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+
+/**
+ * A modifiable version of {@see CssImport} for use in the evaluation step.
+ *
+ * @internal
+ */
+final class ModifiableCssImport extends ModifiableCssNode implements CssImport
+{
+    /**
+     * The URL being imported.
+     *
+     * This includes quotes.
+     *
+     * @var CssValue<string>
+     * @readonly
+     */
+    private $url;
+
+    /**
+     * @var CssValue<string>|null
+     * @readonly
+     */
+    private $supports;
+
+    /**
+     * @var list<CssMediaQuery>|null
+     * @readonly
+     */
+    private $media;
+
+    /**
+     * @var FileSpan
+     * @readonly
+     */
+    private $span;
+
+    /**
+     * @param CssValue<string>         $url
+     * @param FileSpan                 $span
+     * @param CssValue<string>|null    $supports
+     * @param list<CssMediaQuery>|null $media
+     */
+    public function __construct(CssValue $url, FileSpan $span, ?CssValue $supports = null, ?array $media = null)
+    {
+        $this->url = $url;
+        $this->supports = $supports;
+        $this->media = $media;
+        $this->span = $span;
+    }
+
+    public function getUrl(): CssValue
+    {
+        return $this->url;
+    }
+
+    public function getSupports(): ?CssValue
+    {
+        return $this->supports;
+    }
+
+    public function getMedia(): ?array
+    {
+        return $this->media;
+    }
+
+    public function getSpan(): FileSpan
+    {
+        return $this->span;
+    }
+
+    public function accept($visitor)
+    {
+        return $visitor->visitCssImport($this);
+    }
+}

--- a/src/Ast/Css/ModifiableCssKeyframeBlock.php
+++ b/src/Ast/Css/ModifiableCssKeyframeBlock.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Css;
+
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+
+/**
+ * A modifiable version of {@see CssKeyframeBlock} for use in the evaluation step.
+ *
+ * @internal
+ */
+final class ModifiableCssKeyframeBlock extends ModifiableCssParentNode implements CssKeyframeBlock
+{
+    /**
+     * @var CssValue<list<string>>
+     * @readonly
+     */
+    private $selector;
+
+    /**
+     * @var FileSpan
+     * @readonly
+     */
+    private $span;
+
+    /**
+     * @param CssValue<list<string>> $selector
+     * @param FileSpan               $span
+     */
+    public function __construct(CssValue $selector, FileSpan $span)
+    {
+        parent::__construct();
+        $this->selector = $selector;
+        $this->span = $span;
+    }
+
+    public function getSelector(): CssValue
+    {
+        return $this->selector;
+    }
+
+    public function getSpan(): FileSpan
+    {
+        return $this->span;
+    }
+
+    public function accept($visitor)
+    {
+        return $visitor->visitCssKeyframeBlock($this);
+    }
+
+    /**
+     * @phpstan-return ModifiableCssKeyframeBlock
+     */
+    public function copyWithoutChildren(): ModifiableCssParentNode
+    {
+        return new ModifiableCssKeyframeBlock($this->selector, $this->span);
+    }
+}

--- a/src/Ast/Css/ModifiableCssMediaRule.php
+++ b/src/Ast/Css/ModifiableCssMediaRule.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Css;
+
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+
+/**
+ * A modifiable version of {@see CssMediaRule} for use in the evaluation step.
+ *
+ * @internal
+ */
+final class ModifiableCssMediaRule extends ModifiableCssParentNode implements CssMediaRule
+{
+    /**
+     * @var list<CssMediaQuery>
+     */
+    private $queries;
+
+    /**
+     * @var FileSpan
+     * @readonly
+     */
+    private $span;
+
+    /**
+     * @param CssMediaQuery[] $queries
+     * @param FileSpan        $span
+     */
+    public function __construct(array $queries, FileSpan $span)
+    {
+        parent::__construct();
+        $this->queries = $queries;
+        $this->span = $span;
+    }
+
+    public function getQueries(): array
+    {
+        return $this->queries;
+    }
+
+    public function getSpan(): FileSpan
+    {
+        return $this->span;
+    }
+
+    public function accept($visitor)
+    {
+        return $visitor->visitCssMediaRule($this);
+    }
+
+    public function copyWithoutChildren(): ModifiableCssParentNode
+    {
+        return new ModifiableCssMediaRule($this->queries, $this->span);
+    }
+}

--- a/src/Ast/Css/ModifiableCssNode.php
+++ b/src/Ast/Css/ModifiableCssNode.php
@@ -1,0 +1,164 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Css;
+
+use ScssPhp\ScssPhp\Visitor\ModifiableCssVisitor;
+
+/**
+ * A modifiable version of {@see CssNode}.
+ *
+ * Almost all CSS nodes are the modifiable classes under the covers. However,
+ * modification should only be done within the evaluation step, so the
+ * unmodifiable types are used elsewhere to enforce that constraint.
+ *
+ * @internal
+ */
+abstract class ModifiableCssNode implements CssNode
+{
+    /**
+     * @var ModifiableCssParentNode|null
+     */
+    private $parent;
+
+    /**
+     * The index of `$this` in parent's children.
+     *
+     * This makes {@see remove} more efficient.
+     *
+     * @var int|null
+     */
+    private $indexInParent;
+
+    /**
+     * @var bool
+     */
+    private $groupEnd = false;
+
+    public function getParent(): ?ModifiableCssParentNode
+    {
+        return $this->parent;
+    }
+
+    protected function setParent(ModifiableCssParentNode $parent, int $indexInParent): void
+    {
+        $this->parent = $parent;
+        $this->indexInParent = $indexInParent;
+    }
+
+    public function isGroupEnd(): bool
+    {
+        return $this->groupEnd;
+    }
+
+    public function setGroupEnd(bool $groupEnd): void
+    {
+        $this->groupEnd = $groupEnd;
+    }
+
+    /**
+     * Whether this node has a visible sibling after it.
+     */
+    public function hasFollowingSibling(): bool
+    {
+        $parent = $this->parent;
+
+        if ($parent === null) {
+            return false;
+        }
+
+        assert($this->indexInParent !== null);
+        $siblings = $parent->getChildren();
+
+        for ($i = $this->indexInParent + 1; $i < \count($siblings); $i++) {
+            $sibling = $siblings[$i];
+
+            if (!$this->isInvisible($sibling)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns whether $node is invisible for the purposes of
+     * {@see hasFollowingSibling}.
+     *
+     * This can return a false negative for a comment node in compressed mode,
+     * since the AST doesn't know the output style, but that's an extremely
+     * narrow edge case so we don't worry about it.
+     */
+    private function isInvisible(CssNode $node): bool
+    {
+        if ($node instanceof CssParentNode) {
+            // An unknown at-rule is never invisible. Because we don't know the
+            // semantics of unknown rules, we can't guarantee that (for example)
+            // `@foo {}` isn't meaningful.
+            if ($node instanceof CssAtRule) {
+                return false;
+            }
+
+            if ($node instanceof CssStyleRule && $node->getSelector()->getValue()->isInvisible()) {
+                return true;
+            }
+
+            foreach ($node->getChildren() as $child) {
+                if (!$this->isInvisible($child)) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Calls the appropriate visit method on $visitor.
+     *
+     * @template T
+     *
+     * @param ModifiableCssVisitor<T> $visitor
+     *
+     * @return T
+     */
+    abstract public function accept($visitor);
+
+    /**
+     * Removes $this from {@see parent}'s child list.
+     *
+     * @throws \LogicException if {@see parent} is `null`.
+     */
+    public function remove(): void
+    {
+        $parent = $this->parent;
+
+        if ($parent === null) {
+            throw new \LogicException("Can't remove a node without a parent.");
+        }
+
+        assert($this->indexInParent !== null);
+
+        $parent->removeChildAt($this->indexInParent);
+        $children = $parent->getChildren();
+
+        for ($i = $this->indexInParent; $i < \count($children); $i++) {
+            $child = $children[$i];
+            assert($child->indexInParent !== null);
+            $child->indexInParent = $child->indexInParent - 1;
+        }
+        $this->parent = null;
+        $this->indexInParent = null;
+    }
+}

--- a/src/Ast/Css/ModifiableCssParentNode.php
+++ b/src/Ast/Css/ModifiableCssParentNode.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Css;
+
+/**
+ * A modifiable version of {@see CssParentNode} for use in the evaluation step.
+ *
+ * @internal
+ */
+abstract class ModifiableCssParentNode extends ModifiableCssNode implements CssParentNode
+{
+    /**
+     * @var list<ModifiableCssNode>
+     */
+    private $children;
+
+    /**
+     * @param list<ModifiableCssNode> $children
+     */
+    public function __construct(array $children = [])
+    {
+        $this->children = $children;
+    }
+
+    /**
+     * @return list<ModifiableCssNode>
+     */
+    public function getChildren(): array
+    {
+        return $this->children;
+    }
+
+    public function isChildless(): bool
+    {
+        return false;
+    }
+
+    /**
+     * Returns a copy of $this with an empty {@see children} list.
+     *
+     * This is *not* a deep copy. If other parts of this node are modifiable,
+     * they are shared between the new and old nodes.
+     */
+    abstract public function copyWithoutChildren(): ModifiableCssParentNode;
+
+    public function addChild(ModifiableCssNode $child): void
+    {
+        $child->setParent($this, \count($this->children));
+        $this->children[] = $child;
+    }
+
+    /**
+     * @internal
+     */
+    public function removeChildAt(int $index): void
+    {
+        array_splice($this->children, $index, 1);
+    }
+}

--- a/src/Ast/Css/ModifiableCssStyleRule.php
+++ b/src/Ast/Css/ModifiableCssStyleRule.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Css;
+
+use ScssPhp\ScssPhp\Ast\Selector\SelectorList;
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+
+/**
+ * A modifiable version of {@see CssStyleRule} for use in the evaluation step.
+ *
+ * @internal
+ */
+final class ModifiableCssStyleRule extends ModifiableCssParentNode implements CssStyleRule
+{
+    /**
+     * @var ModifiableCssValue<SelectorList>
+     * @readonly
+     */
+    private $selector;
+
+    /**
+     * @var SelectorList
+     * @readonly
+     */
+    private $originalSelector;
+
+    /**
+     * @var FileSpan
+     * @readonly
+     */
+    private $span;
+
+    /**
+     * @param ModifiableCssValue<SelectorList> $selector
+     * @param FileSpan                         $span
+     * @param SelectorList|null                $originalSelector
+     */
+    public function __construct(ModifiableCssValue $selector, FileSpan $span, ?SelectorList $originalSelector = null)
+    {
+        parent::__construct();
+        $this->selector = $selector;
+        $this->originalSelector = $originalSelector ?? $selector->getValue();
+        $this->span = $span;
+    }
+
+    /**
+     * @phpstan-return ModifiableCssValue<SelectorList>
+     */
+    public function getSelector(): CssValue
+    {
+        return $this->selector;
+    }
+
+    public function getOriginalSelector(): SelectorList
+    {
+        return $this->originalSelector;
+    }
+
+    public function getSpan(): FileSpan
+    {
+        return $this->span;
+    }
+
+    public function accept($visitor)
+    {
+        return $visitor->visitCssStyleRule($this);
+    }
+
+    /**
+     * @phpstan-return ModifiableCssStyleRule
+     */
+    public function copyWithoutChildren(): ModifiableCssParentNode
+    {
+        return new ModifiableCssStyleRule($this->selector, $this->span, $this->originalSelector);
+    }
+}

--- a/src/Ast/Css/ModifiableCssStylesheet.php
+++ b/src/Ast/Css/ModifiableCssStylesheet.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Css;
+
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+
+class ModifiableCssStylesheet extends ModifiableCssParentNode implements CssStylesheet
+{
+    /**
+     * @var FileSpan
+     * @readonly
+     */
+    private $span;
+
+    /**
+     * @param FileSpan $span
+     */
+    public function __construct(FileSpan $span)
+    {
+        parent::__construct();
+        $this->span = $span;
+    }
+
+    public function getSpan(): FileSpan
+    {
+        return $this->span;
+    }
+
+    public function accept($visitor)
+    {
+        return $visitor->visitCssStylesheet($this);
+    }
+
+    /**
+     * @phpstan-return ModifiableCssStylesheet
+     */
+    public function copyWithoutChildren(): ModifiableCssParentNode
+    {
+        return new ModifiableCssStylesheet($this->span);
+    }
+}

--- a/src/Ast/Css/ModifiableCssSupportsRule.php
+++ b/src/Ast/Css/ModifiableCssSupportsRule.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Css;
+
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+
+/**
+ * A modifiable version of {@see CssSupportsRule} for use in the evaluation step.
+ *
+ * @internal
+ */
+final class ModifiableCssSupportsRule extends ModifiableCssParentNode implements CssSupportsRule
+{
+    /**
+     * @var CssValue<string>
+     * @readonly
+     */
+    private $condition;
+
+    /**
+     * @var FileSpan
+     * @readonly
+     */
+    private $span;
+
+    /**
+     * @param CssValue<string> $condition
+     * @param FileSpan         $span
+     */
+    public function __construct(CssValue $condition, FileSpan $span)
+    {
+        parent::__construct();
+        $this->condition = $condition;
+        $this->span = $span;
+    }
+
+    public function getCondition(): CssValue
+    {
+        return $this->condition;
+    }
+
+    public function getSpan(): FileSpan
+    {
+        return $this->span;
+    }
+
+    public function accept($visitor)
+    {
+        return $visitor->visitCssSupportsRule($this);
+    }
+
+    /**
+     * @phpstan-return ModifiableCssSupportsRule
+     */
+    public function copyWithoutChildren(): ModifiableCssParentNode
+    {
+        return new ModifiableCssSupportsRule($this->condition, $this->span);
+    }
+}

--- a/src/Ast/Css/ModifiableCssValue.php
+++ b/src/Ast/Css/ModifiableCssValue.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Css;
+
+/**
+ * A modifiable version of {@see CssValue} for use in the evaluation step.
+ *
+ * @template T
+ * @template-extends CssValue<T>
+ *
+ * @internal
+ */
+class ModifiableCssValue extends CssValue
+{
+    /**
+     * @param T $value
+     */
+    public function setValue($value): void
+    {
+        $this->value = $value;
+    }
+}

--- a/src/Exception/SassRuntimeException.php
+++ b/src/Exception/SassRuntimeException.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Exception;
+
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+
+/**
+ * @internal
+ */
+final class SassRuntimeException extends \Exception implements SassException
+{
+    /**
+     * @var string
+     * @readonly
+     */
+    private $originalMessage;
+
+    /**
+     * @var FileSpan
+     * @readonly
+     */
+    private $span;
+
+    public function __construct(string $message, FileSpan $span, \Throwable $previous = null)
+    {
+        $this->originalMessage = $message;
+        $this->span = $span;
+
+        parent::__construct($span->message($message), 0, $previous);
+    }
+
+    /**
+     * Gets the original message without the location info in it.
+     */
+    public function getOriginalMessage(): string
+    {
+        return $this->originalMessage;
+    }
+
+    public function getSpan(): FileSpan
+    {
+        return $this->span;
+    }
+}

--- a/src/Parser/LineScanner.php
+++ b/src/Parser/LineScanner.php
@@ -1,0 +1,163 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Parser;
+
+/**
+ * A subclass of {@see StringScanner} that tracks line and column information.
+ *
+ * @internal
+ */
+final class LineScanner extends StringScanner
+{
+    /**
+     * @var int
+     */
+    private $line = 0;
+
+    /**
+     * @var int
+     */
+    private $column = 0;
+
+    /**
+     * Whether the current position is between a CR character and an LF
+     * character.
+     */
+    private function betweenCRLF(): bool
+    {
+        return $this->peekChar(-1) === "\r" && $this->peekChar() === "\n";
+    }
+
+    public function setPosition(int $position): void
+    {
+        $newPosition = $position;
+        $oldPosition = $this->getPosition();
+        parent::setPosition($position);
+
+        if ($newPosition > $oldPosition) {
+            $newlines = $this->newlinesIn($this->substring($oldPosition, $newPosition));
+            $this->line += \count($newlines);
+
+            if ($newlines === []) {
+                $this->column += $newPosition - $oldPosition;
+            } else {
+                $last = $newlines[\count($newlines) - 1];
+                $end = $last[1] + \strlen($last[0]);
+
+                $this->column = $newPosition - $end;
+            }
+        } else {
+            $newlines = $this->newlinesIn($this->substring($newPosition, $oldPosition));
+
+            if ($this->betweenCRLF()) {
+                array_pop($newlines);
+            }
+            $this->line -= \count($newlines);
+
+            if ($newlines === []) {
+                $this->column -= $oldPosition - $newPosition;
+            } else {
+                // TODO check that
+                $this->column = $newPosition - strrpos($this->getString(), "\n", $newPosition) - 1;
+            }
+        }
+    }
+
+    /**
+     * @phpstan-impure
+     */
+    public function scanChar(string $char): bool
+    {
+        if (!parent::scanChar($char)) {
+            return false;
+        }
+
+        $this->adjustLineAndColumn($char);
+        return true;
+    }
+
+    /**
+     * @phpstan-impure
+     */
+    public function readChar(): string
+    {
+        $character = parent::readChar();
+        $this->adjustLineAndColumn($character);
+
+        return $character;
+    }
+
+    /**
+     * @phpstan-impure
+     */
+    public function readUtf8Char(): string
+    {
+        $character = parent::readUtf8Char();
+        $this->adjustLineAndColumn($character);
+
+        return $character;
+    }
+
+    /**
+     * Adjusts {@see line} and {@see column} after having consumed $character.
+     */
+    private function adjustLineAndColumn(string $character): void
+    {
+        if ($character === "\n" || ($character === "\r" && $this->peekChar() !== "\n")) {
+            $this->line += 1;
+            $this->column = 0;
+        } else {
+            $this->column += \strlen($character);
+        }
+    }
+
+    /**
+     * @phpstan-impure
+     */
+    public function scan(string $string): bool
+    {
+        if (!parent::scan($string)) {
+            return false;
+        }
+
+        $newlines = $this->newlinesIn($string);
+        $this->line += \count($newlines);
+
+        if ($newlines === []) {
+            $this->column += \strlen($string);
+        } else {
+            $last = $newlines[\count($newlines) - 1];
+            $end = $last[1] + \strlen($last[0]);
+
+            $this->column = \strlen($string) - $end;
+        }
+
+        return true;
+    }
+
+    /**
+     * @phpstan-return list<array{string, int}>
+     */
+    private function newlinesIn(string $text): array
+    {
+        preg_match_all('/\r\n?|\n/', $text, $matches, PREG_OFFSET_CAPTURE);
+
+        $newlines = $matches[0];
+
+        if ($this->betweenCRLF()) {
+            array_pop($newlines);
+        }
+
+        return $newlines;
+    }
+}

--- a/src/Parser/StringScanner.php
+++ b/src/Parser/StringScanner.php
@@ -34,7 +34,7 @@ use ScssPhp\ScssPhp\SourceSpan\SourceFile;
  *
  * @internal
  */
-final class StringScanner
+class StringScanner
 {
     /**
      * @var string

--- a/src/Serializer/SerializeResult.php
+++ b/src/Serializer/SerializeResult.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Serializer;
+
+final class SerializeResult
+{
+    /**
+     * @var string
+     * @readonly
+     */
+    private $css;
+
+    public function __construct(string $css)
+    {
+        $this->css = $css;
+    }
+
+    public function getCss(): string
+    {
+        return $this->css;
+    }
+}

--- a/src/Serializer/Serializer.php
+++ b/src/Serializer/Serializer.php
@@ -12,8 +12,11 @@
 
 namespace ScssPhp\ScssPhp\Serializer;
 
+use ScssPhp\ScssPhp\Ast\Css\CssNode;
 use ScssPhp\ScssPhp\Ast\Selector\Selector;
 use ScssPhp\ScssPhp\Exception\SassScriptException;
+use ScssPhp\ScssPhp\OutputStyle;
+use ScssPhp\ScssPhp\Util;
 use ScssPhp\ScssPhp\Value\Value;
 
 /**
@@ -21,6 +24,30 @@ use ScssPhp\ScssPhp\Value\Value;
  */
 final class Serializer
 {
+    /**
+     * @phpstan-param OutputStyle::* $style
+     */
+    public static function serialize(CssNode $node, bool $inspect = false, string $style = OutputStyle::EXPANDED, bool $sourceMap = false, bool $charset = true): SerializeResult
+    {
+        $visitor = new SerializeVisitor($inspect, true, $style);
+        $node->accept($visitor);
+        $css = (string) $visitor->getBuffer();
+
+        $prefix = '';
+
+        if ($charset && strlen($css) !== Util::mbStrlen($css)) {
+            if ($style === OutputStyle::COMPRESSED) {
+                $prefix = "\u{FEFF}";
+            } else {
+                $prefix = '@charset "UTF-8";' . "\n";
+            }
+        }
+
+        // TODO build the source map
+
+        return new SerializeResult($prefix . $css);
+    }
+
     /**
      * Converts $value to a CSS string.
      *

--- a/src/Util/StringUtil.php
+++ b/src/Util/StringUtil.php
@@ -36,6 +36,45 @@ final class StringUtil
         return '' === $needle || ('' !== $haystack && 0 === substr_compare($haystack, $needle, -\strlen($needle)));
     }
 
+    public static function trimAsciiRight(string $string, bool $excludeEscape = false): string
+    {
+        if (!$excludeEscape) {
+            return rtrim($string, ' ');
+        }
+
+        $end = self::lastNonWhitespace($string, $excludeEscape);
+
+        if ($end === null) {
+            return '';
+        }
+
+        return substr($string, 0, $end + 1);
+    }
+
+    /**
+     * Returns the index of the last character in $string that's not ASCII
+     * whitespace, or `null` if $string is entirely spaces.
+     *
+     * If $excludeEscape is `true`, this doesn't move past whitespace that's
+     * included in a CSS escape.
+     */
+    private static function lastNonWhitespace(string $string, bool $excludeEscape = false): ?int
+    {
+        for ($i = \strlen($string) - 1; $i >= 0; $i--) {
+            $char = $string[$i];
+
+            if (!Character::isWhitespace($char)) {
+                if ($excludeEscape && $i !== 0 && $i !== \strlen($string) && $char === '\\') {
+                    return $i + 1;
+                }
+
+                return $i;
+            }
+        }
+
+        return null;
+    }
+
     /**
      * Returns whether $string1 and $string2 are equal, ignoring ASCII case.
      *

--- a/src/Visitor/CssVisitor.php
+++ b/src/Visitor/CssVisitor.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Visitor;
+
+use ScssPhp\ScssPhp\Ast\Css\CssAtRule;
+use ScssPhp\ScssPhp\Ast\Css\CssComment;
+use ScssPhp\ScssPhp\Ast\Css\CssDeclaration;
+use ScssPhp\ScssPhp\Ast\Css\CssImport;
+use ScssPhp\ScssPhp\Ast\Css\CssKeyframeBlock;
+use ScssPhp\ScssPhp\Ast\Css\CssMediaRule;
+use ScssPhp\ScssPhp\Ast\Css\CssStyleRule;
+use ScssPhp\ScssPhp\Ast\Css\CssStylesheet;
+use ScssPhp\ScssPhp\Ast\Css\CssSupportsRule;
+
+/**
+ * An interface for visitors that traverse CSS statements.
+ *
+ * @internal
+ *
+ * @template T
+ * @template-extends ModifiableCssVisitor<T>
+ */
+interface CssVisitor extends ModifiableCssVisitor
+{
+    /**
+     * @param CssAtRule $node
+     *
+     * @return T
+     */
+    public function visitCssAtRule($node);
+
+    /**
+     * @param CssComment $node
+     *
+     * @return T
+     */
+    public function visitCssComment($node);
+
+    /**
+     * @param CssDeclaration $node
+     *
+     * @return T
+     */
+    public function visitCssDeclaration($node);
+
+    /**
+     * @param CssImport $node
+     *
+     * @return T
+     */
+    public function visitCssImport($node);
+
+    /**
+     * @param CssKeyframeBlock $node
+     *
+     * @return T
+     */
+    public function visitCssKeyframeBlock($node);
+
+    /**
+     * @param CssMediaRule $node
+     *
+     * @return T
+     */
+    public function visitCssMediaRule($node);
+
+    /**
+     * @param CssStyleRule $node
+     *
+     * @return T
+     */
+    public function visitCssStyleRule($node);
+
+    /**
+     * @param CssStylesheet $node
+     *
+     * @return T
+     */
+    public function visitCssStylesheet($node);
+
+    /**
+     * @param CssSupportsRule $node
+     *
+     * @return T
+     */
+    public function visitCssSupportsRule($node);
+
+}

--- a/src/Visitor/ModifiableCssVisitor.php
+++ b/src/Visitor/ModifiableCssVisitor.php
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Visitor;
+
+use ScssPhp\ScssPhp\Ast\Css\ModifiableCssAtRule;
+use ScssPhp\ScssPhp\Ast\Css\ModifiableCssComment;
+use ScssPhp\ScssPhp\Ast\Css\ModifiableCssDeclaration;
+use ScssPhp\ScssPhp\Ast\Css\ModifiableCssImport;
+use ScssPhp\ScssPhp\Ast\Css\ModifiableCssKeyframeBlock;
+use ScssPhp\ScssPhp\Ast\Css\ModifiableCssMediaRule;
+use ScssPhp\ScssPhp\Ast\Css\ModifiableCssStyleRule;
+use ScssPhp\ScssPhp\Ast\Css\ModifiableCssStylesheet;
+use ScssPhp\ScssPhp\Ast\Css\ModifiableCssSupportsRule;
+
+/**
+ * An interface for visitors that traverse CSS statements.
+ *
+ * @internal
+ *
+ * @template T
+ */
+interface ModifiableCssVisitor
+{
+    /**
+     * @param ModifiableCssAtRule $node
+     *
+     * @return T
+     */
+    public function visitCssAtRule($node);
+
+    /**
+     * @param ModifiableCssComment $node
+     *
+     * @return T
+     */
+    public function visitCssComment($node);
+
+    /**
+     * @param ModifiableCssDeclaration $node
+     *
+     * @return T
+     */
+    public function visitCssDeclaration($node);
+
+    /**
+     * @param ModifiableCssImport $node
+     *
+     * @return T
+     */
+    public function visitCssImport($node);
+
+    /**
+     * @param ModifiableCssKeyframeBlock $node
+     *
+     * @return T
+     */
+    public function visitCssKeyframeBlock($node);
+
+    /**
+     * @param ModifiableCssMediaRule $node
+     *
+     * @return T
+     */
+    public function visitCssMediaRule($node);
+
+    /**
+     * @param ModifiableCssStyleRule $node
+     *
+     * @return T
+     */
+    public function visitCssStyleRule($node);
+
+    /**
+     * @param ModifiableCssStylesheet $node
+     *
+     * @return T
+     */
+    public function visitCssStylesheet($node);
+
+    /**
+     * @param ModifiableCssSupportsRule $node
+     *
+     * @return T
+     */
+    public function visitCssSupportsRule($node);
+}


### PR DESCRIPTION
This implements the CSS AST ported from dart-sass as well as the associated serialization (without sourcemap support for now, but changes will be small to add it)