### PR TITLE
Validate the import URI in the new parser

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,10 @@
     },
     "require": {
         "php": ">=7.2",
+        "ext-ctype": "*",
         "ext-json": "*",
-        "ext-ctype": "*"
+        "league/uri": "^6.4.0",
+        "league/uri-interfaces": "^2.3"
     },
     "suggest": {
         "ext-mbstring": "For best performance, mbstring should be installed as it is faster than ext-iconv",

--- a/src/Parser/FormatException.php
+++ b/src/Parser/FormatException.php
@@ -25,10 +25,10 @@ final class FormatException extends \Exception
      */
     private $span;
 
-    public function __construct(string $message, FileSpan $span)
+    public function __construct(string $message, FileSpan $span, ?\Throwable $previous = null)
     {
         $this->span = $span;
-        parent::__construct($message);
+        parent::__construct($message, 0, $previous);
     }
 
     public function getSpan(): FileSpan

--- a/src/Parser/Parser.php
+++ b/src/Parser/Parser.php
@@ -897,9 +897,9 @@ class Parser
      *
      * @return never-returns
      */
-    protected function error(string $message, FileSpan $span): void
+    protected function error(string $message, FileSpan $span, ?\Throwable $previous = null): void
     {
-        throw new FormatException($message, $span);
+        throw new FormatException($message, $span, $previous);
     }
 
     protected function wrapException(FormatException $error): SassFormatException

--- a/src/Util/Path.php
+++ b/src/Util/Path.php
@@ -22,8 +22,26 @@ final class Path
             return true;
         }
 
-        if (\DIRECTORY_SEPARATOR !== '\\') {
+        if (\DIRECTORY_SEPARATOR === '\\') {
+            return self::isWindowsAbsolute($path);
+        }
+
+        return false;
+    }
+
+    /**
+     * @param string $path
+     *
+     * @return bool
+     */
+    public static function isWindowsAbsolute(string $path): bool
+    {
+        if ($path === '') {
             return false;
+        }
+
+        if ($path[0] === '/') {
+            return true;
         }
 
         if ($path[0] === '\\') {

--- a/tests/Util/PathTest.php
+++ b/tests/Util/PathTest.php
@@ -8,32 +8,75 @@ use PHPUnit\Framework\TestCase;
 class PathTest extends TestCase
 {
     /**
-     * @dataProvider provideAbsoluteCases
+     * @dataProvider provideCommonAbsolutePaths
      */
-    public function testAbsolute($path, $expected)
+    public function testAbsolutePath(string $path)
     {
-        $this->assertSame($expected, Path::isAbsolute($path));
+        $this->assertTrue(Path::isAbsolute($path));
     }
 
-    public static function provideAbsoluteCases()
+    /**
+     * @dataProvider provideCommonNonAbsolutePaths
+     */
+    public function testNonAbsolutePath(string $path)
     {
-        yield ['', false];
-        yield ['.', false];
-        yield ['..', false];
-        yield ['~', false];
-        yield ['/', true];
-        yield ['/a', true];
-        yield ['a/b', false];
-        yield ['\\', \DIRECTORY_SEPARATOR === '\\'];
-        yield ['\\\\share\a', \DIRECTORY_SEPARATOR === '\\'];
-        yield ['c:\\', \DIRECTORY_SEPARATOR === '\\'];
-        yield ['c:\\a', \DIRECTORY_SEPARATOR === '\\'];
-        yield ['c:/a', \DIRECTORY_SEPARATOR === '\\'];
-        yield ['d:/', \DIRECTORY_SEPARATOR === '\\'];
-        yield ['c:', false];
-        yield ['cd:/a', false];
-        yield ['cd/a', false];
-        yield ['cd\\a', false];
+        $this->assertFalse(Path::isAbsolute($path));
+    }
+    /**
+     * @dataProvider provideWindowsOnlyAbsolutePath
+     */
+    public function testWindowsOnlyAbsolutePath(string $path)
+    {
+        $this->assertSame(\DIRECTORY_SEPARATOR === '\\', Path::isAbsolute($path));
+    }
+
+    /**
+     * @dataProvider provideCommonAbsolutePaths
+     * @dataProvider provideWindowsOnlyAbsolutePath
+     */
+    public function testWindowsAbsolutePath(string $path)
+    {
+        $this->assertTrue(Path::isWindowsAbsolute($path));
+    }
+
+    /**
+     * @dataProvider provideCommonNonAbsolutePaths
+     */
+    public function testWindowsNonAbsolutePath(string $path)
+    {
+        $this->assertFalse(Path::isWindowsAbsolute($path));
+    }
+
+    public static function provideCommonAbsolutePaths()
+    {
+        yield ['/'];
+        yield ['/a'];
+    }
+
+    public static function provideCommonNonAbsolutePaths()
+    {
+        yield [''];
+        yield ['.'];
+        yield ['..'];
+        yield ['~'];
+        yield ['a/b'];
+        yield ['c:'];
+        yield ['cd:/a'];
+        yield ['c::/a'];
+        yield ['cd/a'];
+        yield ['cd\\a'];
+        yield ['$:/a'];
+        yield ['$:\\a'];
+    }
+
+    public static function provideWindowsOnlyAbsolutePath()
+    {
+        yield ['\\'];
+        yield ['\\\\share\a'];
+        yield ['c:\\'];
+        yield ['c:\\a'];
+        yield ['c:/a'];
+        yield ['d:/'];
     }
 
     /**


### PR DESCRIPTION
This introduces the dependency on `league/uri` (as decided in #505).

For now, this is not used a lot yet. But one of my next task is to work on the importer system, which will rely on it a lot.