### PR TITLE
Consistently use floating point numbers

### DIFF
--- a/src/Ast/Sass/Expression/NumberExpression.php
+++ b/src/Ast/Sass/Expression/NumberExpression.php
@@ -14,6 +14,7 @@ namespace ScssPhp\ScssPhp\Ast\Sass\Expression;
 
 use ScssPhp\ScssPhp\Ast\Sass\Expression;
 use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+use ScssPhp\ScssPhp\Value\SassNumber;
 use ScssPhp\ScssPhp\Visitor\ExpressionVisitor;
 
 /**
@@ -24,7 +25,7 @@ use ScssPhp\ScssPhp\Visitor\ExpressionVisitor;
 final class NumberExpression implements Expression
 {
     /**
-     * @var float|int
+     * @var float
      * @readonly
      */
     private $value;
@@ -41,20 +42,14 @@ final class NumberExpression implements Expression
      */
     private $unit;
 
-    /**
-     * @param int|float $value
-     */
-    public function __construct($value, FileSpan $span, ?string $unit = null)
+    public function __construct(float $value, FileSpan $span, ?string $unit = null)
     {
         $this->value = $value;
         $this->span = $span;
         $this->unit = $unit;
     }
 
-    /**
-     * @return float|int
-     */
-    public function getValue()
+    public function getValue(): float
     {
         return $this->value;
     }
@@ -76,6 +71,6 @@ final class NumberExpression implements Expression
 
     public function __toString(): string
     {
-        return $this->value . ($this->unit ?? '');
+        return (string) SassNumber::create($this->value, $this->unit);
     }
 }

--- a/src/Parser/Parser.php
+++ b/src/Parser/Parser.php
@@ -337,11 +337,11 @@ class Parser
     }
 
     /**
-     * Consumes and returns a natural number (that is, a non-negative integer).
+     * Consumes and returns a natural number (that is, a non-negative integer) as a double.
      *
      * Doesn't support scientific notation.
      */
-    protected function naturalNumber(): int
+    protected function naturalNumber(): float
     {
         $first = $this->scanner->readChar();
 
@@ -349,16 +349,14 @@ class Parser
             $this->scanner->error('Expected digit.', $this->scanner->getPosition() - 1);
         }
 
-        $number = $first;
+        $number = (float) intval($first);
 
-        $next = $this->scanner->peekChar();
-
-        while ($next !== null && Character::isDigit($next)) {
-            $number .= $this->scanner->readChar();
-            $next = $this->scanner->peekChar();
+        while (Character::isDigit($this->scanner->peekChar())) {
+            $number *= 10;
+            $number += intval($this->scanner->readChar());
         }
 
-        return intval($number);
+        return $number;
     }
 
     /**

--- a/src/Serializer/SerializeVisitor.php
+++ b/src/Serializer/SerializeVisitor.php
@@ -13,13 +13,11 @@
 namespace ScssPhp\ScssPhp\Serializer;
 
 use ScssPhp\ScssPhp\Ast\AstNode;
-use ScssPhp\ScssPhp\Ast\Css\CssAtRule;
 use ScssPhp\ScssPhp\Ast\Css\CssComment;
 use ScssPhp\ScssPhp\Ast\Css\CssDeclaration;
 use ScssPhp\ScssPhp\Ast\Css\CssMediaQuery;
 use ScssPhp\ScssPhp\Ast\Css\CssNode;
 use ScssPhp\ScssPhp\Ast\Css\CssParentNode;
-use ScssPhp\ScssPhp\Ast\Css\CssStyleRule;
 use ScssPhp\ScssPhp\Ast\Css\CssValue;
 use ScssPhp\ScssPhp\Ast\Selector\AttributeSelector;
 use ScssPhp\ScssPhp\Ast\Selector\ClassSelector;
@@ -934,9 +932,9 @@ final class SerializeVisitor implements CssVisitor, ValueVisitor, SelectorVisito
      * Writes $number without exponent notation and with at most
      * {@see SassNumber::PRECISION} digits after the decimal point.
      *
-     * @param int|float $number
+     * @param float $number
      */
