### PR TITLE
Fix php8.1 strpos deprecated message for pure css imports

### DIFF
--- a/src/SourceMap/SourceMapGenerator.php
+++ b/src/SourceMap/SourceMapGenerator.php
@@ -312,7 +312,7 @@ final class SourceMapGenerator
         }
 
         // Remove extra leading path separators.
-        if (strpos($filename, '\\') === 0 || strpos($filename, '/') === 0) {
+        if ($filename && (strpos($filename, '\\') === 0 || strpos($filename, '/') === 0)) {
             $filename = substr($filename, 1);
         }
 


### PR DESCRIPTION
In case you import a css file `$filename` is null. That causes the following warning:

```
Deprecated: strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in /var/www/html/vendor/scssphp/scssphp/src/SourceMap/SourceMapGenerator.php on line 355
```

By adding a check if `$filename` is set (and not null), the provided null-value to strpos is avoided.