### PR TITLE
Use zurb/foundation 6.7 for the framework tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "thoughtbot/bourbon": "^7.0",
         "twbs/bootstrap": "~5.0",
         "twbs/bootstrap4": "4.6.1",
-        "zurb/foundation": "~6.5"
+        "zurb/foundation": "~6.7.0"
     },
     "repositories": [
         {


### PR DESCRIPTION
The version 6.8 introduces usages of Sass modules, which are not supported yet.