### PR TITLE
Clean the locking of the API for the new 2.0 codebase

### DIFF
--- a/src/Ast/Css/CssComment.php
+++ b/src/Ast/Css/CssComment.php
@@ -16,6 +16,8 @@ namespace ScssPhp\ScssPhp\Ast\Css;
  * A plain CSS comment.
  *
  * This is always a multi-line comment.
+ *
+ * @internal
  */
 interface CssComment extends CssNode
 {

--- a/src/Ast/Css/CssStyleRule.php
+++ b/src/Ast/Css/CssStyleRule.php
@@ -20,6 +20,8 @@ use ScssPhp\ScssPhp\Ast\Selector\SelectorList;
 *  * This applies style declarations to elements that match a given selector.
 *  * Note that this isn't *strictly* plain CSS, since {@see getSelector} may still
 *  * contain placeholder selectors.
+ *
+ * @internal
  */
 interface CssStyleRule extends CssParentNode
 {

--- a/src/Ast/Css/CssValue.php
+++ b/src/Ast/Css/CssValue.php
@@ -22,6 +22,8 @@ use ScssPhp\ScssPhp\SourceSpan\FileSpan;
  * its span.
  *
  * @template T
+ *
+ * @internal
  */
 class CssValue implements AstNode
 {

--- a/src/Ast/Css/ModifiableCssStylesheet.php
+++ b/src/Ast/Css/ModifiableCssStylesheet.php
@@ -14,7 +14,12 @@ namespace ScssPhp\ScssPhp\Ast\Css;
 
 use ScssPhp\ScssPhp\SourceSpan\FileSpan;
 
-class ModifiableCssStylesheet extends ModifiableCssParentNode implements CssStylesheet
+/**
+ * A modifiable version of {@see CssStylesheet} for use in the evaluation step.
+ *
+ * @internal
+ */
+final class ModifiableCssStylesheet extends ModifiableCssParentNode implements CssStylesheet
 {
     /**
      * @var FileSpan

--- a/src/Ast/Css/ModifiableCssValue.php
+++ b/src/Ast/Css/ModifiableCssValue.php
@@ -20,7 +20,7 @@ namespace ScssPhp\ScssPhp\Ast\Css;
  *
  * @internal
  */
-class ModifiableCssValue extends CssValue
+final class ModifiableCssValue extends CssValue
 {
     /**
      * @param T $value

--- a/src/Ast/Sass/AtRootQuery.php
+++ b/src/Ast/Sass/AtRootQuery.php
@@ -21,7 +21,7 @@ use ScssPhp\ScssPhp\Parser\AtRootQueryParser;
  *
  * @internal
  */
-class AtRootQuery
+final class AtRootQuery
 {
     /**
      * Whether the query includes or excludes rules with the specified names.

--- a/src/Ast/Sass/Expression/BinaryOperationExpression.php
+++ b/src/Ast/Sass/Expression/BinaryOperationExpression.php
@@ -16,6 +16,11 @@ use ScssPhp\ScssPhp\Ast\Sass\Expression;
 use ScssPhp\ScssPhp\SourceSpan\FileSpan;
 use ScssPhp\ScssPhp\Visitor\ExpressionVisitor;
 
+/**
+ * A binary operator, as in `1 + 2` or `$this and $other`.
+ *
+ * @internal
+ */
 final class BinaryOperationExpression implements Expression
 {
     /**

--- a/src/Ast/Sass/Expression/CalculationExpression.php
+++ b/src/Ast/Sass/Expression/CalculationExpression.php
@@ -21,7 +21,7 @@ use ScssPhp\ScssPhp\Visitor\ExpressionVisitor;
  *
  * @internal
  */
-class CalculationExpression implements Expression
+final class CalculationExpression implements Expression
 {
     /**
      * This calculation's name.

--- a/src/Ast/Sass/Expression/UnaryOperationExpression.php
+++ b/src/Ast/Sass/Expression/UnaryOperationExpression.php
@@ -21,7 +21,7 @@ use ScssPhp\ScssPhp\Visitor\ExpressionVisitor;
  *
  * @internal
  */
-class UnaryOperationExpression implements Expression
+final class UnaryOperationExpression implements Expression
 {
     /**
      * @var UnaryOperator::*

--- a/src/Ast/Sass/Import/StaticImport.php
+++ b/src/Ast/Sass/Import/StaticImport.php
@@ -16,7 +16,6 @@ use ScssPhp\ScssPhp\Ast\Sass\Import;
 use ScssPhp\ScssPhp\Ast\Sass\Interpolation;
 use ScssPhp\ScssPhp\Ast\Sass\SupportsCondition;
 use ScssPhp\ScssPhp\SourceSpan\FileSpan;
-use ScssPhp\ScssPhp\Visitor\ExpressionVisitor;
 
 /**
  * An import that produces a plain CSS `@import` rule.

--- a/src/Ast/Sass/Statement/HasContentVisitor.php
+++ b/src/Ast/Sass/Statement/HasContentVisitor.php
@@ -25,7 +25,7 @@ use ScssPhp\ScssPhp\Visitor\StatementSearchVisitor;
  *
  * @extends StatementSearchVisitor<bool>
  */
-class HasContentVisitor extends StatementSearchVisitor
+final class HasContentVisitor extends StatementSearchVisitor
 {
     public function visitContentRule(ContentRule $node): bool
     {

--- a/src/Ast/Selector/AttributeOperator.php
+++ b/src/Ast/Selector/AttributeOperator.php
@@ -12,6 +12,9 @@
 
 namespace ScssPhp\ScssPhp\Ast\Selector;
 
+/**
+ * An operator that defines the semantics of an {@see AttributeSelector}.
+ */
 final class AttributeOperator
 {
     /**

--- a/src/Ast/Selector/ComplexSelector.php
+++ b/src/Ast/Selector/ComplexSelector.php
@@ -16,7 +16,13 @@ use ScssPhp\ScssPhp\Extend\ExtendUtil;
 use ScssPhp\ScssPhp\Util\EquatableUtil;
 use ScssPhp\ScssPhp\Visitor\SelectorVisitor;
 
-class ComplexSelector extends Selector
+/**
+ * A complex selector.
+ *
+ * A complex selector is composed of {@see CompoundSelector}s separated by
+ * {@see Combinator}s. It selects elements based on their parent selectors.
+ */
+final class ComplexSelector extends Selector
 {
     /**
      * The components of this selector.

--- a/src/Ast/Selector/QualifiedName.php
+++ b/src/Ast/Selector/QualifiedName.php
@@ -19,7 +19,7 @@ use ScssPhp\ScssPhp\Util\Equatable;
  *
  * [qualified name]: https://www.w3.org/TR/css3-namespace/#css-qnames
  */
-class QualifiedName implements Equatable
+final class QualifiedName implements Equatable
 {
     /**
      * The identifier name.

--- a/src/Ast/Selector/Selector.php
+++ b/src/Ast/Selector/Selector.php
@@ -22,7 +22,7 @@ use ScssPhp\ScssPhp\Visitor\SelectorVisitor;
  * This selector tree is mostly plain CSS, but also may contain a
  * {@see ParentSelector} or a {@see PlaceholderSelector}.
  *
- * Selectors have structural equality semantics
+ * Selectors have structural equality semantics.
  */
 abstract class Selector implements Equatable
 {

--- a/src/Formatter/OutputBlock.php
+++ b/src/Formatter/OutputBlock.php
@@ -19,7 +19,7 @@ namespace ScssPhp\ScssPhp\Formatter;
  *
  * @internal
  */
-class OutputBlock
+final class OutputBlock
 {
     /**
      * @var string|null

--- a/src/Logger/QuietLogger.php
+++ b/src/Logger/QuietLogger.php
@@ -15,7 +15,7 @@ namespace ScssPhp\ScssPhp\Logger;
 /**
  * A logger that silently ignores all messages.
  */
-class QuietLogger implements LoggerInterface
+final class QuietLogger implements LoggerInterface
 {
     public function warn(string $message, bool $deprecation = false)
     {

--- a/src/Logger/StreamLogger.php
+++ b/src/Logger/StreamLogger.php
@@ -15,7 +15,7 @@ namespace ScssPhp\ScssPhp\Logger;
 /**
  * A logger that prints to a PHP stream (for instance stderr)
  */
-class StreamLogger implements LoggerInterface
+final class StreamLogger implements LoggerInterface
 {
     private $stream;
     private $closeOnDestruct;

--- a/src/Parser/KeyframeSelectorParser.php
+++ b/src/Parser/KeyframeSelectorParser.php
@@ -17,8 +17,10 @@ use ScssPhp\ScssPhp\Util\Character;
 
 /**
  * A parser for `@keyframes` block selectors.
+ *
+ * @internal
  */
-class KeyframeSelectorParser extends Parser
+final class KeyframeSelectorParser extends Parser
 {
     /**
      * @return string[]

--- a/src/Parser/MediaQueryParser.php
+++ b/src/Parser/MediaQueryParser.php
@@ -20,7 +20,7 @@ use ScssPhp\ScssPhp\Exception\SassFormatException;
  *
  * @internal
  */
-class MediaQueryParser extends Parser
+final class MediaQueryParser extends Parser
 {
     /**
      * @return list<CssMediaQuery>

--- a/src/Serializer/SerializeResult.php
+++ b/src/Serializer/SerializeResult.php
@@ -12,6 +12,11 @@
 
 namespace ScssPhp\ScssPhp\Serializer;
 
+/**
+ * The result of converting a CSS AST to CSS text.
+ *
+ * @internal
+ */
 final class SerializeResult
 {
     /**

--- a/src/Serializer/SerializeVisitor.php
+++ b/src/Serializer/SerializeVisitor.php
@@ -67,7 +67,7 @@ use ScssPhp\ScssPhp\Visitor\ValueVisitor;
  * @template-implements ValueVisitor<void>
  * @template-implements SelectorVisitor<void>
  */
-class SerializeVisitor implements CssVisitor, ValueVisitor, SelectorVisitor
+final class SerializeVisitor implements CssVisitor, ValueVisitor, SelectorVisitor
 {
     /**
      * @var StringBuffer

--- a/src/Serializer/SimpleStringBuffer.php
+++ b/src/Serializer/SimpleStringBuffer.php
@@ -12,7 +12,10 @@
 
 namespace ScssPhp\ScssPhp\Serializer;
 
-class SimpleStringBuffer implements StringBuffer
+/**
+ * @internal
+ */
+final class SimpleStringBuffer implements StringBuffer
 {
     /**
      * @var string

--- a/src/Util/ErrorUtil.php
+++ b/src/Util/ErrorUtil.php
@@ -15,7 +15,7 @@ namespace ScssPhp\ScssPhp\Util;
 /**
  * @internal
  */
-class ErrorUtil
+final class ErrorUtil
 {
     /**
      * @throws \OutOfRangeException

--- a/src/Util/NumberUtil.php
+++ b/src/Util/NumberUtil.php
@@ -17,7 +17,7 @@ namespace ScssPhp\ScssPhp\Util;
  *
  * @internal
  */
-class NumberUtil
+final class NumberUtil
 {
     public const EPSILON = 0.00000000001; // 10^(-PRECISION-1)
 

--- a/src/Util/SpanUtil.php
+++ b/src/Util/SpanUtil.php
@@ -18,7 +18,7 @@ use ScssPhp\ScssPhp\SourceSpan\FileSpan;
 /**
  * @internal
  */
-class SpanUtil
+final class SpanUtil
 {
     /**
      * Returns this span with all leading whitespace trimmed.


### PR DESCRIPTION
Most of the new classes are using final classes and/or `@internal` properly to define what will be covered by BC once 2.0 is released, but a few things were missing.