### PR TITLE
Mark the bamarni/composer-bin-plugin plugin as allowed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -103,6 +103,9 @@
     ],
     "bin": ["bin/pscss"],
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "bamarni/composer-bin-plugin": true
+        }
     }
 }


### PR DESCRIPTION
Our setup relies on this plugin intentionally, so we should mark it as allowed when using composer 2.2+.