### PR TITLE
Fix the generation of sourcemaps without input path

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -2778,7 +2778,7 @@ class Compiler
         // insert the directive as a comment
         $child = $this->makeOutputBlock(Type::T_COMMENT);
         $child->lines[]      = $line;
-        $child->sourceName   = $this->sourceNames[$this->sourceIndex];
+        $child->sourceName   = $this->sourceNames[$this->sourceIndex] ?: '(stdin)';
         $child->sourceLine   = $this->sourceLine;
         $child->sourceColumn = $this->sourceColumn;
 

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -358,6 +358,31 @@ class ApiTest extends TestCase
         );
     }
 
+    public function testSourceMapWithoutSourcePath()
+    {
+        $source = <<<'SCSS'
+@import "test.css";
+
+body {
+  background-color: orange;
+
+  h1 {
+    border: 2rem dashed black;
+  }
+}
+
+SCSS;
+
+        $compiler = new Compiler();
+        $compiler->setSourceMap(Compiler::SOURCE_MAP_FILE);
+        $compiler->setSourceMapOptions(['sourceMapURL' => 'test.css.map']);
+
+        $result = $compiler->compileString($source);
+
+        $this->assertStringEndsWith('/*# sourceMappingURL=test.css.map */', $result->getCss());
+        $this->assertNotEmpty($result->getSourceMap());
+    }
+
     public function testGetStringText()
     {
         $compiler = new Compiler();


### PR DESCRIPTION
Replaces #517 