### PR TITLE
Rename accepts to accept in the Sass AST nodes

### DIFF
--- a/src/Ast/Sass/Expression.php
+++ b/src/Ast/Sass/Expression.php
@@ -26,5 +26,5 @@ interface Expression extends SassNode
      * @param ExpressionVisitor<T> $visitor
      * @return T
      */
-    public function accepts(ExpressionVisitor $visitor);
+    public function accept(ExpressionVisitor $visitor);
 }

--- a/src/Ast/Sass/Expression/BinaryOperationExpression.php
+++ b/src/Ast/Sass/Expression/BinaryOperationExpression.php
@@ -107,7 +107,7 @@ final class BinaryOperationExpression implements Expression
         return $leftSpan->expand($rightSpan);
     }
 
-    public function accepts(ExpressionVisitor $visitor)
+    public function accept(ExpressionVisitor $visitor)
     {
         return $visitor->visitBinaryOperationExpression($this);
     }

--- a/src/Ast/Sass/Expression/BooleanExpression.php
+++ b/src/Ast/Sass/Expression/BooleanExpression.php
@@ -51,7 +51,7 @@ final class BooleanExpression implements Expression
         return $this->span;
     }
 
-    public function accepts(ExpressionVisitor $visitor)
+    public function accept(ExpressionVisitor $visitor)
     {
         return $visitor->visitBooleanExpression($this);
     }

--- a/src/Ast/Sass/Expression/CalculationExpression.php
+++ b/src/Ast/Sass/Expression/CalculationExpression.php
@@ -146,7 +146,7 @@ class CalculationExpression implements Expression
         return $this->span;
     }
 
-    public function accepts(ExpressionVisitor $visitor)
+    public function accept(ExpressionVisitor $visitor)
     {
         return $visitor->visitCalculationExpression($this);
     }

--- a/src/Ast/Sass/Expression/ColorExpression.php
+++ b/src/Ast/Sass/Expression/ColorExpression.php
@@ -52,7 +52,7 @@ final class ColorExpression implements Expression
         return $this->span;
     }
 
-    public function accepts(ExpressionVisitor $visitor)
+    public function accept(ExpressionVisitor $visitor)
     {
         return $visitor->visitColorExpression($this);
     }

--- a/src/Ast/Sass/Expression/FunctionExpression.php
+++ b/src/Ast/Sass/Expression/FunctionExpression.php
@@ -121,7 +121,7 @@ final class FunctionExpression implements Expression, CallableInvocation, SassRe
         return SpanUtil::initialIdentifier($this->span);
     }
 
-    public function accepts(ExpressionVisitor $visitor)
+    public function accept(ExpressionVisitor $visitor)
     {
         return $visitor->visitFunctionExpression($this);
     }

--- a/src/Ast/Sass/Expression/IfExpression.php
+++ b/src/Ast/Sass/Expression/IfExpression.php
@@ -59,7 +59,7 @@ final class IfExpression implements Expression, CallableInvocation
         return $this->span;
     }
 
-    public function accepts(ExpressionVisitor $visitor)
+    public function accept(ExpressionVisitor $visitor)
     {
         return $visitor->visitIfExpression($this);
     }

--- a/src/Ast/Sass/Expression/InterpolatedFunctionExpression.php
+++ b/src/Ast/Sass/Expression/InterpolatedFunctionExpression.php
@@ -72,7 +72,7 @@ final class InterpolatedFunctionExpression implements Expression, CallableInvoca
         return $this->span;
     }
 
-    public function accepts(ExpressionVisitor $visitor)
+    public function accept(ExpressionVisitor $visitor)
     {
         return $visitor->visitInterpolatedFunctionExpression($this);
     }

--- a/src/Ast/Sass/Expression/ListExpression.php
+++ b/src/Ast/Sass/Expression/ListExpression.php
@@ -88,7 +88,7 @@ final class ListExpression implements Expression
         return $this->span;
     }
 
