### PR TITLE
Use new recommended config for bamarni-bin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,4 +81,4 @@ jobs:
                 run: composer bin phpstan update --ansi --no-progress
 
             -   name: Run phpstan
-                run: vendor/bin/phpstan analyse --ansi --no-progress
+                run: vendor-bin/phpstan/vendor/bin/phpstan analyse --ansi --no-progress

--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,10 @@ vendor: composer.json
 	touch $@
 
 phpstan: vendor-bin/phpstan/vendor
-	vendor/bin/phpstan analyse
+	vendor-bin/phpstan/vendor/bin/phpstan analyse
 
 phpstan-baseline: vendor-bin/phpstan/vendor
-	vendor/bin/phpstan analyse --generate-baseline
+	vendor-bin/phpstan/vendor/bin/phpstan analyse --generate-baseline
 
 vendor-bin/phpstan/vendor: vendor vendor-bin/phpstan/composer.json
 	composer bin phpstan update

--- a/composer.json
+++ b/composer.json
@@ -107,5 +107,11 @@
         "allow-plugins": {
             "bamarni/composer-bin-plugin": true
         }
+    },
+    "extra": {
+        "bamarni-bin": {
+            "forward-command": false,
+            "bin-links": false
+        }
     }
 }


### PR DESCRIPTION
This does not link binaries to the root location anymore (no change when using the Makefile as it abstracts it).

`forward-command` is left disabled as we don't want to run it on non-phpstan jobs.