### PR TITLE
Make AST nodes castable to string

### DIFF
--- a/src/Ast/AstNode.php
+++ b/src/Ast/AstNode.php
@@ -22,4 +22,6 @@ use ScssPhp\ScssPhp\SourceSpan\FileSpan;
 interface AstNode
 {
     public function getSpan(): FileSpan;
+
+    public function __toString(): string;
 }

--- a/src/Ast/Css/CssValue.php
+++ b/src/Ast/Css/CssValue.php
@@ -59,4 +59,13 @@ class CssValue implements AstNode
     {
         return $this->span;
     }
+
+    public function __toString(): string
+    {
+        if (\is_array($this->value)) {
+            return implode($this->value);
+        }
+
+        return (string) $this->value;
+    }
 }

--- a/src/Ast/Css/ModifiableCssNode.php
+++ b/src/Ast/Css/ModifiableCssNode.php
@@ -12,6 +12,7 @@
 
 namespace ScssPhp\ScssPhp\Ast\Css;
 
+use ScssPhp\ScssPhp\Serializer\Serializer;
 use ScssPhp\ScssPhp\Visitor\ModifiableCssVisitor;
 
 /**
@@ -160,5 +161,10 @@ abstract class ModifiableCssNode implements CssNode
         }
         $this->parent = null;
         $this->indexInParent = null;
+    }
+
+    public function __toString(): string
+    {
+        return Serializer::serialize($this, true)->getCss();
     }
 }

--- a/src/Ast/Sass/Argument.php
+++ b/src/Ast/Sass/Argument.php
@@ -70,4 +70,13 @@ final class Argument implements SassNode, SassDeclaration
     {
         return $this->span;
     }
+
+    public function __toString(): string
+    {
+        if ($this->defaultValue === null) {
+            return $this->name;
+        }
+
+        return $this->name . ': ' . $this->defaultValue;
+    }
 }

--- a/src/Ast/Sass/ArgumentDeclaration.php
+++ b/src/Ast/Sass/ArgumentDeclaration.php
@@ -78,4 +78,17 @@ final class ArgumentDeclaration implements SassNode
     {
         return $this->span;
     }
+
+    public function __toString(): string
+    {
+        $parts = [];
+        foreach ($this->arguments as $arg) {
+            $parts[] = "\$$arg";
+        }
+        if ($this->restArgument !== null) {
+            $parts[] = "\$$this->restArgument...";
+        }
+
+        return implode(', ', $parts);
+    }
 }

--- a/src/Ast/Sass/ArgumentInvocation.php
+++ b/src/Ast/Sass/ArgumentInvocation.php
@@ -108,4 +108,20 @@ final class ArgumentInvocation implements SassNode
     {
         return $this->span;
     }
+
+    public function __toString(): string
+    {
+        $parts = $this->positional;
+        foreach ($this->named as $name => $arg) {
+            $parts[] = "\$$name: $arg";
+        }
+        if ($this->rest !== null) {
+            $parts[] = "$this->rest...";
+        }
+        if ($this->keywordRest !== null) {
+            $parts[] = "$this->keywordRest...";
+        }
+
+        return '(' . implode(', ', $parts) . ')';
+    }
 }

--- a/src/Ast/Sass/ConfiguredVariable.php
+++ b/src/Ast/Sass/ConfiguredVariable.php
@@ -78,4 +78,9 @@ final class ConfiguredVariable implements SassNode, SassDeclaration
     {
         return SpanUtil::initialIdentifier($this->span, 1);
     }
+
+    public function __toString(): string
+    {
+        return '$' . $this->name . ': ' . $this->expression . ($this->guarded ? ' !default' : '');
+    }
 }

--- a/src/Ast/Sass/Expression/BinaryOperationExpression.php
+++ b/src/Ast/Sass/Expression/BinaryOperationExpression.php
@@ -116,4 +116,33 @@ final class BinaryOperationExpression implements Expression
     {
         return $visitor->visitBinaryOperationExpression($this);
     }
+
+    public function __toString(): string
+    {
+        $buffer = '';
+
+        $leftNeedsParens = $this->left instanceof BinaryOperationExpression && BinaryOperator::getPrecedence($this->left->getOperator()) < BinaryOperator::getPrecedence($this->operator);
+        if ($leftNeedsParens) {
+            $buffer .= '(';
+        }
+        $buffer .= $this->left;
+        if ($leftNeedsParens) {
+            $buffer .= ')';
+        }
+
+        $buffer .= ' ';
+        $buffer .= $this->operator;
+        $buffer .= ' ';
+
+        $rightNeedsParens = $this->right instanceof BinaryOperationExpression && BinaryOperator::getPrecedence($this->right->getOperator()) <= BinaryOperator::getPrecedence($this->operator);
+        if ($rightNeedsParens) {
+            $buffer .= '(';
+        }
+        $buffer .= $this->right;
+        if ($rightNeedsParens) {
+            $buffer .= ')';
+        }
+
+        return $buffer;
+    }
 }

--- a/src/Ast/Sass/Expression/BooleanExpression.php
+++ b/src/Ast/Sass/Expression/BooleanExpression.php
@@ -55,4 +55,9 @@ final class BooleanExpression implements Expression
     {
         return $visitor->visitBooleanExpression($this);
     }
+
+    public function __toString(): string
+    {
+        return $this->value ? 'true' : 'false';
+    }
 }

--- a/src/Ast/Sass/Expression/CalculationExpression.php
+++ b/src/Ast/Sass/Expression/CalculationExpression.php
@@ -227,4 +227,9 @@ final class CalculationExpression implements Expression
 
         throw new \InvalidArgumentException('Invalid calculation argument.');
     }
+
+    public function __toString(): string
+    {
+        return $this->name . '(' . implode(', ', $this->arguments) . ')';
+    }
 }

--- a/src/Ast/Sass/Expression/ColorExpression.php
+++ b/src/Ast/Sass/Expression/ColorExpression.php
@@ -56,4 +56,9 @@ final class ColorExpression implements Expression
     {
         return $visitor->visitColorExpression($this);
     }
+
+    public function __toString(): string
+    {
+        return (string) $this->value;
+    }
 }

--- a/src/Ast/Sass/Expression/FunctionExpression.php
+++ b/src/Ast/Sass/Expression/FunctionExpression.php
@@ -125,4 +125,17 @@ final class FunctionExpression implements Expression, CallableInvocation, SassRe
     {
         return $visitor->visitFunctionExpression($this);
     }
+
+    public function __toString(): string
+    {
+        $buffer = '';
+
+        if ($this->namespace !== null) {
+            $buffer .= $this->namespace . '.';
+        }
+
+        $buffer .= $this->originalName . $this->arguments;
+
+        return $buffer;
+    }
 }

--- a/src/Ast/Sass/Expression/IfExpression.php
+++ b/src/Ast/Sass/Expression/IfExpression.php
@@ -63,4 +63,9 @@ final class IfExpression implements Expression, CallableInvocation
     {
         return $visitor->visitIfExpression($this);
     }
+
+    public function __toString(): string
+    {
+        return 'if' . $this->arguments;
+    }
 }

--- a/src/Ast/Sass/Expression/InterpolatedFunctionExpression.php
+++ b/src/Ast/Sass/Expression/InterpolatedFunctionExpression.php
@@ -76,4 +76,9 @@ final class InterpolatedFunctionExpression implements Expression, CallableInvoca
     {
         return $visitor->visitInterpolatedFunctionExpression($this);
     }
+
+    public function __toString(): string
+    {
+        return $this->name . $this->arguments;
+    }
 }

--- a/src/Ast/Sass/Expression/MapExpression.php
+++ b/src/Ast/Sass/Expression/MapExpression.php
@@ -61,4 +61,11 @@ final class MapExpression implements Expression
     {
         return $visitor->visitMapExpression($this);
     }
+
+    public function __toString(): string
+    {
+        return '(' . implode(', ', array_map(function ($pair) {
+            return $pair[0] . ': ' . $pair[1];
+        }, $this->pairs)) . ')';
+    }
 }

--- a/src/Ast/Sass/Expression/NullExpression.php
+++ b/src/Ast/Sass/Expression/NullExpression.php
@@ -43,4 +43,9 @@ final class NullExpression implements Expression
     {
         return $visitor->visitNullExpression($this);
     }
+
+    public function __toString(): string
+    {
+        return 'null';
+    }
 }

--- a/src/Ast/Sass/Expression/NumberExpression.php
+++ b/src/Ast/Sass/Expression/NumberExpression.php
@@ -73,4 +73,9 @@ final class NumberExpression implements Expression
     {
         return $visitor->visitNumberExpression($this);
     }
+
+    public function __toString(): string
+    {
+        return $this->value . ($this->unit ?? '');
+    }
 }

--- a/src/Ast/Sass/Expression/ParenthesizedExpression.php
+++ b/src/Ast/Sass/Expression/ParenthesizedExpression.php
@@ -55,4 +55,9 @@ final class ParenthesizedExpression implements Expression
     {
         return $visitor->visitParenthesizedExpression($this);
     }
+
+    public function __toString(): string
+    {
+        return '(' . $this->expression . ')';
+    }
 }

--- a/src/Ast/Sass/Expression/SelectorExpression.php
+++ b/src/Ast/Sass/Expression/SelectorExpression.php
@@ -43,4 +43,9 @@ final class SelectorExpression implements Expression
     {
         return $visitor->visitSelectorExpression($this);
     }
+
+    public function __toString(): string
+    {
+        return '&';
+    }
 }

--- a/src/Ast/Sass/Expression/UnaryOperationExpression.php
+++ b/src/Ast/Sass/Expression/UnaryOperationExpression.php
@@ -73,4 +73,15 @@ final class UnaryOperationExpression implements Expression
     {
         return $visitor->visitUnaryOperationExpression($this);
     }
+
+    public function __toString(): string
+    {
+        $buffer = $this->operator;
+        if ($this->operator === UnaryOperator::NOT) {
+            $buffer .= ' ';
+        }
+        $buffer .= $this->operand;
+
+        return $buffer;
+    }
 }

--- a/src/Ast/Sass/Expression/ValueExpression.php
+++ b/src/Ast/Sass/Expression/ValueExpression.php
@@ -59,4 +59,9 @@ final class ValueExpression implements Expression
     {
         return $visitor->visitValueExpression($this);
     }
+
+    public function __toString(): string
+    {
+        return (string) $this->value;
+    }
 }

--- a/src/Ast/Sass/Expression/VariableExpression.php
+++ b/src/Ast/Sass/Expression/VariableExpression.php
@@ -92,4 +92,13 @@ final class VariableExpression implements Expression, SassReference
     {
         return $visitor->visitVariableExpression($this);
     }
+
+    public function __toString(): string
+    {
+        if ($this->namespace === null) {
+            return '$' . $this->name;
+        }
+
+        return $this->namespace . '$' . $this->name;
+    }
 }

--- a/src/Ast/Sass/Import/DynamicImport.php
+++ b/src/Ast/Sass/Import/DynamicImport.php
@@ -12,6 +12,7 @@
 
 namespace ScssPhp\ScssPhp\Ast\Sass\Import;
 
+use ScssPhp\ScssPhp\Ast\Sass\Expression\StringExpression;
 use ScssPhp\ScssPhp\Ast\Sass\Import;
 use ScssPhp\ScssPhp\SourceSpan\FileSpan;
 
@@ -52,5 +53,10 @@ final class DynamicImport implements Import
     public function getSpan(): FileSpan
     {
         return $this->span;
+    }
+
+    public function __toString(): string
+    {
+        return StringExpression::quoteText($this->urlString);
     }
 }

--- a/src/Ast/Sass/Import/StaticImport.php
+++ b/src/Ast/Sass/Import/StaticImport.php
@@ -79,4 +79,19 @@ final class StaticImport implements Import
     {
         return $this->span;
     }
+
+    public function __toString(): string
+    {
+        $buffer = (string) $this->url;
+
+        if ($this->supports !== null) {
+            $buffer .= " supports($this->supports)";
+        }
+
+        if ($this->media !== null) {
+            $buffer .= ' ' . $this->media;
+        }
+
+        return $buffer;
+    }
 }

--- a/src/Ast/Sass/Interpolation.php
+++ b/src/Ast/Sass/Interpolation.php
@@ -102,4 +102,11 @@ final class Interpolation implements SassNode
 
         return '';
     }
+
+    public function __toString(): string
+    {
+        return implode('', array_map(function ($value) {
+            return \is_string($value) ? $value : '#{' . $value .'}';
+        }, $this->contents));
+    }
 }

--- a/src/Ast/Sass/Statement/AtRootRule.php
+++ b/src/Ast/Sass/Statement/AtRootRule.php
@@ -67,4 +67,14 @@ final class AtRootRule extends ParentStatement
     {
         return $visitor->visitAtRootRule($this);
     }
+
+    public function __toString(): string
+    {
+        $buffer = '@at-root ';
+        if ($this->query !== null) {
+            $buffer .= $this->query . ' ';
+        }
+
+        return $buffer . '{' . implode(' ', $this->getChildren()) . '}';
+    }
 }

--- a/src/Ast/Sass/Statement/AtRule.php
+++ b/src/Ast/Sass/Statement/AtRule.php
@@ -74,4 +74,20 @@ final class AtRule extends ParentStatement
     {
         return $visitor->visitAtRule($this);
     }
+
+    public function __toString(): string
+    {
+        $buffer = '@' . $this->name;
+        if ($this->value !== null) {
+            $buffer .= ' ' . $this->value;
+        }
+
+        $children = $this->getChildren();
+
+        if ($children === null) {
+            return $buffer . ';';
+        }
+
+        return $buffer . '{' . implode(' ', $children) . '}';
+    }
 }

--- a/src/Ast/Sass/Statement/ContentBlock.php
+++ b/src/Ast/Sass/Statement/ContentBlock.php
@@ -36,4 +36,11 @@ final class ContentBlock extends CallableDeclaration
     {
         return $visitor->visitContentBlock($this);
     }
+
+    public function __toString(): string
+    {
+        $buffer = $this->getArguments()->isEmpty() ? '' : ' using (' . $this->getArguments() . ')';
+
+        return $buffer . '{' . implode(' ', $this->getChildren()) . '}';
+    }
 }

--- a/src/Ast/Sass/Statement/ContentRule.php
+++ b/src/Ast/Sass/Statement/ContentRule.php
@@ -63,4 +63,9 @@ final class ContentRule implements Statement
     {
         return $visitor->visitContentRule($this);
     }
+
+    public function __toString(): string
+    {
+        return $this->arguments->isEmpty() ? '@content;' : "@content($this->arguments);";
+    }
 }

--- a/src/Ast/Sass/Statement/DebugRule.php
+++ b/src/Ast/Sass/Statement/DebugRule.php
@@ -58,4 +58,9 @@ final class DebugRule implements Statement
     {
         return $visitor->visitDebugRule($this);
     }
+
+    public function __toString(): string
+    {
+        return '@debug ' . $this->expression . ';';
+    }
 }

--- a/src/Ast/Sass/Statement/Declaration.php
+++ b/src/Ast/Sass/Statement/Declaration.php
@@ -120,4 +120,24 @@ final class Declaration extends ParentStatement
     {
         return $visitor->visitDeclaration($this);
     }
+
+    public function __toString(): string
+    {
+        $buffer = $this->name . ':';
+
+        if ($this->value !== null) {
+            if (!$this->isCustomProperty()) {
+                $buffer .= ' ';
+            }
+            $buffer .= $this->value;
+        }
+
+        $children = $this->getChildren();
+
+        if ($children === null) {
+            return $buffer . ';';
+        }
+
+        return $buffer . '{' . implode(' ', $children) . '}';
+    }
 }

--- a/src/Ast/Sass/Statement/EachRule.php
+++ b/src/Ast/Sass/Statement/EachRule.php
@@ -80,4 +80,9 @@ final class EachRule extends ParentStatement
     {
         return $visitor->visitEachRule($this);
     }
+
+    public function __toString(): string
+    {
+        return '@each ' . implode(', ', array_map(function ($variable) { return '$' . $variable; }, $this->variables)) . ' in ' . $this->list . ' {' . implode(' ', $this->getChildren()) . '}';
+    }
 }

--- a/src/Ast/Sass/Statement/ElseClause.php
+++ b/src/Ast/Sass/Statement/ElseClause.php
@@ -19,4 +19,8 @@ namespace ScssPhp\ScssPhp\Ast\Sass\Statement;
  */
 final class ElseClause extends IfRuleClause
 {
+    public function __toString(): string
+    {
+        return '@else {' . implode(' ', $this->getChildren()) . '}';
+    }
 }

