### PR TITLE
fix: php8.2 var in string deprecation

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -3544,11 +3544,11 @@ EOL;
                 // 1. op[op name][left type][right type]
                 // 2. op[left type][right type] (passing the op as first arg)
                 // 3. op[op name]
-                if (\is_callable([$this, $fn = "op${ucOpName}${ucLType}${ucRType}"])) {
+                if (\is_callable([$this, $fn = "op{$ucOpName}{$ucLType}{$ucRType}"])) {
                     $out = $this->$fn($left, $right, $shouldEval);
-                } elseif (\is_callable([$this, $fn = "op${ucLType}${ucRType}"])) {
+                } elseif (\is_callable([$this, $fn = "op{$ucLType}{$ucRType}"])) {
                     $out = $this->$fn($op, $left, $right, $shouldEval);
-                } elseif (\is_callable([$this, $fn = "op${ucOpName}"])) {
+                } elseif (\is_callable([$this, $fn = "op{$ucOpName}"])) {
                     $out = $this->$fn($left, $right, $shouldEval);
                 } else {
                     $out = null;


### PR DESCRIPTION
Found this while preparing local project for PHP 8.2

Deprecated: Using ${var} in strings is deprecated, use {$var} instead in ./src/Compiler.php on line 3401

Deprecated: Using ${var} in strings is deprecated, use {$var} instead in ./src/Compiler.php on line 3401

Deprecated: Using ${var} in strings is deprecated, use {$var} instead in ./src/Compiler.php on line 3401

Deprecated: Using ${var} in strings is deprecated, use {$var} instead in ./src/Compiler.php on line 3403

Deprecated: Using ${var} in strings is deprecated, use {$var} instead in ./src/Compiler.php on line 3403

Deprecated: Using ${var} in strings is deprecated, use {$var} instead in ./src/Compiler.php on line 3405