### PR TITLE
Add tests covering the compressed formatter

### DIFF
--- a/src/Formatter/Compressed.php
+++ b/src/Formatter/Compressed.php
@@ -50,8 +50,6 @@ class Compressed extends Formatter
         foreach ($block->lines as $index => $line) {
             if (substr($line, 0, 2) === '/*' && substr($line, 2, 1) !== '!') {
                 unset($block->lines[$index]);
-            } elseif (substr($line, 0, 3) === '/*!') {
-                $block->lines[$index] = '/*' . substr($line, 3);
             }
         }
 

--- a/tests/CompressedTest.php
+++ b/tests/CompressedTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Tests;
+
+use PHPUnit\Framework\TestCase;
+use ScssPhp\ScssPhp\Compiler;
+use ScssPhp\ScssPhp\OutputStyle;
+
+class CompressedTest extends TestCase
+{
+    public function testRemovesUnnecessaryWhitespaceAndSemicolons()
+    {
+        $this->assertEquals('a{x:y}', $this->compile('a {x: y}'));
+    }
+
+    public function testForDeclarationsPreservesSemicolonsWhenNecessary()
+    {
+        $this->assertEquals('a{q:r;s:t}', $this->compile('a {q: r; s: t}'));
+    }
+
+    public function testTheTopLevelRemovesWhitespaceAndSemicolonsBetweenAtRules()
+    {
+        $this->assertEquals('@foo;@bar;@baz', $this->compile('@foo; @bar; @baz;'));
+    }
+
+    public function testTheTopLevelRemovesWhitespaceAndSemicolonsBetweenStyleRules()
+    {
+        $this->assertEquals('a{b:c}x{y:z}', $this->compile('a {b: c} x {y: z}'));
+    }
+
+    public function testKeyframesRemovesWhitespaceAfterTheSelector()
+    {
+        $this->assertEquals('@keyframes a{from{a:b}}', $this->compile('@keyframes a {from {a: b}}'));
+    }
+
+    public function testKeyframesRemovesWhitespaceAfterCommas()
+    {
+        $this->assertEquals('@keyframes a{from,to{a:b}}', $this->compile('@keyframes a {from, to {a: b}}'));
+    }
+
+    public function testCommentsAreRemoved()
+    {
+        $this->assertEquals('', $this->compile('/* foo bar */'));
+        $this->assertEquals('a{b:c;d:e}', $this->compile('a {
+          b: c;
+          /* foo bar */
+          d: e;
+        }'));
+    }
+
+    /**
+     * @testdox Comments are preserved with /*!
+     */
+    public function testCommentsArePreserved()
+    {
+        $this->assertEquals('/*! foo bar */', $this->compile('/*! foo bar */'));
+        $this->assertEquals('/*! foo *//*! bar */', $this->compile("/*! foo */\n/*! bar */"));
+        $this->assertEquals('a{/*! foo bar */}', $this->compile('a {
+          /*! foo bar */
+        }'));
+    }
+
+    /**
+     * @param string $input
+     *
+     * @return string
+     */
+    private function compile($input)
+    {
+        $compiler = new Compiler();
+        $compiler->setOutputStyle(OutputStyle::COMPRESSED);
+
+        $result = $compiler->compileString($input);
+
+        return $result->getCss();
+    }
+}


### PR DESCRIPTION
Those are a subset of the tests covering the compressed output of dart-sass, as our compressed mode is not compressed as much as dart-sass (the rendering of values or selectors is not managed by the formatter and so does not get compressed).

This also preserves the `!` in preserved comments (i.e. comments starting with `/*!`) in the compressed style. This matches the behavior of dart-sass (which is useless to keep this comment as preserved if another tool is running on the generated CSS).