--- a/src/Ast/Sass/Statement/ErrorRule.php
+++ b/src/Ast/Sass/Statement/ErrorRule.php
@@ -58,4 +58,9 @@ final class ErrorRule implements Statement
     {
         return $visitor->visitErrorRule($this);
     }
+
+    public function __toString(): string
+    {
+        return '@error ' . $this->expression . ';';
+    }
 }

--- a/src/Ast/Sass/Statement/ExtendRule.php
+++ b/src/Ast/Sass/Statement/ExtendRule.php
@@ -76,4 +76,9 @@ final class ExtendRule implements Statement
     {
         return $visitor->visitExtendRule($this);
     }
+
+    public function __toString(): string
+    {
+        return '@extend ' . $this->selector . ($this->optional ? ' !optional' : '') . ';';
+    }
 }

--- a/src/Ast/Sass/Statement/ForRule.php
+++ b/src/Ast/Sass/Statement/ForRule.php
@@ -103,4 +103,9 @@ final class ForRule extends ParentStatement
     {
         return $visitor->visitForRule($this);
     }
+
+    public function __toString(): string
+    {
+        return '@for $' . $this->variable . ' from ' . $this->from . ($this->exclusive ? ' to ' : ' through ') . $this->to . '{' . implode(' ', $this->getChildren()) . '}';
+    }
 }

