### PR TITLE
Fix the exclusion list builder to account for Error that can happen

### DIFF
--- a/tests/SassSpecTest.php
+++ b/tests/SassSpecTest.php
@@ -312,6 +312,11 @@ class SassSpecTest extends TestCase
                     fclose($fp_err_stream);
                     $this->assertNull(null);
                     return;
+                } catch (\Throwable $e) {
+                    $this->appendToExclusionList($name);
+                    fclose($fp_err_stream);
+                    $this->assertNull(null);
+                    return;
                     //throwException($e);
                 }
             } else {
@@ -377,6 +382,8 @@ class SassSpecTest extends TestCase
                     // TODO assert the error message ?
                     // Keep the test
                 } catch (\Exception $e) {
+                    $this->appendToExclusionList($name);
+                } catch (\Throwable $e) {
                     $this->appendToExclusionList($name);
                 }
                 $this->assertNull(null);


### PR DESCRIPTION
With PHP 8 turning many warnings into Error, some specs that were previously excluded were breaking the script when rebuilding on PHP 8 rather than PHP 7