### PR TITLE
Improve the error reporting for invalid UTF-8

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -273,6 +273,11 @@ class Parser
         $this->saveEncoding();
         $this->extractLineNumbers($buffer);
 
+        if ($this->utf8 && !preg_match('//u', $buffer)) {
+            $message = $this->sourceName ? 'Invalid UTF-8 file: ' . $this->sourceName : 'Invalid UTF-8 file';
+            throw new ParserException($message);
+        }
+
         $this->pushBlock(null); // root block
         $this->whitespace();
         $this->pushBlock(null);

--- a/tests/ExceptionTest.php
+++ b/tests/ExceptionTest.php
@@ -158,6 +158,10 @@ END_OF_SCSS
                 ,
                 '1.5 is not an integer.'
             ],
+            [
+                ".foo { } .bar { } /* comment with \xd6-character */",
+                'Invalid UTF-8 file',
+            ]
         ];
     }
 


### PR DESCRIPTION
This avoids reporting the error as being on line 1 column 0 while we don't know where the file contains an invalid character.

Closes https://github.com/scssphp/scssphp/issues/652