--- a/src/Ast/Sass/Statement/FunctionRule.php
+++ b/src/Ast/Sass/Statement/FunctionRule.php
@@ -35,4 +35,9 @@ final class FunctionRule extends CallableDeclaration implements SassDeclaration
     {
         return $visitor->visitFunctionRule($this);
     }
+
+    public function __toString(): string
+    {
+        return '@function ' . $this->getName() . '(' . $this->getArguments() . ') {' . implode(' ', $this->getChildren()) . '}';
+    }
 }

--- a/src/Ast/Sass/Statement/IfRule.php
+++ b/src/Ast/Sass/Statement/IfRule.php
@@ -88,4 +88,19 @@ final class IfRule implements Statement
     {
         return $visitor->visitIfRule($this);
     }
+
+    public function __toString(): string
+    {
+        $parts = [];
+
+        foreach ($this->clauses as $index => $clause) {
+            $parts[] = ($index === 0 ? '@if ' : '@else if ') . $clause->getExpression() . '{' . implode(' ', $clause->getChildren()) . '}';
+        }
+
+        if ($this->lastClause !== null) {
+            $parts[] = $this->lastClause;
+        }
+
+        return implode(' ', $parts);
+    }
 }

--- a/src/Ast/Sass/Statement/ImportRule.php
+++ b/src/Ast/Sass/Statement/ImportRule.php
@@ -62,4 +62,9 @@ final class ImportRule implements Statement
     {
         return $visitor->visitImportRule($this);
     }
