### PR TITLE
Rework special blocks to use child classes instead of nullable fields

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,16 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Property ScssPhp\\\\ScssPhp\\\\Block\\:\\:\\$args type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Block.php
-
-		-
-			message: "#^Property ScssPhp\\\\ScssPhp\\\\Block\\:\\:\\$child type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Block.php
-
-		-
 			message: "#^Property ScssPhp\\\\ScssPhp\\\\Block\\:\\:\\$children type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Block.php
@@ -21,59 +11,84 @@ parameters:
 			path: src/Block.php
 
 		-
-			message: "#^Property ScssPhp\\\\ScssPhp\\\\Block\\:\\:\\$cond type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Block.php
-
-		-
-			message: "#^Property ScssPhp\\\\ScssPhp\\\\Block\\:\\:\\$end type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Block.php
-
-		-
-			message: "#^Property ScssPhp\\\\ScssPhp\\\\Block\\:\\:\\$list type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Block.php
-
-		-
-			message: "#^Property ScssPhp\\\\ScssPhp\\\\Block\\:\\:\\$name type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Block.php
-
-		-
-			message: "#^Property ScssPhp\\\\ScssPhp\\\\Block\\:\\:\\$prefix type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Block.php
-
-		-
-			message: "#^Property ScssPhp\\\\ScssPhp\\\\Block\\:\\:\\$queryList type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Block.php
-
-		-
-			message: "#^Property ScssPhp\\\\ScssPhp\\\\Block\\:\\:\\$selector type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Block.php
-
-		-
 			message: "#^Property ScssPhp\\\\ScssPhp\\\\Block\\:\\:\\$selectors type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Block.php
 
 		-
-			message: "#^Property ScssPhp\\\\ScssPhp\\\\Block\\:\\:\\$start type has no value type specified in iterable type array\\.$#"
+			message: "#^Property ScssPhp\\\\ScssPhp\\\\Block\\\\AtRootBlock\\:\\:\\$selector type has no value type specified in iterable type array\\.$#"
 			count: 1
-			path: src/Block.php
+			path: src/Block/AtRootBlock.php
 
 		-
-			message: "#^Property ScssPhp\\\\ScssPhp\\\\Block\\:\\:\\$value type has no value type specified in iterable type array\\.$#"
+			message: "#^Property ScssPhp\\\\ScssPhp\\\\Block\\\\AtRootBlock\\:\\:\\$with type has no value type specified in iterable type array\\.$#"
 			count: 1
-			path: src/Block.php
+			path: src/Block/AtRootBlock.php
 
 		-
-			message: "#^Property ScssPhp\\\\ScssPhp\\\\Block\\:\\:\\$with type has no value type specified in iterable type array\\.$#"
+			message: "#^Property ScssPhp\\\\ScssPhp\\\\Block\\\\CallableBlock\\:\\:\\$args type has no value type specified in iterable type array\\.$#"
 			count: 1
