### PR TITLE
Use double quotes to render strings by default

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -4520,8 +4520,7 @@ EOL;
                     // force double quote as string quote for the output in certain cases
                     if (
                         $value[1] === "'" &&
-                        (strpos($content, '"') === false or strpos($content, "'") !== false) &&
-                        strpbrk($content, '{}\\\'') !== false
+                        (strpos($content, '"') === false or strpos($content, "'") !== false)
                     ) {
                         $value[1] = '"';
                     } elseif (

--- a/tests/outputs/builtins.css
+++ b/tests/outputs/builtins.css
@@ -57,7 +57,7 @@
   color: 6;
   color: tri;
   color: trin;
-  color: 'string';
+  color: "string";
   color: STRING;
   color: string;
   color: string;

--- a/tests/outputs/comments.css
+++ b/tests/outputs/comments.css
@@ -9,11 +9,11 @@ Here is a block comment
 div {
   border: 1px solid red;
   /* another property */
-  color: url('http://mage-page.com');
+  color: url("http://mage-page.com");
   string: "hello /* this is not a comment */";
   world: "// neither is this";
-  string: 'hello /* this is not a comment */';
-  world: '// neither is this';
+  string: "hello /* this is not a comment */";
+  world: "// neither is this";
   what-ever: 100px;
   background: url();
 }

--- a/tests/outputs/directives.css
+++ b/tests/outputs/directives.css
@@ -31,7 +31,7 @@ div {
   color: red;
   height: 20px;
 }
-@keyframes 'bounce' {
+@keyframes "bounce" {
   from {
     top: 100px;
     animation-timing-function: ease-out;
@@ -64,11 +64,11 @@ div {
   }
 }
 div {
-  animation-name: 'diagonal-slide';
+  animation-name: "diagonal-slide";
   animation-duration: 5s;
   animation-iteration-count: 10;
 }
-@keyframes 'diagonal-slide' {
+@keyframes "diagonal-slide" {
   from {
     left: 0;
     top: 0;

--- a/tests/outputs/extends.css
+++ b/tests/outputs/extends.css
@@ -98,7 +98,7 @@ wassup {
   display: block;
   width: 255px;
   height: 42px;
-  background: transparent url('images/login-btns.png') no-repeat;
+  background: transparent url("images/login-btns.png") no-repeat;
   background-position: 0 0;
 }
 #content .social-login .facebook:hover, #content .social-login .twitter:hover {

--- a/tests/outputs/functions.css
+++ b/tests/outputs/functions.css
@@ -28,18 +28,18 @@ p {
   color: arglist;
 }
 .test {
-  display: 'global';
-  display: 'test-mixin';
-  display: 'test-mixin';
-  display: 'global';
+  display: "global";
+  display: "test-mixin";
+  display: "test-mixin";
+  display: "global";
 }
 .test-inspect {
   n: null;
   b1: true;
   b2: false;
   n1: 0;
-  s1: '';
-  s2: 'hello';
+  s1: "";
+  s2: "hello";
   l1: 1 2;
   l2: 3 4;
   l3: 5, 6;

--- a/tests/outputs/import.css
+++ b/tests/outputs/import.css
@@ -30,10 +30,10 @@ body {
   background: gray;
 }
 a:before {
-  content: '';
+  content: "";
 }
 div::before {
-  content: ':)';
+  content: ":)";
 }
 @keyframes spin {
   0% {

--- a/tests/outputs/map.css
+++ b/tests/outputs/map.css
@@ -3,7 +3,7 @@ div {
   color: red;
   foo: black, red, #00FF00;
   bar: color, length;
-  baz: (color: white, color2: red, 'color3': #00FF00, length: 40em);
+  baz: (color: white, color2: red, "color3": #00FF00, length: 40em);
   foo: (length: 40em);
   bar: true;
 }

--- a/tests/outputs/scss_css.css
+++ b/tests/outputs/scss_css.css
@@ -4,9 +4,9 @@
 @foo;
 
 @import "foo.css";
-@import 'foo.css';
+@import "foo.css";
 @import url("foo.css");
-@import url('foo.css');
+@import url("foo.css");
 @import url(foo.css);
 @import "foo.css" screen;
 @import "foo.css" screen, print;

--- a/tests/outputs/selector_functions.css
+++ b/tests/outputs/selector_functions.css
@@ -49,16 +49,16 @@
   /* true*/
 }
 a.disabled {
-  content: 'a.disabled';
+  content: "a.disabled";
 }
 .accordion__copy {
-  content: '.accordion__copy';
+  content: ".accordion__copy";
 }
 .accordion__copy, .accordion__image {
-  content: '.accordion__copy, .accordion__image';
+  content: ".accordion__copy, .accordion__image";
 }
 .accordion__copy, .slider__copy, .accordion__image, .slider__image {
-  content: '.accordion__copy, .slider__copy, .accordion__image, .slider__image';
+  content: ".accordion__copy, .slider__copy, .accordion__image, .slider__image";
 }
 a.disabled, .disabled.link {
   content: "a.disabled, .link.disabled";

--- a/tests/outputs/selectors.css
+++ b/tests/outputs/selectors.css
@@ -377,7 +377,7 @@ ul ul, ol ul, ul ol, ol ol {
 }
 .❮ {
   display: inline;
-  content: '↦';
+  content: "↦";
 }
 ul li a .tocnumber {
   min-width: 100%;


### PR DESCRIPTION
This matches the behavior of dart-sass and libsass.

With this change, `DISALLOW_QUOTE_DIFFERENCE=1 phpunit tests/SassSpecTest.php` reports only 3 failures. 2 of them are related to single quotes in CSS imports and the third one to single quotes in an unknown directive. Those are cases where official Sass implementation are not parsing the CSS strings as Sass strings (and so does not manage quotes that are rendered), while we do. This is not an issue, as it is still equivalent CSS.