+
+    public function __toString(): string
+    {
+        return '@import ' . implode(', ', $this->imports) . ';';
+    }
 }

--- a/src/Ast/Sass/Statement/IncludeRule.php
+++ b/src/Ast/Sass/Statement/IncludeRule.php
@@ -119,4 +119,22 @@ final class IncludeRule implements Statement, CallableInvocation, SassReference
     {
         return $visitor->visitIncludeRule($this);
     }
+
+    public function __toString(): string
+    {
+        $buffer = '@include ';
+
+        if ($this->namespace !== null) {
+            $buffer .= $this->namespace . '.';
+        }
+        $buffer .= $this->name;
+
+        if (!$this->arguments->isEmpty()) {
+            $buffer .= "($this->arguments)";
+        }
+
+        $buffer .= $this->content === null ? ';' : ' ' . $this->content;
+
+        return $buffer;
+    }
 }

--- a/src/Ast/Sass/Statement/LoudComment.php
+++ b/src/Ast/Sass/Statement/LoudComment.php
@@ -49,4 +49,9 @@ final class LoudComment implements Statement
     {
         return $visitor->visitLoudComment($this);
     }
+
+    public function __toString(): string
+    {
+        return (string) $this->text;
+    }
 }

--- a/src/Ast/Sass/Statement/MediaRule.php
+++ b/src/Ast/Sass/Statement/MediaRule.php
@@ -67,4 +67,9 @@ final class MediaRule extends ParentStatement
     {
         return $visitor->visitMediaRule($this);
     }