-    public function accepts(ExpressionVisitor $visitor)
+    public function accept(ExpressionVisitor $visitor)
     {
         return $visitor->visitListExpression($this);
     }

--- a/src/Ast/Sass/Expression/MapExpression.php
+++ b/src/Ast/Sass/Expression/MapExpression.php
@@ -57,7 +57,7 @@ final class MapExpression implements Expression
         return $this->span;
     }
 
-    public function accepts(ExpressionVisitor $visitor)
+    public function accept(ExpressionVisitor $visitor)
     {
         return $visitor->visitMapExpression($this);
     }

--- a/src/Ast/Sass/Expression/NullExpression.php
+++ b/src/Ast/Sass/Expression/NullExpression.php
@@ -39,7 +39,7 @@ final class NullExpression implements Expression
         return $this->span;
     }
 
-    public function accepts(ExpressionVisitor $visitor)
+    public function accept(ExpressionVisitor $visitor)
     {
         return $visitor->visitNullExpression($this);
     }

--- a/src/Ast/Sass/Expression/NumberExpression.php
+++ b/src/Ast/Sass/Expression/NumberExpression.php
@@ -69,7 +69,7 @@ final class NumberExpression implements Expression
         return $this->unit;
     }
 
-    public function accepts(ExpressionVisitor $visitor)
+    public function accept(ExpressionVisitor $visitor)
     {
         return $visitor->visitNumberExpression($this);
     }

--- a/src/Ast/Sass/Expression/ParenthesizedExpression.php
+++ b/src/Ast/Sass/Expression/ParenthesizedExpression.php
@@ -51,7 +51,7 @@ final class ParenthesizedExpression implements Expression
         return $this->span;
     }
 
-    public function accepts(ExpressionVisitor $visitor)
+    public function accept(ExpressionVisitor $visitor)
     {
         return $visitor->visitParenthesizedExpression($this);
     }

--- a/src/Ast/Sass/Expression/SelectorExpression.php
+++ b/src/Ast/Sass/Expression/SelectorExpression.php
@@ -39,7 +39,7 @@ final class SelectorExpression implements Expression
         return $this->span;
     }
 
-    public function accepts(ExpressionVisitor $visitor)
+    public function accept(ExpressionVisitor $visitor)
     {
         return $visitor->visitSelectorExpression($this);
     }

--- a/src/Ast/Sass/Expression/StringExpression.php
+++ b/src/Ast/Sass/Expression/StringExpression.php
@@ -67,7 +67,7 @@ final class StringExpression implements Expression
         return $this->text->getSpan();
     }
 
-    public function accepts(ExpressionVisitor $visitor)
+    public function accept(ExpressionVisitor $visitor)
     {
         return $visitor->visitStringExpression($this);
     }

--- a/src/Ast/Sass/Expression/UnaryOperationExpression.php
+++ b/src/Ast/Sass/Expression/UnaryOperationExpression.php
@@ -69,7 +69,7 @@ class UnaryOperationExpression implements Expression
         return $this->span;
     }
 
-    public function accepts(ExpressionVisitor $visitor)
+    public function accept(ExpressionVisitor $visitor)
     {
         return $visitor->visitUnaryOperationExpression($this);
     }

--- a/src/Ast/Sass/Expression/ValueExpression.php
+++ b/src/Ast/Sass/Expression/ValueExpression.php
@@ -55,7 +55,7 @@ final class ValueExpression implements Expression
         return $this->span;
     }
 
-    public function accepts(ExpressionVisitor $visitor)
+    public function accept(ExpressionVisitor $visitor)
     {
         return $visitor->visitValueExpression($this);
     }

--- a/src/Ast/Sass/Expression/VariableExpression.php
+++ b/src/Ast/Sass/Expression/VariableExpression.php
@@ -88,7 +88,7 @@ final class VariableExpression implements Expression, SassReference
         return SpanUtil::initialIdentifier($this->span);
     }
 
