### PR TITLE
Rework the late initialization of the MixinRule::$content property

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,11 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Property ScssPhp\\\\ScssPhp\\\\Ast\\\\Sass\\\\Statement\\\\MixinRule\\:\\:\\$content \\(bool\\) in isset\\(\\) is not nullable\\.$#"
-			count: 1
-			path: src/Ast/Sass/Statement/MixinRule.php
-
-		-
 			message: "#^Property ScssPhp\\\\ScssPhp\\\\Block\\:\\:\\$children type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Block.php

--- a/src/Ast/Sass/Statement/MixinRule.php
+++ b/src/Ast/Sass/Statement/MixinRule.php
@@ -31,8 +31,7 @@ final class MixinRule extends CallableDeclaration implements SassDeclaration
     /**
      * Whether the mixin contains a `@content` rule.
      *
-     * @var bool
-     * @readonly
+     * @var bool|null
      */
     private $content;
 


### PR DESCRIPTION
PHP static analyzers don't support properly the pattern of late initialization right now.
The new code defines the property as nullable and not read-only, to allow changing the property later in case it is null. This is less explicit about the intent of the property, but it is supported by the tooling.