### PR TITLE
Properly clean the output buffer when an error occurs during formatting

### DIFF
--- a/src/Formatter.php
+++ b/src/Formatter.php
@@ -286,7 +286,15 @@ abstract class Formatter
 
         ob_start();
 
-        $this->block($block);
+        try {
+            $this->block($block);
+        } catch (\Exception $e) {
+            ob_end_clean();
+            throw $e;
+        } catch (\Throwable $e) {
+            ob_end_clean();
+            throw $e;
+        }
 
         $out = ob_get_clean();
         assert($out !== false);


### PR DESCRIPTION
This makes the debugging of errors a lot easier, as it avoid leaking the content of the buffer to the output.