### PR TITLE
Add a `frameworks` group on the framework tests

### DIFF
--- a/tests/FrameworkTest.php
+++ b/tests/FrameworkTest.php
@@ -16,6 +16,9 @@ use PHPUnit\Framework\TestCase;
 use ScssPhp\ScssPhp\Compiler;
 use ScssPhp\ScssPhp\Logger\QuietLogger;
 
+/**
+ * @group frameworks
+ */
 class FrameworkTest extends TestCase
 {
     public function testBootstrap()


### PR DESCRIPTION
This allows excluding them easily when running tests. There are several reasons that might justify that:

- they are slow (at least the Foundation one)
- when collecting code coverage, they generate so much data that it uses too much memory and makes the process being killed

This backports #492 to the 1.x branch.