-			path: src/Block.php
+			path: src/Block/CallableBlock.php
+
+		-
+			message: "#^Property ScssPhp\\\\ScssPhp\\\\Block\\\\ContentBlock\\:\\:\\$child type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Block/ContentBlock.php
+
+		-
+			message: "#^Property ScssPhp\\\\ScssPhp\\\\Block\\\\DirectiveBlock\\:\\:\\$name type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Block/DirectiveBlock.php
+
+		-
+			message: "#^Property ScssPhp\\\\ScssPhp\\\\Block\\\\DirectiveBlock\\:\\:\\$value type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Block/DirectiveBlock.php
+
+		-
+			message: "#^Property ScssPhp\\\\ScssPhp\\\\Block\\\\EachBlock\\:\\:\\$list type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Block/EachBlock.php
+
+		-
+			message: "#^Property ScssPhp\\\\ScssPhp\\\\Block\\\\ElseifBlock\\:\\:\\$cond type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Block/ElseifBlock.php
+
+		-
+			message: "#^Property ScssPhp\\\\ScssPhp\\\\Block\\\\ForBlock\\:\\:\\$end type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Block/ForBlock.php
+
+		-
+			message: "#^Property ScssPhp\\\\ScssPhp\\\\Block\\\\ForBlock\\:\\:\\$start type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Block/ForBlock.php
+
+		-
+			message: "#^Property ScssPhp\\\\ScssPhp\\\\Block\\\\IfBlock\\:\\:\\$cond type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Block/IfBlock.php
+
+		-
+			message: "#^Property ScssPhp\\\\ScssPhp\\\\Block\\\\MediaBlock\\:\\:\\$queryList type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Block/MediaBlock.php
+
+		-
+			message: "#^Property ScssPhp\\\\ScssPhp\\\\Block\\\\MediaBlock\\:\\:\\$value type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Block/MediaBlock.php
+
+		-
+			message: "#^Property ScssPhp\\\\ScssPhp\\\\Block\\\\NestedPropertyBlock\\:\\:\\$prefix type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Block/NestedPropertyBlock.php
+
+		-
+			message: "#^Property ScssPhp\\\\ScssPhp\\\\Block\\\\WhileBlock\\:\\:\\$cond type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Block/WhileBlock.php
 
 		-
 			message: "#^Method ScssPhp\\\\ScssPhp\\\\Cache\\:\\:cacheName\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
@@ -109,16 +124,6 @@ parameters:
 			message: "#^Result of \\|\\| is always false\\.$#"
 			count: 3
 			path: src/Colors.php
-
-		-
-			message: "#^Access to an undefined property object\\:\\:\\$children\\.$#"
-			count: 2
-			path: src/Compiler.php
-
-		-
-			message: "#^Access to an undefined property object\\:\\:\\$name\\.$#"
-			count: 1
-			path: src/Compiler.php
 
 		-
 			message: "#^Access to an undefined property object\\:\\:\\$sourceColumn\\.$#"
@@ -1507,7 +1512,7 @@ parameters:
 
 		-
 			message: "#^Negated boolean expression is always false\\.$#"
-			count: 2
+			count: 1
 			path: src/Compiler.php
 
 		-
@@ -1532,11 +1537,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$dimension of class ScssPhp\\\\ScssPhp\\\\Node\\\\Number constructor expects float\\|int, float\\|int\\|string given\\.$#"
-			count: 2
-			path: src/Compiler.php
-
-		-
-			message: "#^Parameter \\#1 \\$directiveName of method ScssPhp\\\\ScssPhp\\\\Compiler\\:\\:compileDirectiveName\\(\\) expects array\\|string, array\\|string\\|null given\\.$#"
 			count: 2
 			path: src/Compiler.php
 
@@ -1617,11 +1617,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$string of function substr expects string, string\\|false given\\.$#"
-			count: 1
-			path: src/Compiler.php
-
-		-
-			message: "#^Parameter \\#1 \\$value of method ScssPhp\\\\ScssPhp\\\\Compiler\\:\\:compileValue\\(\\) expects array\\|ScssPhp\\\\ScssPhp\\\\Node\\\\Number, array\\|null given\\.$#"
 			count: 1
 			path: src/Compiler.php
 

--- a/src/Block.php
+++ b/src/Block.php
@@ -12,8 +12,6 @@
 
 namespace ScssPhp\ScssPhp;
 
-use ScssPhp\ScssPhp\Compiler\Environment;
-
 /**
  * Block
  *
@@ -72,106 +70,4 @@ class Block
      * @var Block|null
      */
     public $selfParent;