+
+    public function __toString(): string
+    {
+        return '@media ' . $this->query . ' {' . implode(' ', $this->getChildren()) . '}';
+    }
 }

--- a/src/Ast/Sass/Statement/MixinRule.php
+++ b/src/Ast/Sass/Statement/MixinRule.php
@@ -65,4 +65,17 @@ final class MixinRule extends CallableDeclaration implements SassDeclaration
     {
         return $visitor->visitMixinRule($this);
     }
+
+    public function __toString(): string
+    {
+        $buffer = '@mixin ' . $this->getName();
+
+        if (!$this->getArguments()->isEmpty()) {
+            $buffer .= "({$this->getArguments()})";
+        }
+
+        $buffer .= ' {' . implode(' ', $this->getChildren()) . '}';
+
+        return $buffer;
+    }
 }

--- a/src/Ast/Sass/Statement/ReturnRule.php
+++ b/src/Ast/Sass/Statement/ReturnRule.php
@@ -58,4 +58,9 @@ final class ReturnRule implements Statement
     {
         return $visitor->visitReturnRule($this);
     }
+
+    public function __toString(): string
+    {
+        return '@return ' . $this->expression . ';';
+    }
 }

--- a/src/Ast/Sass/Statement/SilentComment.php
+++ b/src/Ast/Sass/Statement/SilentComment.php
@@ -55,4 +55,9 @@ final class SilentComment implements Statement
     {
         return $visitor->visitSilentComment($this);
     }