-    public function accepts(ExpressionVisitor $visitor)
+    public function accept(ExpressionVisitor $visitor)
     {
         return $visitor->visitVariableExpression($this);
     }

--- a/src/Ast/Sass/Statement.php
+++ b/src/Ast/Sass/Statement.php
@@ -26,5 +26,5 @@ interface Statement extends SassNode
      * @param StatementVisitor<T> $visitor
      * @return T
      */
-    public function accepts(StatementVisitor $visitor);
+    public function accept(StatementVisitor $visitor);
 }

--- a/src/Ast/Sass/Statement/AtRootRule.php
+++ b/src/Ast/Sass/Statement/AtRootRule.php
@@ -63,7 +63,7 @@ final class AtRootRule extends ParentStatement
         return $this->span;
     }
 
-    public function accepts(StatementVisitor $visitor)
+    public function accept(StatementVisitor $visitor)
     {
         return $visitor->visitAtRootRule($this);
     }

--- a/src/Ast/Sass/Statement/AtRule.php
+++ b/src/Ast/Sass/Statement/AtRule.php
@@ -70,7 +70,7 @@ final class AtRule extends ParentStatement
         return $this->span;
     }
 
-    public function accepts(StatementVisitor $visitor)
+    public function accept(StatementVisitor $visitor)
     {
         return $visitor->visitAtRule($this);
     }

--- a/src/Ast/Sass/Statement/ContentBlock.php
+++ b/src/Ast/Sass/Statement/ContentBlock.php
@@ -32,7 +32,7 @@ final class ContentBlock extends CallableDeclaration
         parent::__construct('@content', $arguments, $span, $children);
     }
 
-    public function accepts(StatementVisitor $visitor)
+    public function accept(StatementVisitor $visitor)
     {
         return $visitor->visitContentBlock($this);
     }

--- a/src/Ast/Sass/Statement/ContentRule.php
+++ b/src/Ast/Sass/Statement/ContentRule.php
@@ -59,7 +59,7 @@ final class ContentRule implements Statement
         return $this->span;
     }
 
-    public function accepts(StatementVisitor $visitor)
+    public function accept(StatementVisitor $visitor)
     {
         return $visitor->visitContentRule($this);
     }

--- a/src/Ast/Sass/Statement/DebugRule.php
+++ b/src/Ast/Sass/Statement/DebugRule.php
@@ -54,7 +54,7 @@ final class DebugRule implements Statement
         return $this->span;
     }
 
-    public function accepts(StatementVisitor $visitor)
+    public function accept(StatementVisitor $visitor)
     {
         return $visitor->visitDebugRule($this);
     }

--- a/src/Ast/Sass/Statement/Declaration.php
+++ b/src/Ast/Sass/Statement/Declaration.php
@@ -116,7 +116,7 @@ final class Declaration extends ParentStatement
         return $this->span;
     }
 
-    public function accepts(StatementVisitor $visitor)
+    public function accept(StatementVisitor $visitor)
     {
         return $visitor->visitDeclaration($this);
     }

--- a/src/Ast/Sass/Statement/EachRule.php
+++ b/src/Ast/Sass/Statement/EachRule.php
@@ -76,7 +76,7 @@ final class EachRule extends ParentStatement
         return $this->span;
     }
 
-    public function accepts(StatementVisitor $visitor)
+    public function accept(StatementVisitor $visitor)
     {
         return $visitor->visitEachRule($this);
     }

--- a/src/Ast/Sass/Statement/ErrorRule.php
+++ b/src/Ast/Sass/Statement/ErrorRule.php
@@ -54,7 +54,7 @@ final class ErrorRule implements Statement
         return $this->span;
     }
 
-    public function accepts(StatementVisitor $visitor)
+    public function accept(StatementVisitor $visitor)
     {
         return $visitor->visitErrorRule($this);
     }

