### PR TITLE
fix collapse selector on single node

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -2090,6 +2090,11 @@ class Compiler
             foreach ($selector as $node) {
                 $compound = '';
 
+                if (!is_array($node)) {
+                    $output[] = $node;
+                    continue;
+                }
+
                 array_walk_recursive(
                     $node,
                     function ($value, $key) use (&$compound) {
@@ -2124,12 +2129,16 @@ class Compiler
             foreach ($selector as $node) {
                 $compound = '';
 
-                array_walk_recursive(
-                    $node,
-                    function ($value, $key) use (&$compound) {
-                        $compound .= $value;
-                    }
-                );
+                if (!is_array($node)) {
+                    $compound .= $node;
+                } else {
+                    array_walk_recursive(
+                        $node,
+                        function ($value, $key) use (&$compound) {
+                            $compound .= $value;
+                        }
+                    );
+                }
 
                 if ($this->isImmediateRelationshipCombinator($compound)) {
                     if (\count($output)) {

--- a/tests/inputs/extending_is_selector.scss
+++ b/tests/inputs/extending_is_selector.scss
@@ -1,0 +1,8 @@
+
+.ext-test {
+  @extend .ext-test-inner;
+}
+
+:is(.ext-test-inner, .ext-test-inner3) {
+  padding: inherit;
+}

--- a/tests/outputs/extending_is_selector.css
+++ b/tests/outputs/extending_is_selector.css
@@ -1,0 +1,3 @@
+:is(.ext-test-inner, .ext-test-inner3), :is(.ext-test, . ext-test-inner3) {
+  padding: inherit;
+}


### PR DESCRIPTION
moved from: https://github.com/scssphp/scssphp/pull/653 to 1.x

collapseSelectors throw Exception if `@extend` is used with a selector that also is combined with `:is()`

eg:
```scss
.item-header {
    @extend .specific-item-header;
}

:is(.some-table-header, .specific-item-header ) {
    padding: 14px 14px 0;
} 
```