-
-    /**
-     * @var bool|null
-     */
-    public $hasValue;
-
-    /**
-     * @var string|array|null
-     */
-    public $name;
-
-    /**
-     * @var array|null
-     */
-    public $args;
-
-    /**
-     * @var Environment|null
-     */
-    public $parentEnv;
-
-    /**
-     * @var Environment|null
-     */
-    public $scope;
-
-    /**
-     * @var array|null
-     */
-    public $prefix;
-
-    /**
-     * The selector of an at-root rule
-     *
-     * @var array|null
-     */
-    public $selector;
-
-    /**
-     * @var array|null
-     */
-    public $with;
-
-    /**
-     * @var string|array|null
-     */
-    public $value;
-
-    /**
-     * @var Block[]|null
-     */
-    public $cases;
-
-    /**
-     * @var array|null
-     */
-    public $cond;
-
-    /**
-     * @var bool|null
-     */
-    public $dontAppend;
-
-    /**
-     * @var array|null
-     */
-    public $child;
-
-    /**
-     * @var string[]|null
-     */
-    public $vars;
-
-    /**
-     * @var array|null
-     */
-    public $list;
-
-    /**
-     * @var string|null
-     */
-    public $var;
-
-    /**
-     * @var array|null
-     */
-    public $start;
-
-    /**
-     * @var array|null
-     */
-    public $end;
-
-    /**
-     * @var bool|null
-     */
-    public $until;
-
-    /**
-     * @var array|null
-     */
-    public $queryList;
 }

--- a/src/Block/AtRootBlock.php
+++ b/src/Block/AtRootBlock.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Block;
+
+use ScssPhp\ScssPhp\Block;
+use ScssPhp\ScssPhp\Type;
+
+/**
+ * @internal
+ */
+class AtRootBlock extends Block
+{
+    /**
+     * @var array|null
+     */
+    public $selector;
+
+    /**
+     * @var array|null
+     */
+    public $with;
+
+    public function __construct()
+    {
+        $this->type = Type::T_AT_ROOT;
+    }
+}

--- a/src/Block/CallableBlock.php
+++ b/src/Block/CallableBlock.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Block;
+
+use ScssPhp\ScssPhp\Block;
+use ScssPhp\ScssPhp\Compiler\Environment;
+
+/**
+ * @internal
+ */
+class CallableBlock extends Block
+{
+    /**
+     * @var string
+     */
+    public $name;
+
+    /**
+     * @var array|null
+     */
+    public $args;
+
+    /**
+     * @var Environment|null
+     */
+    public $parentEnv;
+
+    /**
+     * @param string $type
+     */
+    public function __construct($type)
+    {
+        $this->type = $type;
+    }
+}

--- a/src/Block/ContentBlock.php
+++ b/src/Block/ContentBlock.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Block;
+
+use ScssPhp\ScssPhp\Block;
+use ScssPhp\ScssPhp\Compiler\Environment;
+use ScssPhp\ScssPhp\Type;
+
+/**
+ * @internal
+ */
+class ContentBlock extends Block
+{
+    /**
+     * @var array|null
+     */
+    public $child;
+
+    /**
+     * @var Environment|null
+     */
+    public $scope;
+
+    public function __construct()
+    {
+        $this->type = Type::T_INCLUDE;
+    }
+}

--- a/src/Block/DirectiveBlock.php
+++ b/src/Block/DirectiveBlock.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Block;
+
+use ScssPhp\ScssPhp\Block;
+use ScssPhp\ScssPhp\Type;
+
+/**
+ * @internal
+ */
+class DirectiveBlock extends Block
+{
+    /**
+     * @var string|array
+     */
+    public $name;
+
+    /**
+     * @var string|array|null
+     */
+    public $value;
+
+    public function __construct()
+    {
+        $this->type = Type::T_DIRECTIVE;
+    }
+}

--- a/src/Block/EachBlock.php
+++ b/src/Block/EachBlock.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Block;
+
+use ScssPhp\ScssPhp\Block;
+use ScssPhp\ScssPhp\Type;
+
+/**
+ * @internal
+ */
+class EachBlock extends Block
+{
+    /**
+     * @var string[]
+     */
+    public $vars = [];
+
+    /**
+     * @var array
+     */
+    public $list;
+
+    public function __construct()
+    {
+        $this->type = Type::T_EACH;
+    }
+}