-    private function writeNumber($number): void
+    private function writeNumber(float $number): void
     {
         if (is_nan($number)) {
             $this->buffer->write('NaN');

--- a/src/Value/ComplexSassNumber.php
+++ b/src/Value/ComplexSassNumber.php
@@ -32,12 +32,12 @@ final class ComplexSassNumber extends SassNumber
     private $denominatorUnits;
 
     /**
-     * @param int|float                          $value
+     * @param float                              $value
      * @param list<string>                       $numeratorUnits
      * @param list<string>                       $denominatorUnits
      * @param array{SassNumber, SassNumber}|null $asSlash
      */
-    public function __construct($value, array $numeratorUnits, array $denominatorUnits, array $asSlash = null)
+    public function __construct(float $value, array $numeratorUnits, array $denominatorUnits, array $asSlash = null)
     {
         assert(\count($numeratorUnits) > 1 || \count($denominatorUnits) > 0);
 
@@ -78,7 +78,7 @@ final class ComplexSassNumber extends SassNumber
         throw new \BadMethodCallException(__METHOD__ . 'is not implemented.');
     }
 
-    protected function withValue($value): SassNumber
+    protected function withValue(float $value): SassNumber
     {
         return new self($value, $this->numeratorUnits, $this->denominatorUnits);
     }

--- a/src/Value/SassColor.php
+++ b/src/Value/SassColor.php
@@ -46,28 +46,28 @@ final class SassColor extends Value
     /**
      * This color's hue, between `0` and `360`.
      *
-     * @var int|float|null
+     * @var float|null
      */
     private $hue;
 
     /**
      * This color's saturation, a percentage between `0` and `100`.
      *
-     * @var int|float|null
+     * @var float|null
      */
     private $saturation;
 
     /**
      * This color's lightness, a percentage between `0` and `100`.
      *
-     * @var int|float|null
+     * @var float|null
      */
     private $lightness;
 
     /**
      * This color's alpha channel, between `0` and `1`.
      *
-     * @var int|float
+     * @var float
      * @readonly
      */
     private $alpha;
@@ -85,13 +85,13 @@ final class SassColor extends Value
      * @param int $red
      * @param int $blue
      * @param int $green
-     * @param int|float|null $alpha
+     * @param float|null $alpha
      *
      * @return SassColor
      *
      * @throws \OutOfRangeException if values are outside the expected range.
      */
-    public static function rgb(int $red, int $green, int $blue, $alpha = null): SassColor
+    public static function rgb(int $red, int $green, int $blue, ?float $alpha = null): SassColor
     {
         return self::rgbInternal($red, $green, $blue, $alpha);
     }
@@ -104,7 +104,7 @@ final class SassColor extends Value
      * @param int $red
      * @param int $blue
      * @param int $green
-     * @param int|float|null $alpha
+     * @param float|null $alpha
      * @param SpanColorFormat|string|null $format
      *
      * @return SassColor
@@ -113,10 +113,10 @@ final class SassColor extends Value
      *
      * @throws \OutOfRangeException if values are outside the expected range.
      */
-    public static function rgbInternal(int $red, int $green, int $blue, $alpha = null, $format = null): SassColor
+    public static function rgbInternal(int $red, int $green, int $blue, ?float $alpha = null, $format = null): SassColor
     {
         if ($alpha === null) {
-            $alpha = 1;
+            $alpha = 1.0;
         } else {
             $alpha = NumberUtil::fuzzyAssertRange($alpha, 0, 1, 'alpha');
         }
@@ -129,16 +129,16 @@ final class SassColor extends Value
     }
 
     /**
-     * @param int|float $hue
-     * @param int|float $saturation
-     * @param int|float $lightness
-     * @param int|float|null $alpha
+     * @param float $hue
+     * @param float $saturation
+     * @param float $lightness
+     * @param float|null $alpha
      *
      * @return SassColor
      *
      * @throws \OutOfRangeException if values are outside the expected range.
      */
-    public static function hsl($hue, $saturation, $lightness, $alpha = null): SassColor
+    public static function hsl(float $hue, float $saturation, float $lightness, ?float $alpha = null): SassColor
     {
         return self::hslInternal($hue, $saturation, $lightness, $alpha);
     }
@@ -148,10 +148,10 @@ final class SassColor extends Value
      *
      * @internal
      *
-     * @param int|float $hue
-     * @param int|float $saturation
-     * @param int|float $lightness
-     * @param int|float|null $alpha
+     * @param float $hue
+     * @param float $saturation
+     * @param float $lightness
+     * @param float|null $alpha
      * @param SpanColorFormat|string|null $format
      *
      * @return SassColor
@@ -160,10 +160,10 @@ final class SassColor extends Value
      *
      * @phpstan-param SpanColorFormat|ColorFormat::*|null $format
      */
-    public static function hslInternal($hue, $saturation, $lightness, $alpha = null, $format = null): SassColor
+    public static function hslInternal(float $hue, float $saturation, float $lightness, ?float $alpha = null, $format = null): SassColor
     {
         if ($alpha === null) {
-            $alpha = 1;
+            $alpha = 1.0;
         } else {
             $alpha = NumberUtil::fuzzyAssertRange($alpha, 0, 1, 'alpha');
         }
@@ -176,14 +176,14 @@ final class SassColor extends Value
     }
 
     /**
-     * @param int|float      $hue
-     * @param int|float      $whiteness
-     * @param int|float      $blackness
-     * @param int|float|null $alpha
+     * @param float      $hue
+     * @param float      $whiteness
+     * @param float      $blackness
+     * @param float|null $alpha
      *
      * @return SassColor
      */
-    public static function hwb($hue, $whiteness, $blackness, $alpha = null): SassColor
+    public static function hwb(float $hue, float $whiteness, float $blackness, ?float $alpha = null): SassColor
     {
         $scaledHue = fmod($hue , 360) / 360;
         $scaledWhiteness = NumberUtil::fuzzyAssertRange($whiteness, 0, 100, 'whiteness') / 100;
@@ -216,15 +216,15 @@ final class SassColor extends Value
      * @param int|null       $red
      * @param int|null       $green
      * @param int|null       $blue
-     * @param int|float|null $hue
-     * @param int|float|null $saturation
-     * @param int|float|null $lightness
-     * @param int|float      $alpha
+     * @param float|null     $hue
+     * @param float|null     $saturation
+     * @param float|null     $lightness
+     * @param float          $alpha
      * @param SpanColorFormat|string|null $format
      *
      * @phpstan-param SpanColorFormat|ColorFormat::*|null $format
      */
-    private function __construct(?int $red, ?int $green, ?int $blue, $hue, $saturation, $lightness, $alpha, $format = null)
+    private function __construct(?int $red, ?int $green, ?int $blue, ?float $hue, ?float $saturation, ?float $lightness, float $alpha, $format = null)
     {
         $this->red = $red;
         $this->green = $green;
@@ -266,10 +266,7 @@ final class SassColor extends Value
         return $this->blue;
     }
 
-    /**
-     * @return int|float
-     */
-    public function getHue()
+    public function getHue(): float
     {
         if (\is_null($this->hue)) {
             $this->rgbToHsl();
@@ -279,10 +276,7 @@ final class SassColor extends Value
         return $this->hue;
     }
 
-    /**
-     * @return int|float
-     */
-    public function getSaturation()
+    public function getSaturation(): float
     {
         if (\is_null($this->saturation)) {
             $this->rgbToHsl();
@@ -292,10 +286,7 @@ final class SassColor extends Value
         return $this->saturation;
     }
 
-    /**
-     * @return int|float
-     */
-    public function getLightness()
+    public function getLightness(): float
     {
         if (\is_null($this->lightness)) {
             $this->rgbToHsl();
@@ -305,26 +296,17 @@ final class SassColor extends Value
         return $this->lightness;
     }
 
-    /**
-     * @return float|int
-     */
-    public function getWhiteness()
+    public function getWhiteness(): float
     {
         return min($this->getRed(), $this->getGreen(), $this->getBlue()) / 255 * 100;
     }
 
-    /**
-     * @return float|int
-     */
-    public function getBlackness()
+    public function getBlackness(): float
     {
         return 100 - max($this->getRed(), $this->getGreen(), $this->getBlue()) / 255 * 100;
     }
 
-    /**
-     * @return int|float
-     */
-    public function getAlpha()
+    public function getAlpha(): float
     {
         return $this->alpha;
     }
@@ -358,47 +340,47 @@ final class SassColor extends Value
      * @param int|null $red
      * @param int|null $green
      * @param int|null $blue
-     * @param int|float|null $alpha
+     * @param float|null $alpha
      *
      * @return SassColor
      */
-    public function changeRgb(?int $red = null, ?int $green = null, ?int $blue = null, $alpha = null): SassColor
+    public function changeRgb(?int $red = null, ?int $green = null, ?int $blue = null, ?float $alpha = null): SassColor
     {
         return self::rgb($red ?? $this->getRed(), $green ?? $this->getGreen(), $blue ?? $this->getBlue(), $alpha ?? $this->alpha);
     }
 
     /**
-     * @param int|float|null $hue
-     * @param int|float|null $saturation
-     * @param int|float|null $lightness
-     * @param int|float|null $alpha
+     * @param float|null $hue
+     * @param float|null $saturation
+     * @param float|null $lightness
+     * @param float|null $alpha
      *
      * @return SassColor
      */
-    public function changeHsl($hue = null, $saturation = null, $lightness = null, $alpha = null): SassColor
+    public function changeHsl(?float $hue = null, ?float $saturation = null, ?float $lightness = null, ?float $alpha = null): SassColor
     {
         return self::hsl($hue ?? $this->getHue(), $saturation ?? $this->getSaturation(), $lightness ?? $this->getLightness(), $alpha ?? $this->alpha);
     }
 
     /**
-     * @param int|float|null $hue
-     * @param int|float|null $whiteness
-     * @param int|float|null $blackness
-     * @param int|float|null $alpha
+     * @param float|null $hue
+     * @param float|null $whiteness
+     * @param float|null $blackness
+     * @param float|null $alpha
      *
      * @return SassColor
      */
-    public function changeHwb($hue = null, $whiteness = null, $blackness = null, $alpha = null): SassColor
+    public function changeHwb(?float $hue = null, ?float $whiteness = null, ?float $blackness = null, ?float $alpha = null): SassColor
     {
         return self::hwb($hue ?? $this->getHue(), $whiteness ?? $this->getWhiteness(), $blackness ?? $this->getBlackness(), $alpha ?? $this->alpha);
     }
 
     /**
-     * @param int|float $alpha
+     * @param float $alpha
      *
      * @return SassColor
      */
-    public function changeAlpha($alpha): SassColor
+    public function changeAlpha(float $alpha): SassColor
     {
         return new self(
             $this->red,
@@ -508,14 +490,7 @@ final class SassColor extends Value
         $this->blue = NumberUtil::fuzzyRound(self::hueToRgb($m1, $m2, $scaledHue - 1 / 3) * 255);
     }
 
-    /**
-     * @param int|float $m1
-     * @param int|float $m2
-     * @param int|float $hue
-     *
-     * @return int|float
-     */
-    private static function hueToRgb($m1, $m2, $hue)
+    private static function hueToRgb(float $m1, float $m2, float $hue): float
     {
         if ($hue < 0) {
             $hue += 1;

--- a/src/Value/SassNumber.php
+++ b/src/Value/SassNumber.php
@@ -33,30 +33,30 @@ abstract class SassNumber extends Value
      */
     private const CONVERSIONS = [
         'in' => [
-            'in' => 1,
-            'pc' => 6,
-            'pt' => 72,
-            'px' => 96,
+            'in' => 1.0,
+            'pc' => 6.0,
+            'pt' => 72.0,
+            'px' => 96.0,
             'cm' => 2.54,
             'mm' => 25.4,
             'q'  => 101.6,
         ],
         'deg' => [
-            'deg'  => 360,
-            'grad' => 400,
-            'rad'  => 6.28318530717958647692528676, // 2 * M_PI
-            'turn' => 1,
+            'deg'  => 360.0,
+            'grad' => 400.0,
+            'rad'  => 2 * M_PI,
+            'turn' => 1.0,
         ],
         's' => [
-            's'  => 1,
-            'ms' => 1000,
+            's'  => 1.0,
+            'ms' => 1000.0,
         ],
         'Hz' => [
-            'Hz'  => 1,
+            'Hz'  => 1.0,
             'kHz' => 0.001,
         ],
         'dpi' => [
-            'dpi'  => 1,
+            'dpi'  => 1.0,
             'dpcm' => 1 / 2.54,
             'dppx' => 1 / 96,
         ],
@@ -99,7 +99,7 @@ abstract class SassNumber extends Value
     ];
 
     /**
-     * @var int|float
+     * @var float
      * @readonly
      */
     private $value;
@@ -114,10 +114,10 @@ abstract class SassNumber extends Value
     private $asSlash;
 
     /**
-     * @param int|float  $value
+     * @param float                              $value
      * @param array{SassNumber, SassNumber}|null $asSlash
      */
-    protected function __construct($value, array $asSlash = null)
+    protected function __construct(float $value, array $asSlash = null)
     {
         $this->value = $value;
         $this->asSlash = $asSlash;
@@ -129,12 +129,12 @@ abstract class SassNumber extends Value
      * This matches the numbers that can be written as literals.
      * {@see SassNumber::withUnits} can be used to construct more complex units.
      *
-     * @param int|float   $value
+     * @param float       $value
      * @param string|null $unit
      *
      * @return self
      */
-    final public static function create($value, ?string $unit = null): SassNumber
+    final public static function create(float $value, ?string $unit = null): SassNumber
     {
         if ($unit === null) {
             return new UnitlessSassNumber($value);
@@ -146,13 +146,13 @@ abstract class SassNumber extends Value
     /**
      * Creates a number with full $numeratorUnits and $denominatorUnits.
      *
-     * @param int|float    $value
+     * @param float        $value
      * @param list<string> $numeratorUnits
      * @param list<string> $denominatorUnits
      *
      * @return self
      */
-    final public static function withUnits($value, array $numeratorUnits = [], array $denominatorUnits = []): SassNumber
+    final public static function withUnits(float $value, array $numeratorUnits = [], array $denominatorUnits = []): SassNumber
     {
         if (empty($numeratorUnits) && empty($denominatorUnits)) {
             return new UnitlessSassNumber($value);
@@ -213,10 +213,8 @@ abstract class SassNumber extends Value
      * float even if $this represents an int from Sass's perspective. Use
      * {@see isInt} to determine whether this is an integer, {@see asInt} to get its
      * integer value, or {@see assertInt} to do both at once.
-     *
-     * @return float|int
      */
-    public function getValue()
+    public function getValue(): float
     {
         return $this->value;
     }
@@ -249,11 +247,11 @@ abstract class SassNumber extends Value
     /**
      * Returns a SassNumber with this value and the same units.
      *
-     * @param int|float $value
+     * @param float $value
      *
      * @return self
      */
-    abstract protected function withValue($value): SassNumber;
+    abstract protected function withValue(float $value): SassNumber;
 
     /**
      * @param SassNumber $numerator
@@ -337,15 +335,15 @@ abstract class SassNumber extends Value
      * came from a function argument, $name is the argument name (without the
      * `$`). It's used for error reporting.
      *
-     * @param int|float   $min
-     * @param int|float   $max
+     * @param float       $min
+     * @param float       $max
      * @param string|null $name
      *
-     * @return int|float
+     * @return float
      *
      * @throws SassScriptException if the value is outside the range
      */
-    public function valueInRange($min, $max, ?string $name = null)
+    public function valueInRange(float $min, float $max, ?string $name = null): float
     {
         $result = NumberUtil::fuzzyCheckRange($this->value, $min, $max);
 
@@ -366,18 +364,18 @@ abstract class SassNumber extends Value
      * and should be removed once https://github.com/sass/sass/issues/3374 fully lands and unitless values
      * are required in these positions.
      *
-     * @param int|float $min
-     * @param int|float $max
-     * @param string    $name
-     * @param string    $unit
+     * @param float  $min
+     * @param float  $max
+     * @param string $name
+     * @param string $unit
      *
-     * @return int|float
+     * @return float
      *
      * @throws SassScriptException if the value is outside the range
      *
      * @internal
      */
-    public function valueInRangeWithUnit($min, $max, string $name, string $unit)
+    public function valueInRangeWithUnit(float $min, float $max, string $name, string $unit): float
     {
         $result = NumberUtil::fuzzyCheckRange($this->value, $min, $max);
 
@@ -503,11 +501,11 @@ abstract class SassNumber extends Value
      * @param list<string> $newDenominatorUnits
      * @param string|null  $name                The argument name if this is a function argument
      *
-     * @return int|float
+     * @return float
      *
      * @throws SassScriptException if this number's units are not compatible with $newNumeratorUnits and $newDenominatorUnits, or if either number is unitless but the other is not.
      */
-    public function convertValue(array $newNumeratorUnits, array $newDenominatorUnits, ?string $name = null)
+    public function convertValue(array $newNumeratorUnits, array $newDenominatorUnits, ?string $name = null): float
     {
         return $this->convertOrCoerceValue($newNumeratorUnits, $newDenominatorUnits, false, $name);
     }
@@ -538,11 +536,11 @@ abstract class SassNumber extends Value
      * @param string|null $name      The argument name if this is a function argument
      * @param string|null $otherName The argument name for $other if this is a function argument
      *
-     * @return int|float
+     * @return float
      *
      * @throws SassScriptException if the units are not compatible or if either number is unitless but the other is not.
      */
-    public function convertValueToMatch(SassNumber $other, ?string $name = null, ?string $otherName = null)
+    public function convertValueToMatch(SassNumber $other, ?string $name = null, ?string $otherName = null): float
     {
         return $this->convertOrCoerceValue($other->getNumeratorUnits(), $other->getDenominatorUnits(), false, $name, $other, $otherName);
     }
@@ -583,11 +581,11 @@ abstract class SassNumber extends Value
      * @param list<string> $newDenominatorUnits
      * @param string|null  $name                The argument name if this is a function argument
      *
-     * @return int|float
+     * @return float
      *
      * @throws SassScriptException if this number's units are not compatible with $newNumeratorUnits and $newDenominatorUnits
      */
-    public function coerceValue(array $newNumeratorUnits, array $newDenominatorUnits, ?string $name = null)
+    public function coerceValue(array $newNumeratorUnits, array $newDenominatorUnits, ?string $name = null): float
     {
         return $this->convertOrCoerceValue($newNumeratorUnits, $newDenominatorUnits, true, $name);
     }
@@ -598,9 +596,9 @@ abstract class SassNumber extends Value
      * @param string      $unit
      * @param string|null $name The argument name if this is a function argument
      *
-     * @return int|float
+     * @return float
      */
-    public function coerceValueToUnit(string $unit, ?string $name = null)
+    public function coerceValueToUnit(string $unit, ?string $name = null): float
     {
         return $this->coerceValue([$unit], [], $name);
     }
@@ -639,11 +637,11 @@ abstract class SassNumber extends Value
      * @param string|null $name      The argument name if this is a function argument
      * @param string|null $otherName The argument name for $other if this is a function argument
      *
-     * @return int|float
+     * @return float
      *
      * @throws SassScriptException if the units are not compatible
      */
-    public function coerceValueToMatch(SassNumber $other, ?string $name = null, ?string $otherName = null)
+    public function coerceValueToMatch(SassNumber $other, ?string $name = null, ?string $otherName = null): float
     {
         return $this->convertOrCoerceValue($other->getNumeratorUnits(), $other->getDenominatorUnits(), true, $name, $other, $otherName);
     }
@@ -815,22 +813,15 @@ abstract class SassNumber extends Value
 
     /**
      * @param list<string> $units
-     *
-     * @return float|int
      */
-    private static function getCanonicalMultiplier(array $units)
+    private static function getCanonicalMultiplier(array $units): float
     {
         return array_reduce($units, function ($multiplier, $unit) {
             return $multiplier * self::getCanonicalMultiplierForUnit($unit);
-        }, 1);
+        }, 1.0);
     }
 
-    /**
-     * @param string $unit
-     *
-     * @return float|int
-     */
-    private static function getCanonicalMultiplierForUnit(string $unit)
+    private static function getCanonicalMultiplierForUnit(string $unit): float
     {
         foreach (self::CONVERSIONS as $canonicalUnit => $conversions) {
             if (isset($conversions[$unit])) {
@@ -838,7 +829,7 @@ abstract class SassNumber extends Value
             }
         }
 
-        return 1;
+        return 1.0;
     }
 
     /**
@@ -882,8 +873,8 @@ abstract class SassNumber extends Value
     /**
      * @template T
      *
-     * @param SassNumber                        $other
-     * @param callable(int|float, int|float): T $operation
+     * @param SassNumber                $other
+     * @param callable(float, float): T $operation
      *
      * @return T
      */
@@ -909,11 +900,11 @@ abstract class SassNumber extends Value
      * @param SassNumber|null $other
      * @param string|null     $otherName The argument name for $other if this is a function argument
      *
-     * @return int|float
+     * @return float
      *
      * @throws SassScriptException if this number's units are not compatible with $newNumeratorUnits and $newDenominatorUnits
      */
-    private function convertOrCoerceValue(array $newNumeratorUnits, array $newDenominatorUnits, bool $coerceUnitless, ?string $name = null, SassNumber $other = null, ?string $otherName = null)
+    private function convertOrCoerceValue(array $newNumeratorUnits, array $newDenominatorUnits, bool $coerceUnitless, ?string $name = null, SassNumber $other = null, ?string $otherName = null): float
     {
         assert($other === null || ($other->getNumeratorUnits() === $newNumeratorUnits && $other->getDenominatorUnits() === $newDenominatorUnits), sprintf("Expected %s to have units %s.", $other, self::buildUnitString($newNumeratorUnits, $newDenominatorUnits)));
 
@@ -1015,13 +1006,13 @@ abstract class SassNumber extends Value
     }
 
     /**
-     * @param int|float    $value
+     * @param float        $value
      * @param list<string> $otherNumerators
      * @param list<string> $otherDenominators
      *
      * @return SassNumber
      */
-    protected function multiplyUnits($value, array $otherNumerators, array $otherDenominators): SassNumber
+    protected function multiplyUnits(float $value, array $otherNumerators, array $otherDenominators): SassNumber
     {
         $newNumerators = array();
 
@@ -1072,9 +1063,9 @@ abstract class SassNumber extends Value
      * @param string $unit1
      * @param string $unit2
      *
-     * @return float|int|null
+     * @return float|null
      */
-    protected static function getConversionFactor(string $unit1, string $unit2)
+    protected static function getConversionFactor(string $unit1, string $unit2): ?float
     {
         if ($unit1 === $unit2) {
             return 1;

--- a/src/Value/SingleUnitSassNumber.php
+++ b/src/Value/SingleUnitSassNumber.php
@@ -62,11 +62,11 @@ final class SingleUnitSassNumber extends SassNumber
     private $unit;
 
     /**
-     * @param int|float                          $value
+     * @param float                              $value
      * @param string                             $unit
      * @param array{SassNumber, SassNumber}|null $asSlash
      */
-    public function __construct($value, string $unit, array $asSlash = null)
+    public function __construct(float $value, string $unit, array $asSlash = null)
     {
         parent::__construct($value, $asSlash);
         $this->unit = $unit;
@@ -87,7 +87,7 @@ final class SingleUnitSassNumber extends SassNumber
         return true;
     }
 
-    protected function withValue($value): SassNumber
+    protected function withValue(float $value): SassNumber
     {
         return new self($value, $this->unit);
     }
@@ -143,7 +143,7 @@ final class SingleUnitSassNumber extends SassNumber
         return parent::coerceToMatch($other, $name, $otherName);
     }
 
-    public function coerceValueToMatch(SassNumber $other, ?string $name = null, ?string $otherName = null)
+    public function coerceValueToMatch(SassNumber $other, ?string $name = null, ?string $otherName = null): float
     {
         if ($other instanceof SingleUnitSassNumber) {
             $coerced = $this->tryCoerceValueToUnit($other->unit);
@@ -171,7 +171,7 @@ final class SingleUnitSassNumber extends SassNumber
         return parent::convertToMatch($other, $name, $otherName);
     }
 
-    public function convertValueToMatch(SassNumber $other, ?string $name = null, ?string $otherName = null)
+    public function convertValueToMatch(SassNumber $other, ?string $name = null, ?string $otherName = null): float
     {
         if ($other instanceof SingleUnitSassNumber) {
             $coerced = $this->tryCoerceValueToUnit($other->unit);
@@ -199,7 +199,7 @@ final class SingleUnitSassNumber extends SassNumber
         return parent::coerce($newNumeratorUnits, $newDenominatorUnits, $name);
     }
 
-    public function coerceValue(array $newNumeratorUnits, array $newDenominatorUnits, ?string $name = null)
+    public function coerceValue(array $newNumeratorUnits, array $newDenominatorUnits, ?string $name = null): float
     {
         if (\count($newNumeratorUnits) === 1 && \count($newDenominatorUnits) === 0) {
             $coerced = $this->tryCoerceValueToUnit($newNumeratorUnits[0]);
@@ -213,7 +213,7 @@ final class SingleUnitSassNumber extends SassNumber
         return parent::coerceValue($newNumeratorUnits, $newDenominatorUnits, $name);
     }
 
-    public function coerceValueToUnit(string $unit, ?string $name = null)
+    public function coerceValueToUnit(string $unit, ?string $name = null): float
     {
         $coerced = $this->tryCoerceValueToUnit($unit);
 
@@ -242,13 +242,13 @@ final class SingleUnitSassNumber extends SassNumber
     }
 
     /**
-     * @param int|float    $value
+     * @param float        $value
      * @param list<string> $otherNumerators
      * @param list<string> $otherDenominators
      *
      * @return SassNumber
      */
-    protected function multiplyUnits($value, array $otherNumerators, array $otherDenominators): SassNumber
+    protected function multiplyUnits(float $value, array $otherNumerators, array $otherDenominators): SassNumber
     {
         $newNumerators = $otherDenominators;
         $removed = false;
@@ -275,11 +275,6 @@ final class SingleUnitSassNumber extends SassNumber
         return SassNumber::withUnits($value, $newNumerators, $otherDenominators);
     }
 
-    /**
-     * @param string $unit
-     *
-     * @return SassNumber|null
-     */
     private function tryCoerceToUnit(string $unit): ?SassNumber
     {
         if ($unit === $this->unit) {
@@ -295,12 +290,7 @@ final class SingleUnitSassNumber extends SassNumber
         return new SingleUnitSassNumber($this->getValue() * $factor, $unit);
     }
 
-    /**
-     * @param string $unit
-     *
-     * @return float|int|null
-     */
-    private function tryCoerceValueToUnit(string $unit)
+    private function tryCoerceValueToUnit(string $unit): ?float
     {
         $factor = self::getConversionFactor($unit, $this->unit);
 

--- a/src/Value/UnitlessSassNumber.php
+++ b/src/Value/UnitlessSassNumber.php
@@ -22,10 +22,10 @@ use ScssPhp\ScssPhp\Util\NumberUtil;
 final class UnitlessSassNumber extends SassNumber
 {
     /**
-     * @param int|float  $value
+     * @param float                              $value
      * @param array{SassNumber, SassNumber}|null $asSlash
      */
-    public function __construct($value, array $asSlash = null)
+    public function __construct(float $value, array $asSlash = null)
     {
         parent::__construct($value, $asSlash);
     }
@@ -45,7 +45,7 @@ final class UnitlessSassNumber extends SassNumber
         return false;
     }
 
-    protected function withValue($value): SassNumber
+    protected function withValue(float $value): SassNumber
     {
         return new self($value);
     }
@@ -80,7 +80,7 @@ final class UnitlessSassNumber extends SassNumber
         return $other->withValue($this->getValue());
     }
 
-    public function coerceValueToMatch(SassNumber $other, ?string $name = null, ?string $otherName = null)
+    public function coerceValueToMatch(SassNumber $other, ?string $name = null, ?string $otherName = null): float
     {
         return $this->getValue();
     }
@@ -95,7 +95,7 @@ final class UnitlessSassNumber extends SassNumber
         return parent::convertToMatch($other, $name, $otherName);
     }
 
-    public function convertValueToMatch(SassNumber $other, ?string $name = null, ?string $otherName = null)
+    public function convertValueToMatch(SassNumber $other, ?string $name = null, ?string $otherName = null): float
     {
         if (!$other->hasUnits()) {
             return $this->getValue();
@@ -110,12 +110,12 @@ final class UnitlessSassNumber extends SassNumber
         return SassNumber::withUnits($this->getValue(), $newNumeratorUnits, $newDenominatorUnits);
     }
 
-    public function coerceValue(array $newNumeratorUnits, array $newDenominatorUnits, ?string $name = null)
+    public function coerceValue(array $newNumeratorUnits, array $newDenominatorUnits, ?string $name = null): float
     {
         return $this->getValue();
     }
 
-    public function coerceValueToUnit(string $unit, ?string $name = null)
+    public function coerceValueToUnit(string $unit, ?string $name = null): float
     {
         return $this->getValue();
     }

--- a/tests/Value/SassColor/SassColorTest.php
+++ b/tests/Value/SassColor/SassColorTest.php
@@ -13,7 +13,6 @@
 namespace ScssPhp\ScssPhp\Tests\Value\SassColor;
 
 use ScssPhp\ScssPhp\Tests\Value\ValueTestCase;
-use ScssPhp\ScssPhp\Util\NumberUtil;
 use ScssPhp\ScssPhp\Value\SassColor;
 
 class SassColorTest extends ValueTestCase
@@ -22,7 +21,7 @@ class SassColorTest extends ValueTestCase
     {
         /** @var SassColor $color */
         $color = self::parseValue('rgba(10, 20, 30, 0.7)');
-        $this->assertEqualsWithDelta(0.7, $color->getAlpha(), NumberUtil::EPSILON);
+        $this->assertEqualsWithDelta(0.7, $color->getAlpha(), 1e-11);
     }
 
     /**

--- a/tests/Value/SassNumber/UnitlessIntegerTest.php
+++ b/tests/Value/SassNumber/UnitlessIntegerTest.php
@@ -34,7 +34,7 @@ class UnitlessIntegerTest extends ValueTestCase
     public function testHasTheCorrectValue()
     {
         $this->assertEquals(123, $this->value->getValue());
-        $this->assertIsInt($this->value->getValue());
+        $this->assertIsFloat($this->value->getValue());
     }
 
     public function testHasNoUnits()


### PR DESCRIPTION
This is only applied to the new codebase, not to the old one, as it is scheduled for removal.

see https://github.com/sass/sass/issues/2892 and https://github.com/sass/dart-sass/pull/1802