### PR TITLE
Add explicit return type to avoid Symfony debug warning

### DIFF
--- a/src/Node/Number.php
+++ b/src/Node/Number.php
@@ -147,7 +147,7 @@ class Number extends Node implements \ArrayAccess
     }
 
     /**
-     * {@inheritdoc}
+     * @return bool
      */
     #[\ReturnTypeWillChange]
     public function offsetExists($offset)
@@ -173,7 +173,7 @@ class Number extends Node implements \ArrayAccess
     }
 
     /**
-     * {@inheritdoc}
+     * @return mixed
      */
     #[\ReturnTypeWillChange]
     public function offsetGet($offset)
@@ -209,7 +209,7 @@ class Number extends Node implements \ArrayAccess
     }
 
     /**
-     * {@inheritdoc}
+     * @return void
      */
     #[\ReturnTypeWillChange]
     public function offsetUnset($offset)

--- a/src/Node/Number.php
+++ b/src/Node/Number.php
@@ -200,7 +200,7 @@ class Number extends Node implements \ArrayAccess
     }
 
     /**
-     * {@inheritdoc}
+     * @return void
      */
     #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)


### PR DESCRIPTION
07:40:37 INFO      [php] User Deprecated: Method "ArrayAccess::offsetSet()" might add "void" as a native return type declaration in the future. Do the same in implementation "ScssPhp\ScssPhp\Node\Number" now to avoid errors or add an explicit @return annotation to suppress this message.