+
+    public function __toString(): string
+    {
+        return $this->text;
+    }
 }

--- a/src/Ast/Sass/Statement/StyleRule.php
+++ b/src/Ast/Sass/Statement/StyleRule.php
@@ -69,4 +69,9 @@ final class StyleRule extends ParentStatement
     {
         return $visitor->visitStyleRule($this);
     }
+
+    public function __toString(): string
+    {
+        return $this->selector . ' {' . implode(' ', $this->getChildren()) . '}';
+    }
 }

--- a/src/Ast/Sass/Statement/Stylesheet.php
+++ b/src/Ast/Sass/Statement/Stylesheet.php
@@ -118,4 +118,9 @@ final class Stylesheet extends ParentStatement
     {
         return (new CssParser($contents, $logger, $sourceUrl))->parse();
     }
+
+    public function __toString(): string
+    {
+        return implode(' ', $this->getChildren());
+    }
 }

--- a/src/Ast/Sass/Statement/SupportsRule.php
+++ b/src/Ast/Sass/Statement/SupportsRule.php
@@ -62,4 +62,9 @@ final class SupportsRule extends ParentStatement
     {
         return $visitor->visitSupportsRule($this);
     }
+
+    public function __toString(): string
+    {
+        return '@supports ' . $this->condition . ' {' . implode(' ', $this->getChildren()) . '}';
+    }
 }

--- a/src/Ast/Sass/Statement/VariableDeclaration.php
+++ b/src/Ast/Sass/Statement/VariableDeclaration.php
@@ -147,4 +147,15 @@ final class VariableDeclaration implements Statement, SassDeclaration
     {
         return $visitor->visitVariableDeclaration($this);
     }
+
+    public function __toString(): string
+    {
+        $buffer = '';
+        if ($this->namespace !== null) {
+            $buffer .= $this->namespace . '.';
+        }
+        $buffer .= "\$$this->name: $this->expression;";
+
+        return $buffer;
+    }
 }

--- a/src/Ast/Sass/Statement/WarnRule.php
+++ b/src/Ast/Sass/Statement/WarnRule.php
@@ -58,4 +58,9 @@ final class WarnRule implements Statement
     {
         return $visitor->visitWarnRule($this);
     }
