### PR TITLE
Allow filtering in the comparison script

### DIFF
--- a/tests/compare-scss.sh
+++ b/tests/compare-scss.sh
@@ -3,8 +3,9 @@
 test_dir=$(dirname $0)
 diff_tool="$1"
 sass_executable=${SASS_EXECUTABLE:-sass}
+glob=${INPUT_GLOB:-*}
 
-for file in $(ls $test_dir/inputs/*.scss); do
+for file in $(ls $test_dir/inputs/$glob.scss); do
 	out_file=$(echo $file | sed -e 's/inputs/outputs/' -e 's/\.scss$/\.css/')
 	sass=$($sass_executable --style=expanded $file 2> /dev/null)
 	if [ $? = "0" ]; then


### PR DESCRIPTION
The script now allows passing a `INPUT_GLOB` env variable when running it to change the glob matching scss filenames inside the inputs folder. When omitted, it defaults to `*` to compare all files.

This is especially meant to be used in combination with the argument (passing a diff tool) allowing to see the diff between the outputs, to focus the diff on the file being worked on.