--- a/src/Block/ElseBlock.php
+++ b/src/Block/ElseBlock.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Block;
+
+use ScssPhp\ScssPhp\Block;
+use ScssPhp\ScssPhp\Type;
+
+/**
+ * @internal
+ */
+class ElseBlock extends Block
+{
+    public function __construct()
+    {
+        $this->type = Type::T_ELSE;
+    }
+}

--- a/src/Block/ElseifBlock.php
+++ b/src/Block/ElseifBlock.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Block;
+
+use ScssPhp\ScssPhp\Block;
+use ScssPhp\ScssPhp\Type;
+
+/**
+ * @internal
+ */
+class ElseifBlock extends Block
+{
+    /**
+     * @var array
+     */
+    public $cond;
+
+    public function __construct()
+    {
+        $this->type = Type::T_ELSEIF;
+    }
+}

--- a/src/Block/ForBlock.php
+++ b/src/Block/ForBlock.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Block;
+
+use ScssPhp\ScssPhp\Block;
+use ScssPhp\ScssPhp\Type;
+
+/**
+ * @internal
+ */
+class ForBlock extends Block
+{
+    /**
+     * @var string
+     */
+    public $var;
+
+    /**
+     * @var array
+     */
+    public $start;
+
+    /**
+     * @var array
+     */
+    public $end;
+
+    /**
+     * @var bool
+     */
+    public $until;
+
+    public function __construct()
+    {
+        $this->type = Type::T_FOR;
+    }
+}

--- a/src/Block/IfBlock.php
+++ b/src/Block/IfBlock.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Block;
+
+use ScssPhp\ScssPhp\Block;
+use ScssPhp\ScssPhp\Type;
+
+/**
+ * @internal
+ */
+class IfBlock extends Block
+{
+    /**
+     * @var array
+     */
+    public $cond;
+
+    /**
+     * @var array<ElseifBlock|ElseBlock>
+     */
+    public $cases = [];
+
+    public function __construct()
+    {
+        $this->type = Type::T_IF;
+    }
+}

--- a/src/Block/MediaBlock.php
+++ b/src/Block/MediaBlock.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Block;
+
+use ScssPhp\ScssPhp\Block;
+use ScssPhp\ScssPhp\Type;
+
+/**
+ * @internal
+ */
+class MediaBlock extends Block
+{
+    /**
+     * @var string|array|null
+     */
+    public $value;
+
+    /**
+     * @var array|null
+     */
+    public $queryList;
+
+    public function __construct()
+    {
+        $this->type = Type::T_MEDIA;
+    }
+}

--- a/src/Block/NestedPropertyBlock.php
+++ b/src/Block/NestedPropertyBlock.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Block;
+
+use ScssPhp\ScssPhp\Block;
+use ScssPhp\ScssPhp\Type;
+
+/**
+ * @internal
+ */
+class NestedPropertyBlock extends Block
+{
+    /**
+     * @var bool
+     */
+    public $hasValue;
+
+    /**
+     * @var array
+     */
+    public $prefix;
+
+    public function __construct()
+    {
+        $this->type = Type::T_NESTED_PROPERTY;
+    }
+}

--- a/src/Block/WhileBlock.php
+++ b/src/Block/WhileBlock.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Block;
+
+use ScssPhp\ScssPhp\Block;
+use ScssPhp\ScssPhp\Type;
+
+/**
+ * @internal
+ */
+class WhileBlock extends Block
+{
+    /**
+     * @var array
+     */
+    public $cond;
+
+    public function __construct()
+    {
+        $this->type = Type::T_WHILE;
+    }
+}


### PR DESCRIPTION
This makes it easier to analyse the code relying on those properties.

Follow up of #532, moving all new properties of the Block class to child classes needing them.