+
+    public function __toString(): string
+    {
+        return '@warn ' . $this->expression . ';';
+    }
 }

--- a/src/Ast/Sass/Statement/WhileRule.php
+++ b/src/Ast/Sass/Statement/WhileRule.php
@@ -65,4 +65,9 @@ final class WhileRule extends ParentStatement
     {
         return $visitor->visitWhileRule($this);
     }
+
+    public function __toString(): string
+    {
+        return '@while ' . $this->condition . ' {' . implode(' ', $this->getChildren()) . '}';
+    }
 }

--- a/src/Ast/Sass/SupportsCondition/SupportsAnything.php
+++ b/src/Ast/Sass/SupportsCondition/SupportsAnything.php
@@ -53,4 +53,9 @@ final class SupportsAnything implements SupportsCondition
     {
         return $this->span;
     }
+
+    public function __toString(): string
+    {
+        return "($this->contents)";
+    }
 }

--- a/src/Ast/Sass/SupportsCondition/SupportsDeclaration.php
+++ b/src/Ast/Sass/SupportsCondition/SupportsDeclaration.php
@@ -83,4 +83,9 @@ final class SupportsDeclaration implements SupportsCondition
     {
         return $this->name instanceof StringExpression && !$this->name->hasQuotes() && StringUtil::startsWith($this->name->getText()->getInitialPlain(), '--');
     }
+
+    public function __toString(): string
+    {
+        return "($this->name: $this->value)";
+    }
 }

--- a/src/Ast/Sass/SupportsCondition/SupportsFunction.php
+++ b/src/Ast/Sass/SupportsCondition/SupportsFunction.php
@@ -66,4 +66,9 @@ final class SupportsFunction implements SupportsCondition
     {
         return $this->span;
     }
+
+    public function __toString(): string
+    {
+        return "$this->name($this->arguments)";
+    }
 }

--- a/src/Ast/Sass/SupportsCondition/SupportsInterpolation.php
+++ b/src/Ast/Sass/SupportsCondition/SupportsInterpolation.php
@@ -52,4 +52,9 @@ final class SupportsInterpolation implements SupportsCondition
     {
         return $this->span;
     }
+
+    public function __toString(): string
+    {
+        return '#{' . $this->expression . '}';
+    }
 }

--- a/src/Ast/Sass/SupportsCondition/SupportsNegation.php
+++ b/src/Ast/Sass/SupportsCondition/SupportsNegation.php
@@ -51,4 +51,13 @@ final class SupportsNegation implements SupportsCondition
     {
         return $this->span;
     }
+
+    public function __toString(): string
+    {
+        if ($this->condition instanceof SupportsNegation || $this->condition instanceof SupportsOperation) {
+            return "not ($this->condition)";
+        }
+
+        return 'not ' . $this->condition;
+    }
 }

--- a/src/Ast/Sass/SupportsCondition/SupportsOperation.php
+++ b/src/Ast/Sass/SupportsCondition/SupportsOperation.php
@@ -77,4 +77,18 @@ final class SupportsOperation implements SupportsCondition
     {
         return $this->span;
     }
+
+    public function __toString(): string
+    {
+        return $this->parenthesize($this->left) . ' ' . $this->operator . ' ' . $this->parenthesize($this->right);
+    }
+
+    private function parenthesize(SupportsCondition $condition): string
+    {
+        if ($condition instanceof SupportsNegation || $condition instanceof SupportsOperation && $condition->operator === $this->operator) {
+            return "($condition)";
+        }
+
+        return (string) $condition;
+    }
 }


### PR DESCRIPTION
I initially omitted that string representation when porting the AST, thinking it was only about providing a better debugging experience. But I was wrong. The evaluator casts the AST to string to provide recommendations in some deprecation warnings.

As part of that porting work, I went over the string representation of all AST nodes in dart-sass, which made me discover a few issues in their logic (the string representation is not covered by the testsuite, except for cases used by some deprecation warnings in sass-spec, but that's mostly expression nodes). The fixes submitted in https://github.com/sass/dart-sass/pull/1682 are already included in this PR.