--- a/src/Ast/Sass/Statement/ExtendRule.php
+++ b/src/Ast/Sass/Statement/ExtendRule.php
@@ -72,7 +72,7 @@ final class ExtendRule implements Statement
         return $this->span;
     }
 
-    public function accepts(StatementVisitor $visitor)
+    public function accept(StatementVisitor $visitor)
     {
         return $visitor->visitExtendRule($this);
     }

--- a/src/Ast/Sass/Statement/ForRule.php
+++ b/src/Ast/Sass/Statement/ForRule.php
@@ -99,7 +99,7 @@ final class ForRule extends ParentStatement
         return $this->span;
     }
 
-    public function accepts(StatementVisitor $visitor)
+    public function accept(StatementVisitor $visitor)
     {
         return $visitor->visitForRule($this);
     }

--- a/src/Ast/Sass/Statement/FunctionRule.php
+++ b/src/Ast/Sass/Statement/FunctionRule.php
@@ -31,7 +31,7 @@ final class FunctionRule extends CallableDeclaration implements SassDeclaration
         return SpanUtil::initialIdentifier(SpanUtil::withoutInitialAtRule($this->getSpan()));
     }
 
-    public function accepts(StatementVisitor $visitor)
+    public function accept(StatementVisitor $visitor)
     {
         return $visitor->visitFunctionRule($this);
     }

--- a/src/Ast/Sass/Statement/IfRule.php
+++ b/src/Ast/Sass/Statement/IfRule.php
@@ -84,7 +84,7 @@ final class IfRule implements Statement
         return $this->span;
     }
 
-    public function accepts(StatementVisitor $visitor)
+    public function accept(StatementVisitor $visitor)
     {
         return $visitor->visitIfRule($this);
     }

--- a/src/Ast/Sass/Statement/ImportRule.php
+++ b/src/Ast/Sass/Statement/ImportRule.php
@@ -58,7 +58,7 @@ final class ImportRule implements Statement
         return $this->span;
     }
 
-    public function accepts(StatementVisitor $visitor)
+    public function accept(StatementVisitor $visitor)
     {
         return $visitor->visitImportRule($this);
     }

--- a/src/Ast/Sass/Statement/IncludeRule.php
+++ b/src/Ast/Sass/Statement/IncludeRule.php
@@ -115,7 +115,7 @@ final class IncludeRule implements Statement, CallableInvocation, SassReference
         return SpanUtil::initialIdentifier($startSpan);
     }
 
-    public function accepts(StatementVisitor $visitor)
+    public function accept(StatementVisitor $visitor)
     {
         return $visitor->visitIncludeRule($this);
     }

--- a/src/Ast/Sass/Statement/LoudComment.php
+++ b/src/Ast/Sass/Statement/LoudComment.php
@@ -45,7 +45,7 @@ final class LoudComment implements Statement
         return $this->text->getSpan();
     }
 
-    public function accepts(StatementVisitor $visitor)
+    public function accept(StatementVisitor $visitor)
     {
         return $visitor->visitLoudComment($this);
     }

--- a/src/Ast/Sass/Statement/MediaRule.php
+++ b/src/Ast/Sass/Statement/MediaRule.php
@@ -63,7 +63,7 @@ final class MediaRule extends ParentStatement
         return $this->span;
     }
 
-    public function accepts(StatementVisitor $visitor)
+    public function accept(StatementVisitor $visitor)
     {
         return $visitor->visitMediaRule($this);
     }

--- a/src/Ast/Sass/Statement/MixinRule.php
+++ b/src/Ast/Sass/Statement/MixinRule.php
@@ -61,7 +61,7 @@ final class MixinRule extends CallableDeclaration implements SassDeclaration
         return SpanUtil::initialIdentifier($startSpan);
     }
 
-    public function accepts(StatementVisitor $visitor)
+    public function accept(StatementVisitor $visitor)
     {
         return $visitor->visitMixinRule($this);
     }

