### PR TITLE
Remove support for expressions in StatementSearchVisitor

### DIFF
--- a/src/Ast/Sass/Statement/HasContentVisitor.php
+++ b/src/Ast/Sass/Statement/HasContentVisitor.php
@@ -12,9 +12,6 @@
 
 namespace ScssPhp\ScssPhp\Ast\Sass\Statement;
 
-use ScssPhp\ScssPhp\Ast\Sass\ArgumentInvocation;
-use ScssPhp\ScssPhp\Ast\Sass\Interpolation;
-use ScssPhp\ScssPhp\Ast\Sass\SupportsCondition;
 use ScssPhp\ScssPhp\Visitor\StatementSearchVisitor;
 
 /**
@@ -30,20 +27,5 @@ final class HasContentVisitor extends StatementSearchVisitor
     public function visitContentRule(ContentRule $node): bool
     {
         return true;
-    }
-
-    protected function visitArgumentInvocation(ArgumentInvocation $invocation): ?bool
-    {
-        return null;
-    }
-
-    protected function visitSupportsCondition(SupportsCondition $condition): ?bool
-    {
-        return null;
-    }
-
-    protected function visitInterpolation(Interpolation $interpolation): ?bool
-    {
-        return null;
     }
 }

--- a/src/Visitor/StatementSearchVisitor.php
+++ b/src/Visitor/StatementSearchVisitor.php
@@ -12,12 +12,6 @@
 
 namespace ScssPhp\ScssPhp\Visitor;
 
-use ScssPhp\ScssPhp\Ast\Sass\Argument;
-use ScssPhp\ScssPhp\Ast\Sass\ArgumentInvocation;
-use ScssPhp\ScssPhp\Ast\Sass\Expression;
-use ScssPhp\ScssPhp\Ast\Sass\Import;
-use ScssPhp\ScssPhp\Ast\Sass\Import\StaticImport;
-use ScssPhp\ScssPhp\Ast\Sass\Interpolation;
 use ScssPhp\ScssPhp\Ast\Sass\Statement;
 use ScssPhp\ScssPhp\Ast\Sass\Statement\AtRootRule;
 use ScssPhp\ScssPhp\Ast\Sass\Statement\AtRule;
@@ -47,11 +41,6 @@ use ScssPhp\ScssPhp\Ast\Sass\Statement\SupportsRule;
 use ScssPhp\ScssPhp\Ast\Sass\Statement\VariableDeclaration;
 use ScssPhp\ScssPhp\Ast\Sass\Statement\WarnRule;
 use ScssPhp\ScssPhp\Ast\Sass\Statement\WhileRule;
-use ScssPhp\ScssPhp\Ast\Sass\SupportsCondition;
-use ScssPhp\ScssPhp\Ast\Sass\SupportsCondition\SupportsDeclaration;
-use ScssPhp\ScssPhp\Ast\Sass\SupportsCondition\SupportsInterpolation;
-use ScssPhp\ScssPhp\Ast\Sass\SupportsCondition\SupportsNegation;
-use ScssPhp\ScssPhp\Ast\Sass\SupportsCondition\SupportsOperation;
 
 /**
  * A StatementVisitor whose `visit*` methods default to returning `null`, but
@@ -69,30 +58,16 @@ abstract class StatementSearchVisitor implements StatementVisitor
 {
     public function visitAtRootRule(AtRootRule $node)
     {
-        if ($node->getQuery() !== null) {
-            $result = $this->visitInterpolation($node->getQuery());
-
-            if ($result !== null) {
-                return $result;
-            }
-        }
-
         return $this->visitChildren($node->getChildren());
     }
 
     public function visitAtRule(AtRule $node)
     {
-        $value = $this->visitInterpolation($node->getName());
-
-        if ($node->getValue() !== null) {
-            $value = $value ?? $this->visitInterpolation($node->getValue());
-        }
-
         if ($node->getChildren() !== null) {
-            $value = $value ?? $this->visitChildren($node->getChildren());
+            return $this->visitChildren($node->getChildren());
         }
 
-        return $value;
+        return null;
     }
 
     public function visitContentBlock(ContentBlock $node)
@@ -102,47 +77,41 @@ abstract class StatementSearchVisitor implements StatementVisitor
 
     public function visitContentRule(ContentRule $node)
     {
-        return $this->visitArgumentInvocation($node->getArguments());
+        return null;
     }
 
     public function visitDebugRule(DebugRule $node)
     {
-        return $this->visitExpression($node->getExpression());
+        return null;
     }
 
     public function visitDeclaration(Declaration $node)
     {
-        $value = $this->visitInterpolation($node->getName());
-
-        if ($node->getValue() !== null) {
-            $value = $value ?? $this->visitExpression($node->getValue());
-        }
-
         if ($node->getChildren() !== null) {
-            $value = $value ?? $this->visitChildren($node->getChildren());
+            return $this->visitChildren($node->getChildren());
         }
 
-        return $value;
+        return null;
     }
 
     public function visitEachRule(EachRule $node)
     {
-        return $this->visitExpression($node->getList()) ?? $this->visitChildren($node->getChildren());
+        return $this->visitChildren($node->getChildren());
     }
 
     public function visitErrorRule(ErrorRule $node)
     {
-        return $this->visitExpression($node->getExpression());
+        return null;
     }
 
     public function visitExtendRule(ExtendRule $node)
     {
-        return $this->visitInterpolation($node->getSelector());
+        return null;
     }
 
     public function visitForRule(ForRule $node)
     {
-        return $this->visitExpression($node->getFrom()) ?? $this->visitExpression($node->getTo()) ?? $this->visitChildren($node->getChildren());
+        return $this->visitChildren($node->getChildren());
     }
 
     public function visitFunctionRule(FunctionRule $node)
@@ -153,11 +122,15 @@ abstract class StatementSearchVisitor implements StatementVisitor
     public function visitIfRule(IfRule $node)
     {
         $value = $this->searchIterable($node->getClauses(), function (IfClause $clause) {
-            return $this->visitExpression($clause->getExpression()) ?? $this->visitChildren($clause->getChildren());
+            return $this->searchIterable($clause->getChildren(), function (Statement $child) {
+                return $child->accept($this);
+            });
         });
 
         if ($node->getLastClause() !== null) {
-            $value = $value ?? $this->visitChildren($node->getLastClause()->getChildren());
+            $value = $value ?? $this->searchIterable($node->getLastClause()->getChildren(), function (Statement $child) {
+                return $child->accept($this);
+            });
         }
 
         return $value;
@@ -165,33 +138,11 @@ abstract class StatementSearchVisitor implements StatementVisitor
 
     public function visitImportRule(ImportRule $node)
     {
-        return $this->searchIterable($node->getImports(), function (Import $import) {
-            if ($import instanceof StaticImport) {
-                $value = $this->visitInterpolation($import->getUrl());
-
-                if ($import->getSupports() !== null) {
-                    $value = $value ?? $this->visitSupportsCondition($import->getSupports());
-                }
-
-                if ($import->getMedia() !== null) {
-                    $value = $value ?? $this->visitInterpolation($import->getMedia());
-                }
-
-                return $value;
-            }
-
-            return null;
-        });
+        return null;
     }
 
     public function visitIncludeRule(IncludeRule $node)
     {
-        $value = $this->visitArgumentInvocation($node->getArguments());
-
-        if ($value !== null) {
-            return $value;
-        }
-
         if ($node->getContent() !== null) {
             return $this->visitContentBlock($node->getContent());
         }
@@ -201,12 +152,12 @@ abstract class StatementSearchVisitor implements StatementVisitor
 
     public function visitLoudComment(LoudComment $node)
     {
-        return $this->visitInterpolation($node->getText());
+        return null;
     }
 
     public function visitMediaRule(MediaRule $node)
     {
-        return $this->visitInterpolation($node->getQuery()) ?? $this->visitChildren($node->getChildren());
+        return $this->visitChildren($node->getChildren());
     }
 
     public function visitMixinRule(MixinRule $node)
@@ -216,7 +167,7 @@ abstract class StatementSearchVisitor implements StatementVisitor
 
     public function visitReturnRule(ReturnRule $node)
     {
-        return $this->visitExpression($node->getExpression());
+        return null;
     }
 
     public function visitSilentComment(SilentComment $node)
@@ -226,7 +177,7 @@ abstract class StatementSearchVisitor implements StatementVisitor
 
     public function visitStyleRule(StyleRule $node)
     {
-        return $this->visitInterpolation($node->getSelector()) ?? $this->visitChildren($node->getChildren());
+        return $this->visitChildren($node->getChildren());
     }
 
     public function visitStylesheet(Stylesheet $node)
@@ -236,22 +187,22 @@ abstract class StatementSearchVisitor implements StatementVisitor
 
     public function visitSupportsRule(SupportsRule $node)
     {
-        return $this->visitSupportsCondition($node->getCondition()) ?? $this->visitChildren($node->getChildren());
+        return $this->visitChildren($node->getChildren());
     }
 
     public function visitVariableDeclaration(VariableDeclaration $node)
     {
-        return $this->visitExpression($node->getExpression());
+        return null;
     }
 
     public function visitWarnRule(WarnRule $node)
     {
-        return $this->visitExpression($node->getExpression());
+        return null;
     }
 
     public function visitWhileRule(WhileRule $node)
     {
-        return $this->visitExpression($node->getCondition()) ?? $this->visitChildren($node->getChildren());
+        return $this->visitChildren($node->getChildren());
     }
 
     /**
@@ -264,74 +215,7 @@ abstract class StatementSearchVisitor implements StatementVisitor
      */
     protected function visitCallableDeclaration(CallableDeclaration $node)
     {
-        return $this->searchIterable($node->getArguments()->getArguments(), function (Argument $argument) {
-            if ($argument->getDefaultValue() === null) {
-                return null;
-            }
-
-            return $this->visitExpression($argument->getDefaultValue());
-        }) ?? $this->visitChildren($node->getChildren());
-    }
-
-    /**
-     * Visits each expression in an invocation.
-     *
-     * The default implementation of the visit methods calls this to visit any
-     * argument invocation in a statement.
-     *
-     * @return T|null
-     */
-    protected function visitArgumentInvocation(ArgumentInvocation $invocation)
-    {
-        $value = $this->searchIterable($invocation->getPositional(), [$this, 'visitExpression'])
-            ?? $this->searchIterable($invocation->getNamed(), [$this, 'visitExpression']);
-
-        if ($value !== null) {
-            return $value;
-        }
-
-        if ($invocation->getRest() !== null) {
-            $value = $this->visitExpression($invocation->getRest());
-
-            if ($value !== null) {
-                return $value;
-            }
-        }
-
-        if ($invocation->getKeywordRest() !== null) {
-            return $this->visitExpression($invocation->getKeywordRest());
-        }
-
-        return null;
-    }
-
-    /**
-     * Visits each expression in $condition.
-     *
-     * The default implementation of the visit methods call this to visit any
-     * {@see SupportsCondition} they encounter.
-     *
-     * @return T|null
-     */
-    protected function visitSupportsCondition(SupportsCondition $condition)
-    {
-        if ($condition instanceof SupportsOperation) {
-            return $this->visitSupportsCondition($condition->getLeft()) ?? $this->visitSupportsCondition($condition->getRight());
-        }
-
-        if ($condition instanceof SupportsNegation) {
-            return $this->visitSupportsCondition($condition->getCondition());
-        }
-
-        if ($condition instanceof SupportsInterpolation) {
-            return $this->visitExpression($condition->getExpression());
-        }
-
-        if ($condition instanceof SupportsDeclaration) {
-            return $this->visitExpression($condition->getName()) ?? $this->visitExpression($condition->getValue());
-        }
-
-        return null;
+        return $this->visitChildren($node->getChildren());
     }
 
     /**
@@ -354,39 +238,6 @@ abstract class StatementSearchVisitor implements StatementVisitor
             }
         }
 
-        return null;
-    }
-
-    /**
-     * Visits each expression in an interpolation.
-     *
-     * The default implementation of the visit methods call this to visit any
-     * interpolation in a statement.
-     *
-     * @return T|null
-     */
-    protected function visitInterpolation(Interpolation $interpolation)
-    {
-        foreach ($interpolation->getContents() as $node) {
-            if ($node instanceof Expression) {
-                $result = $this->visitExpression($node);
-
-                if ($result !== null) {
-                    return $result;
-                }
-            }
-        }
-
-        return null;
-    }
-
-    /**
-     * Visits an expression
-     *
-     * @return T|null
-     */
-    protected function visitExpression(Expression $expression)
-    {
         return null;
     }
 


### PR DESCRIPTION
This support has been removed in dart-sass as it was not necessary.