### PR TITLE
Split invalid SCSS inputs into their own input tests

### DIFF
--- a/tests/inputs/color_operators.scss
+++ b/tests/inputs/color_operators.scss
@@ -1,0 +1,13 @@
+#colors {
+    color: red + rgb(1,2,3);
+    color: red - rgb(1,2,3);
+    color: rgba(1,2,3, 0.5) * rgba(3,4,5, 0.5);
+    color: rgba(10,15,20, 0.5) / rgba(2,2,2, 0.5);
+
+    color: rgba(1,2,3, 0.5) * 2;
+    color: rgba(1,2,3, 0.5) / 2;
+    color: rgba(1,2,3, 0.5) + 2;
+    color: rgba(1,2,3, 0.5) - 2;
+
+    color: blue + 34;
+}

--- a/tests/inputs/comment_incomplete_interpolation.scss
+++ b/tests/inputs/comment_incomplete_interpolation.scss
@@ -1,0 +1,18 @@
+$color:red;
+$radius:2px;
+
+/* This is a comment with vars references:
+color:#{$color}
+and a fake #{ doing nothing
+radius:#{$radius}
+   and also a #{$fake} interpolation that should not throw an error
+ */
+
+.class {
+  /* This is a comment with vars references not on root level
+  color:#{$color}
+  and a fake #{ doing nothing
+  radius:#{$radius}
+     and also a #{$fake} interpolation that should not throw an error
+  */
+}

--- a/tests/inputs/comments.scss
+++ b/tests/inputs/comments.scss
@@ -50,9 +50,7 @@ $radius:2px;
 
 /* This is a comment with vars references:
 color:#{$color}
-and a fake #{ doing nothing
 radius:#{$radius}
-   and also a #{$fake} interpolation that should not throw an error
  */
 
 // end
@@ -70,8 +68,6 @@ radius:#{$radius}
 .class {
   /* This is a comment with vars references not on root level
   color:#{$color}
-  and a fake #{ doing nothing
   radius:#{$radius}
-     and also a #{$fake} interpolation that should not throw an error
   */
 }

--- a/tests/inputs/operators.scss
+++ b/tests/inputs/operators.scss
@@ -35,18 +35,6 @@ div {
 }
 
 #colors {
-    color: red + rgb(1,2,3);
-    color: red - rgb(1,2,3);
-    color: rgba(1,2,3, 0.5) * rgba(3,4,5, 0.5);
-    color: rgba(10,15,20, 0.5) / rgba(2,2,2, 0.5);
-
-    color: rgba(1,2,3, 0.5) * 2;
-    color: rgba(1,2,3, 0.5) / 2;
-    color: rgba(1,2,3, 0.5) + 2;
-    color: rgba(1,2,3, 0.5) - 2;
-
-    color: blue + 34;
-
     color: #fff == 255;
     color: #fff != 255;
     color: 255 == #fff;

--- a/tests/outputs/color_operators.css
+++ b/tests/outputs/color_operators.css
@@ -1,0 +1,11 @@
+#colors {
+  color: #ff0203;
+  color: #fe0000;
+  color: rgba(3, 8, 15, 0.5);
+  color: rgba(5, 7, 10, 0.5);
+  color: rgba(2, 4, 6, 0.5);
+  color: rgba(0, 1, 1, 0.5);
+  color: rgba(3, 4, 5, 0.5);
+  color: rgba(0, 0, 1, 0.5);
+  color: #22f;
+}

--- a/tests/outputs/comment_incomplete_interpolation.css
+++ b/tests/outputs/comment_incomplete_interpolation.css
@@ -1,0 +1,14 @@
+/* This is a comment with vars references:
+color:red
+and a fake #{ doing nothing
+radius:2px
+   and also a #{$fake} interpolation that should not throw an error
+ */
+.class {
+  /* This is a comment with vars references not on root level
+  color:red
+  and a fake #{ doing nothing
+  radius:2px
+     and also a #{$fake} interpolation that should not throw an error
+  */
+}

--- a/tests/outputs/comments.css
+++ b/tests/outputs/comments.css
@@ -34,9 +34,7 @@ a {
 /* коммент */
 /* This is a comment with vars references:
 color:red
-and a fake #{ doing nothing
 radius:2px
-   and also a #{$fake} interpolation that should not throw an error
  */
 .textimage-background-fullheight .background {
   /* @noflip */
@@ -47,8 +45,6 @@ radius:2px
 .class {
   /* This is a comment with vars references not on root level
   color:red
-  and a fake #{ doing nothing
   radius:2px
-     and also a #{$fake} interpolation that should not throw an error
   */
 }

--- a/tests/outputs/operators.css
+++ b/tests/outputs/operators.css
@@ -26,15 +26,6 @@ div {
   test: 1cm;
 }
 #colors {
-  color: #ff0203;
-  color: #fe0000;
-  color: rgba(3, 8, 15, 0.5);
-  color: rgba(5, 7, 10, 0.5);
-  color: rgba(2, 4, 6, 0.5);
-  color: rgba(0, 1, 1, 0.5);
-  color: rgba(3, 4, 5, 0.5);
-  color: rgba(0, 0, 1, 0.5);
-  color: #22f;
   color: false;
   color: true;
   color: false;


### PR DESCRIPTION
Our input tests are including a few behaviors that are considered errors in dart-sass (color arithmetic and broken interpolation in loud comments). Those behavior are deprecated in scssphp but still supported for BC.
Extracting those into dedicated inputs for the testsuite allows comparing the other parts of those tests to the official implementation.