### PR TITLE
fix collapse selector on single node

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -1954,6 +1954,11 @@ final class Compiler
             foreach ($selector as $node) {
                 $compound = '';
 
+                if (!is_array($node)) {
+                    $output[] = $node;
+                    continue;
+                }
+
                 array_walk_recursive(
                     $node,
                     function ($value, $key) use (&$compound) {
@@ -1988,12 +1993,16 @@ final class Compiler
             foreach ($selector as $node) {
                 $compound = '';
 
-                array_walk_recursive(
-                    $node,
-                    function ($value, $key) use (&$compound) {
-                        $compound .= $value;
-                    }
-                );
+                if (!is_array($node)) {
+                    $compound .= $node;
+                } else {
+                    array_walk_recursive(
+                        $node,
+                        function ($value, $key) use (&$compound) {
+                            $compound .= $value;
+                        }
+                    );
+                }
 
                 if ($this->isImmediateRelationshipCombinator($compound)) {
                     if (\count($output)) {


### PR DESCRIPTION
collapseSelectors throw Exception if `@extend` is used with a selector that also is combined with `:is()`

eg:
```scss
.item-header {
    @extend .specific-item-header;
}

:is(.some-table-header, .specific-item-header ) {
    padding: 14px 14px 0;
} 
```