### PR TITLE
Fix the handling of negative numbers in str-insert

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -9401,7 +9401,7 @@ will be an error in future versions of Sass.\n         on line $line of $fname";
             $index = $index - 1;
         }
         if ($index < 0) {
-            $index = Util::mbStrlen($stringContent) + 1 + $index;
+            $index = max(Util::mbStrlen($stringContent) + 1 + $index, 0);
         }
 
         $string[2] = [

--- a/tests/specs/sass-spec-exclude.txt
+++ b/tests/specs/sass-spec-exclude.txt
@@ -477,7 +477,6 @@ core_functions/selector/unify/simple/universal/and_universal/empty/and_explicit
 core_functions/selector/unify/simple/universal/and_universal/explicit/and_any
 core_functions/selector/unify/simple/universal/and_universal/explicit/and_default
 core_functions/selector/unify/simple/universal/and_universal/explicit/and_empty
-core_functions/string/insert/index/negative/after_last/less_than_double
 core_functions/string/unquote/error/type
 css/comment/error/loud/interpolation/failure
 css/comment/error/loud/interpolation/unterminated


### PR DESCRIPTION
The upgrade of sass-spec in #550 brought an improved set of tests for `str-index` (added because dart-sass also contained bugs for some negative index). One of those new tests detected a bug in our implementation (which looks similar to the dart-sass bug btw)