--- a/src/Ast/Sass/Statement/ReturnRule.php
+++ b/src/Ast/Sass/Statement/ReturnRule.php
@@ -54,7 +54,7 @@ final class ReturnRule implements Statement
         return $this->span;
     }
 
-    public function accepts(StatementVisitor $visitor)
+    public function accept(StatementVisitor $visitor)
     {
         return $visitor->visitReturnRule($this);
     }

--- a/src/Ast/Sass/Statement/SilentComment.php
+++ b/src/Ast/Sass/Statement/SilentComment.php
@@ -51,7 +51,7 @@ final class SilentComment implements Statement
         return $this->span;
     }
 
-    public function accepts(StatementVisitor $visitor)
+    public function accept(StatementVisitor $visitor)
     {
         return $visitor->visitSilentComment($this);
     }

--- a/src/Ast/Sass/Statement/StyleRule.php
+++ b/src/Ast/Sass/Statement/StyleRule.php
@@ -65,7 +65,7 @@ final class StyleRule extends ParentStatement
         return $this->span;
     }
 
-    public function accepts(StatementVisitor $visitor)
+    public function accept(StatementVisitor $visitor)
     {
         return $visitor->visitStyleRule($this);
     }

--- a/src/Ast/Sass/Statement/Stylesheet.php
+++ b/src/Ast/Sass/Statement/Stylesheet.php
@@ -65,7 +65,7 @@ final class Stylesheet extends ParentStatement
         return $this->span;
     }
 
-    public function accepts(StatementVisitor $visitor)
+    public function accept(StatementVisitor $visitor)
     {
         return $visitor->visitStylesheet($this);
     }

--- a/src/Ast/Sass/Statement/SupportsRule.php
+++ b/src/Ast/Sass/Statement/SupportsRule.php
@@ -58,7 +58,7 @@ final class SupportsRule extends ParentStatement
         return $this->span;
     }
 
-    public function accepts(StatementVisitor $visitor)
+    public function accept(StatementVisitor $visitor)
     {
         return $visitor->visitSupportsRule($this);
     }

--- a/src/Ast/Sass/Statement/VariableDeclaration.php
+++ b/src/Ast/Sass/Statement/VariableDeclaration.php
@@ -143,7 +143,7 @@ final class VariableDeclaration implements Statement, SassDeclaration
         return SpanUtil::initialIdentifier($this->span);
     }
 
-    public function accepts(StatementVisitor $visitor)
+    public function accept(StatementVisitor $visitor)
     {
         return $visitor->visitVariableDeclaration($this);
     }

--- a/src/Ast/Sass/Statement/WarnRule.php
+++ b/src/Ast/Sass/Statement/WarnRule.php
@@ -54,7 +54,7 @@ final class WarnRule implements Statement
         return $this->span;
     }
 
-    public function accepts(StatementVisitor $visitor)
+    public function accept(StatementVisitor $visitor)
     {
         return $visitor->visitWarnRule($this);
     }

--- a/src/Ast/Sass/Statement/WhileRule.php
+++ b/src/Ast/Sass/Statement/WhileRule.php
@@ -61,7 +61,7 @@ final class WhileRule extends ParentStatement
         return $this->span;
     }
 
-    public function accepts(StatementVisitor $visitor)
+    public function accept(StatementVisitor $visitor)
     {
         return $visitor->visitWhileRule($this);
     }

--- a/src/Visitor/StatementSearchVisitor.php
+++ b/src/Visitor/StatementSearchVisitor.php
@@ -347,7 +347,7 @@ abstract class StatementSearchVisitor implements StatementVisitor
     protected function visitChildren(array $children)
     {
         foreach ($children as $child) {
-            $result = $child->accepts($this);
+            $result = $child->accept($this);
 
             if ($result !== null) {
                 return $result;


### PR DESCRIPTION
The Selector AST and the Value API are already using the accept() naming, which is the one used in dart-sass for all those APIs.