### PR TITLE
Rework selector-append to match the dart-sass output

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -9848,21 +9848,18 @@ will be an error in future versions of Sass.\n         on line $line of $fname";
             // do the trick, happening $lastSelector to $previousSelector
             $appended = [];
 
-            foreach ($lastSelectors as $lastSelector) {
-                $previous = $previousSelectors;
-
-                foreach ($lastSelector as $lastSelectorParts) {
-                    foreach ($lastSelectorParts as $lastSelectorPart) {
-                        foreach ($previous as $i => $previousSelector) {
-                            foreach ($previousSelector as $j => $previousSelectorParts) {
-                                $previous[$i][$j][] = $lastSelectorPart;
+            foreach ($previousSelectors as $previousSelector) {
+                foreach ($lastSelectors as $lastSelector) {
+                    $previous = $previousSelector;
+                    foreach ($previousSelector as $j => $previousSelectorParts) {
+                        foreach ($lastSelector as $lastSelectorParts) {
+                            foreach ($lastSelectorParts as $lastSelectorPart) {
+                                $previous[$j][] = $lastSelectorPart;
                             }
                         }
                     }
-                }
 
-                foreach ($previous as $ps) {
-                    $appended[] = $ps;
+                    $appended[] = $previous;
                 }
             }
 

--- a/tests/inputs/selector_functions.scss
+++ b/tests/inputs/selector_functions.scss
@@ -61,7 +61,7 @@
 }
 
 #{selector-append(".accordion, .slider", "__copy, __image")} {
-	content:'.accordion__copy, .slider__copy, .accordion__image, .slider__image';
+	content:'accordion__copy, .accordion__image, .slider__copy, .slider__image';
 }
 
 #{selector-extend("a.disabled", "a", ".link")} {

--- a/tests/outputs/selector_functions.css
+++ b/tests/outputs/selector_functions.css
@@ -57,8 +57,8 @@ a.disabled {
 .accordion__copy, .accordion__image {
   content: ".accordion__copy, .accordion__image";
 }
-.accordion__copy, .slider__copy, .accordion__image, .slider__image {
-  content: ".accordion__copy, .slider__copy, .accordion__image, .slider__image";
+.accordion__copy, .accordion__image, .slider__copy, .slider__image {
+  content: "accordion__copy, .accordion__image, .slider__copy, .slider__image";
 }
 a.disabled, .disabled.link {
   content: "a.disabled, .link.disabled";


### PR DESCRIPTION
When processing selector lists, the output of scssphp was semantically equivalent to the output of dart-sass but in a different order. Producing the same output makes it easier to compare the output.

With that change, the `tests/compare-scss.sh` script reports a `PASS` status for `tests/inputs/selector_functions.scss` when comparing to dart-sass.