### PR TITLE
Assert that `$n` is an integer for `nth($list, $n)` and `set-nth($list, $n, $value)`

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -8769,7 +8769,7 @@ will be an error in future versions of Sass.\n         on line $line of $fname";
     protected function libNth($args)
     {
         $list = $this->coerceList($args[0], ',', false);
-        $n = $this->assertNumber($args[1])->getDimension();
+        $n = $this->assertInteger($args[1]);
 
         if ($n > 0) {
             $n--;
@@ -8784,7 +8784,7 @@ will be an error in future versions of Sass.\n         on line $line of $fname";
     protected function libSetNth($args)
     {
         $list = $this->coerceList($args[0]);
-        $n = $this->assertNumber($args[1])->getDimension();
+        $n = $this->assertInteger($args[1]);
 
         if ($n > 0) {
             $n--;

--- a/tests/ExceptionTest.php
+++ b/tests/ExceptionTest.php
@@ -132,6 +132,24 @@ END_OF_SCSS
                 ,
                 'file not found for @import'
             ],
+            [<<<'END_OF_SCSS'
+.test {
+    $list: 1, 2, 3;
+    value: nth($list, 1.5);
+}
+END_OF_SCSS
+                ,
+                '1.5 is not an integer.'
+            ],
+            [<<<'END_OF_SCSS'
+.test {
+    $list: 1, 2, 3;
+    $new-list: set-nth($list, 1.5, 5);
+}
+END_OF_SCSS
+                ,
+                '1.5 is not an integer.'
+            ],
         ];
     }
 


### PR DESCRIPTION
In PHP 8.1 implicit conversions from floats to integers trigger a deprecation warning.
The change from `assertNumber()` to `assertInteger()` falls in line with the behavior of Dart Sass, which throws an exception if the index isn't a number, if that number isn't an integer, or if that integer isn't a valid index for the given list.
See [list.dart](https://github.com/sass/dart-sass/blob/bc8df44f6a681223d450abdd89013a61bfe90e9f/lib/src/functions/list.dart#L32) and [value.dart](https://github.com/sass/dart-sass/blob/bc8df44f6a681223d450abdd89013a61bfe90e9f/lib/src/value.dart#L118-L120).
I’ve also added two simple test cases.

Current behavior:
-----------------------
Test files:
```scss
.test {
    $list: 1, 2, 3;
    value: nth($list, 1.5);
}
```
```scss
.test {
    $list: 1, 2, 3;
    $new-list: set-nth($list, 1.5, 5);
}
```
Result:
```
[max@/t/scssphp (master)]php -r 'echo(phpversion());'
8.1.8⏎
[max@/t/scssphp (master)]bin/pscss test.scss
[27-Jul-2022 01:44:37 Europe/Berlin] PHP Deprecated:  Implicit conversion from float 0.5 to int loses precision in /tmp/scssphp/src/Compiler.php on line 8143

Deprecated: Implicit conversion from float 0.5 to int loses precision in /tmp/scssphp/src/Compiler.php on line 8143
[27-Jul-2022 01:44:37 Europe/Berlin] PHP Deprecated:  Implicit conversion from float 0.5 to int loses precision in /tmp/scssphp/src/Compiler.php on line 8143

Deprecated: Implicit conversion from float 0.5 to int loses precision in /tmp/scssphp/src/Compiler.php on line 8143
.test {
  value: 1;
}
[max@/t/scssphp (master)]bin/pscss test2.scss
[27-Jul-2022 01:44:40 Europe/Berlin] PHP Deprecated:  Implicit conversion from float 0.5 to int loses precision in /tmp/scssphp/src/Compiler.php on line 8158

Deprecated: Implicit conversion from float 0.5 to int loses precision in /tmp/scssphp/src/Compiler.php on line 8158
[27-Jul-2022 01:44:40 Europe/Berlin] PHP Deprecated:  Implicit conversion from float 0.5 to int loses precision in /tmp/scssphp/src/Compiler.php on line 8162

Deprecated: Implicit conversion from float 0.5 to int loses precision in /tmp/scssphp/src/Compiler.php on line 8162
```

```
[max@/t/scssphp (master)]vendor/bin/phpunit tests
[…]
Time: 00:23.598, Memory: 102.00 MB

OK, but incomplete, skipped, or risky tests!
Tests: 7645, Assertions: 7884, Skipped: 2942.
```

With the changes applied:
----------------------------------

```
[max@/t/scssphp (fix-nth-implicit-conversion)]bin/pscss test.scss
Error: 1.5 is not an integer.: test.scss on line 3, at column 5
[max@/t/scssphp (fix-nth-implicit-conversion) [1]]bin/pscss test2.scss
Error: 1.5 is not an integer.: test2.scss on line 3, at column 5
[max@/t/scssphp (fix-nth-implicit-conversion) [1]] 
```

```
[max@/t/scssphp (fix-nth-implicit-conversion)]vendor/bin/phpunit tests
[…]
Time: 00:23.699, Memory: 102.00 MB

OK, but incomplete, skipped, or risky tests!
Tests: 7647, Assertions: 7888, Skipped: 2942.
```