### PR TITLE
Bump the PHP requirement to PHP 8.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2' ]
+                php: [ '8.1', '8.2' ]
                 extensions: [ '' ]
                 os: [ubuntu-latest]
                 include:

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "psr-4": { "ScssPhp\\ScssPhp\\Tests\\": "tests/" }
     },
     "require": {
-        "php": ">=7.2",
+        "php": ">=8.1",
         "ext-ctype": "*",
         "ext-json": "*",
         "league/uri": "^6.4.0",

--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,8 @@
         "php": ">=8.1",
         "ext-ctype": "*",
         "ext-json": "*",
-        "league/uri": "^6.4.0",
-        "league/uri-interfaces": "^2.3"
+        "league/uri": "^7.3",
+        "league/uri-interfaces": "^7.3"
     },
     "suggest": {
         "ext-mbstring": "For best performance, mbstring should be installed as it is faster than ext-iconv",

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     },
     "require-dev": {
         "bamarni/composer-bin-plugin": "^1.4",
-        "phpunit/phpunit": "^8.5 || ^9.5",
+        "phpunit/phpunit": "^9.5.6",
         "sass/sass-spec": "*",
         "squizlabs/php_codesniffer": "~3.5",
         "symfony/phpunit-bridge": "^5.1",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,6 +1,11 @@
 parameters:
 	ignoreErrors:
 		-
+			message: "#^Cannot cast T of array\\<string\\|Stringable\\>\\|string\\|Stringable\\|null to string\\.$#"
+			count: 1
+			path: src/Ast/Css/CssValue.php
+
+		-
 			message: "#^Property ScssPhp\\\\ScssPhp\\\\Block\\:\\:\\$children type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Block.php
@@ -1686,22 +1691,7 @@ parameters:
 			path: src/Parser.php
 
 		-
-			message: "#^Parameter \\#1 \\$leadingCombinators of class ScssPhp\\\\ScssPhp\\\\Ast\\\\Selector\\\\ComplexSelector constructor expects array\\<int, ScssPhp\\\\ScssPhp\\\\Ast\\\\Css\\\\CssValue\\<'\\+'\\|'\\>'\\|'~'\\>\\>, array\\<int, ScssPhp\\\\ScssPhp\\\\Ast\\\\Css\\\\CssValue\\<'\\+'\\|'\\>'\\|'~'\\>\\|ScssPhp\\\\ScssPhp\\\\Ast\\\\Css\\\\CssValue\\<string\\>\\> given\\.$#"
-			count: 1
-			path: src/Parser/SelectorParser.php
-
-		-
-			message: "#^Parameter \\#2 \\$combinators of class ScssPhp\\\\ScssPhp\\\\Ast\\\\Selector\\\\ComplexSelectorComponent constructor expects array\\<int, ScssPhp\\\\ScssPhp\\\\Ast\\\\Css\\\\CssValue\\<'\\+'\\|'\\>'\\|'~'\\>\\>, array\\<int, ScssPhp\\\\ScssPhp\\\\Ast\\\\Css\\\\CssValue\\<'\\+'\\|'\\>'\\|'~'\\>\\|ScssPhp\\\\ScssPhp\\\\Ast\\\\Css\\\\CssValue\\<string\\>\\> given\\.$#"
-			count: 2
-			path: src/Parser/SelectorParser.php
-
-		-
 			message: "#^Negated boolean expression is always true\\.$#"
-			count: 1
-			path: src/Serializer/SerializeVisitor.php
-
-		-
-			message: "#^Parameter \\#1 \\$iterable of method ScssPhp\\\\ScssPhp\\\\Serializer\\\\SerializeVisitor\\:\\:writeBetween\\(\\) expects iterable\\<ScssPhp\\\\ScssPhp\\\\Ast\\\\Css\\\\CssValue\\<string\\>\\>, array\\<int, ScssPhp\\\\ScssPhp\\\\Ast\\\\Css\\\\CssValue\\<'\\+'\\|'\\>'\\|'~'\\>\\> given\\.$#"
 			count: 1
 			path: src/Serializer/SerializeVisitor.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1691,6 +1691,11 @@ parameters:
 			path: src/Parser.php
 
 		-
+			message: "#^Call to function assert\\(\\) with false and 'unknown format' will always evaluate to false\\.$#"
+			count: 1
+			path: src/Serializer/SerializeVisitor.php
+
+		-
 			message: "#^Negated boolean expression is always true\\.$#"
 			count: 1
 			path: src/Serializer/SerializeVisitor.php

--- a/phpstan-no-baseline.neon
+++ b/phpstan-no-baseline.neon
@@ -5,12 +5,6 @@ parameters:
     paths:
         - ./src/
     ignoreErrors:
-        # We want to document the enum as return type, without caring about the exact values.
-        -
-            message: "#^Method ScssPhp\\\\ScssPhp\\\\Parser\\\\StylesheetParser\\:\\:unaryOperatorFor\\(\\) never returns 'not' so it can be removed from the return type\\.$#"
-            count: 1
-            path: src/Parser/StylesheetParser.php
-
         # Ignore errors about not having typehints for definitions of builtin functions. These won't be typed until they are extracted.
         -
             message: "#^Property ScssPhp\\\\ScssPhp\\\\Compiler\\:\\:\\$lib[\\w]+ has no type specified\\.$#"

--- a/phpstan-no-baseline.neon
+++ b/phpstan-no-baseline.neon
@@ -39,4 +39,5 @@ parameters:
             path: src/Parser.php
 
 includes:
+    - vendor-bin/phpstan/vendor/phpstan/phpstan-deprecation-rules/rules.neon
     - vendor-bin/phpstan/vendor/jiripudil/phpstan-sealed-classes/extension.neon

--- a/phpstan-no-baseline.neon
+++ b/phpstan-no-baseline.neon
@@ -43,3 +43,6 @@ parameters:
         -
             message: "#^Method ScssPhp\\\\ScssPhp\\\\Parser\\:\\:[^(]+\\(\\) has parameter \\$out with no value type specified in iterable type array\\.$#"
             path: src/Parser.php
+
+includes:
+    - vendor-bin/phpstan/vendor/jiripudil/phpstan-sealed-classes/extension.neon

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,28 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<!-- http://www.phpunit.de/manual/current/en/appendixes.configuration.html -->
 <phpunit
-    backupGlobals               = "false"
-    backupStaticAttributes      = "false"
-    colors                      = "true"
-    convertErrorsToExceptions   = "true"
-    convertNoticesToExceptions  = "true"
-    convertWarningsToExceptions = "true"
-    processIsolation            = "false"
-    stopOnFailure               = "false"
-    bootstrap                   = "vendor/autoload.php">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    colors="true"
+    bootstrap="vendor/autoload.php"
+    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+>
+    <coverage>
+        <include>
+            <directory>src/</directory>
+        </include>
+    </coverage>
 
     <testsuites>
         <testsuite name="Project Test Suite">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>src</directory>
-        </whitelist>
-    </filter>
 
     <listeners>
         <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />

--- a/src/Ast/Css/CssMediaQuery.php
+++ b/src/Ast/Css/CssMediaQuery.php
@@ -22,30 +22,21 @@ use ScssPhp\ScssPhp\Parser\MediaQueryParser;
  *
  * @internal
  */
-final class CssMediaQuery
+final class CssMediaQuery implements MediaQueryMergeResult
 {
-    public const MERGE_RESULT_EMPTY = 'empty';
-    public const MERGE_RESULT_UNREPRESENTABLE = 'unrepresentable';
-
     /**
      * The modifier, probably either "not" or "only".
      *
      * This may be `null` if no modifier is in use.
-     *
-     * @var string|null
-     * @readonly
      */
-    private $modifier;
+    private readonly ?string $modifier;
 
     /**
      * The media type, for example "screen" or "print".
      *
      * This may be `null`. If so, {@see $conditions} will not be empty.
-     *
-     * @var string|null
-     * @readonly
      */
-    private $type;
+    private readonly ?string $type;
 
     /**
      * Whether {@see $conditions} is a conjunction or a disjunction.
@@ -55,11 +46,8 @@ final class CssMediaQuery
      * condition in {@see $conditions} is met.
      *
      * If this is `false`, {@see $modifier} and {@see $type} will both be `null`.
-     *
-     * @var bool
-     * @readonly
      */
-    private $conjunction;
+    private readonly bool $conjunction;
 
     /**
      * Media conditions, including parentheses.
@@ -69,9 +57,8 @@ final class CssMediaQuery
      * [`<media-in-parens>`]: https://drafts.csswg.org/mediaqueries-4/#typedef-media-in-parens
      *
      * @var list<string>
-     * @readonly
      */
-    private $conditions;
+    private readonly array $conditions;
 
     /**
      * Parses a media query from $contents.
@@ -162,14 +149,11 @@ final class CssMediaQuery
     /**
      * Merges this with $other to return a query that matches the intersection
      * of both inputs.
-     *
-     * @return CssMediaQuery|string
-     * @phpstan-return CssMediaQuery|CssMediaQuery::*
      */
-    public function merge(CssMediaQuery $other)
+    public function merge(CssMediaQuery $other): MediaQueryMergeResult
     {
         if (!$this->conjunction || !$other->conjunction) {
-            return self::MERGE_RESULT_UNREPRESENTABLE;
+            return MediaQuerySingletonMergeResult::unrepresentable;
         }
 
         $ourModifier = $this->modifier !== null ? strtolower($this->modifier) : null;
@@ -194,14 +178,14 @@ final class CssMediaQuery
                 // (grid)`, because it means `not (screen and (color))` and so it allows
                 // a screen with no color but with a grid.
                 if (empty(array_diff($negativeConditions, $positiveConditions))) {
-                    return self::MERGE_RESULT_EMPTY;
+                    return MediaQuerySingletonMergeResult::empty;
                 }
 
-                return self::MERGE_RESULT_UNREPRESENTABLE;
+                return MediaQuerySingletonMergeResult::unrepresentable;
             }
 
             if ($this->matchesAllTypes() || $other->matchesAllTypes()) {
-                return self::MERGE_RESULT_UNREPRESENTABLE;
+                return MediaQuerySingletonMergeResult::unrepresentable;
             }
 
             if ($ourModifier === 'not') {
@@ -216,7 +200,7 @@ final class CssMediaQuery
         } elseif ($ourModifier === 'not') {
             // CSS has no way of representing "neither screen nor print".
             if ($ourType !== $theirType) {
-                return self::MERGE_RESULT_UNREPRESENTABLE;
+                return MediaQuerySingletonMergeResult::unrepresentable;
             }
 
             $moreConditions = \count($this->conditions) > \count($other->conditions) ? $this->conditions : $other->conditions;
@@ -230,7 +214,7 @@ final class CssMediaQuery
                 $conditions = $moreConditions;
             } else {
                 // Otherwise, there's no way to represent the intersection.
-                return self::MERGE_RESULT_UNREPRESENTABLE;
+                return MediaQuerySingletonMergeResult::unrepresentable;
             }
         } elseif ($this->matchesAllTypes()) {
             $modifier = $theirModifier;
@@ -243,7 +227,7 @@ final class CssMediaQuery
             $type = $ourType;
             $conditions = array_merge($this->conditions, $other->conditions);
         } elseif ($ourType !== $theirType) {
-            return self::MERGE_RESULT_EMPTY;
+            return MediaQuerySingletonMergeResult::empty;
         } else {
             $modifier = $ourModifier ?? $theirModifier;
             $type = $ourType;

--- a/src/Ast/Css/CssNode.php
+++ b/src/Ast/Css/CssNode.php
@@ -37,7 +37,7 @@ interface CssNode extends AstNode
      *
      * @return T
      */
-    public function accept($visitor);
+    public function accept(CssVisitor $visitor);
 
     /**
      * Whether this is invisible and won't be emitted to the compiled stylesheet.

--- a/src/Ast/Css/CssValue.php
+++ b/src/Ast/Css/CssValue.php
@@ -27,23 +27,19 @@ use ScssPhp\ScssPhp\Util\EquatableUtil;
  *
  * @internal
  */
-class CssValue implements AstNode, Equatable
+final class CssValue implements AstNode, Equatable
 {
     /**
      * @phpstan-var T
      */
-    protected $value;
+    private readonly mixed $value;
 
-    /**
-     * @var FileSpan
-     * @readonly
-     */
-    private $span;
+    private readonly FileSpan $span;
 
     /**
      * @param T $value
      */
-    public function __construct($value, FileSpan $span)
+    public function __construct(mixed $value, FileSpan $span)
     {
         $this->value = $value;
         $this->span = $span;
@@ -52,7 +48,7 @@ class CssValue implements AstNode, Equatable
     /**
      * @return T
      */
-    public function getValue()
+    public function getValue(): mixed
     {
         return $this->value;
     }

--- a/src/Ast/Css/CssValue.php
+++ b/src/Ast/Css/CssValue.php
@@ -13,6 +13,7 @@
 namespace ScssPhp\ScssPhp\Ast\Css;
 
 use ScssPhp\ScssPhp\Ast\AstNode;
+use ScssPhp\ScssPhp\Ast\Selector\Combinator;
 use ScssPhp\ScssPhp\SourceSpan\FileSpan;
 use ScssPhp\ScssPhp\Util\Equatable;
 use ScssPhp\ScssPhp\Util\EquatableUtil;
@@ -23,7 +24,7 @@ use ScssPhp\ScssPhp\Util\EquatableUtil;
  * This is used to associate a span with a value that doesn't otherwise track
  * its span. It has value equality semantics.
  *
- * @template T
+ * @template T of string|\Stringable|array<string|\Stringable>|Combinator|null
  *
  * @internal
  */
@@ -65,6 +66,10 @@ final class CssValue implements AstNode, Equatable
 
     public function __toString(): string
     {
+        if ($this->value instanceof Combinator) {
+            return $this->value->getText();
+        }
+
         if (\is_array($this->value)) {
             return implode($this->value);
         }

--- a/src/Ast/Css/IsInvisibleVisitor.php
+++ b/src/Ast/Css/IsInvisibleVisitor.php
@@ -23,19 +23,13 @@ final class IsInvisibleVisitor extends EveryCssVisitor
 {
     /**
      * Whether to consider selectors with bogus combinators invisible.
-     *
-     * @var bool
-     * @readonly
      */
-    private $includeBogus;
+    private readonly bool $includeBogus;
 
     /**
      * Whether to consider comments invisible.
-     *
-     * @var bool
-     * @readonly
      */
-    private $includeComments;
+    private readonly bool $includeComments;
 
     public function __construct(bool $includeBogus, bool $includeComments)
     {
@@ -43,7 +37,7 @@ final class IsInvisibleVisitor extends EveryCssVisitor
         $this->includeComments = $includeComments;
     }
 
-    public function visitCssAtRule($node): bool
+    public function visitCssAtRule(CssAtRule $node): bool
     {
         // An unknown at-rule is never invisible. Because we don't know the semantics
         // of unknown rules, we can't guarantee that (for example) `@foo {}` isn't
@@ -51,12 +45,12 @@ final class IsInvisibleVisitor extends EveryCssVisitor
         return false;
     }
 
-    public function visitCssComment($node): bool
+    public function visitCssComment(CssComment $node): bool
     {
         return $this->includeComments && !$node->isPreserved();
     }
 
-    public function visitCssStyleRule($node): bool
+    public function visitCssStyleRule(CssStyleRule $node): bool
     {
         return ($this->includeBogus ? $node->getSelector()->isInvisible() : $node->getSelector()->isInvisibleOtherThanBogusCombinators()) || parent::visitCssStyleRule($node);
     }

--- a/src/Ast/Css/MediaQueryMergeResult.php
+++ b/src/Ast/Css/MediaQueryMergeResult.php
@@ -10,16 +10,14 @@
  * @link http://scssphp.github.io/scssphp
  */
 
-namespace ScssPhp\ScssPhp\Ast;
+namespace ScssPhp\ScssPhp\Ast\Css;
 
-use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+use JiriPudil\SealedClasses\Sealed;
 
 /**
- * A node in an abstract syntax tree.
- *
  * @internal
  */
-interface AstNode extends \Stringable
+#[Sealed(permits: [CssMediaQuery::class, MediaQuerySingletonMergeResult::class])]
+interface MediaQueryMergeResult
 {
-    public function getSpan(): FileSpan;
 }

--- a/src/Ast/Css/MediaQuerySingletonMergeResult.php
+++ b/src/Ast/Css/MediaQuerySingletonMergeResult.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Ast\Css;
+
+enum MediaQuerySingletonMergeResult implements MediaQueryMergeResult
+{
+    case empty;
+    case unrepresentable;
+}

--- a/src/Ast/Css/ModifiableCssAtRule.php
+++ b/src/Ast/Css/ModifiableCssAtRule.php
@@ -14,6 +14,7 @@ namespace ScssPhp\ScssPhp\Ast\Css;
 
 use ScssPhp\ScssPhp\SourceSpan\FileSpan;
 use ScssPhp\ScssPhp\Util\EquatableUtil;
+use ScssPhp\ScssPhp\Visitor\ModifiableCssVisitor;
 
 /**
  * A modifiable version of {@see CssAtRule} for use in the evaluation step.
@@ -25,30 +26,20 @@ final class ModifiableCssAtRule extends ModifiableCssParentNode implements CssAt
     /**
      * @var CssValue<string>
      */
-    private $name;
+    private readonly CssValue $name;
 
     /**
      * @var CssValue<string>|null
      */
-    private $value;
+    private readonly ?CssValue $value;
+
+    private readonly bool $childless;
+
+    private readonly FileSpan $span;
 
     /**
-     * @var bool
-     * @readonly
-     */
-    private $childless;
-
-    /**
-     * @var FileSpan
-     * @readonly
-     */
-    private $span;
-
-    /**
-     * @param CssValue<string>      $name
+     * @param CssValue<string> $name
      * @param CssValue<string>|null $value
-     * @param bool                  $childless
-     * @param FileSpan              $span
      */
     public function __construct(CssValue $name, FileSpan $span, bool $childless = false, ?CssValue $value = null)
     {
@@ -80,7 +71,7 @@ final class ModifiableCssAtRule extends ModifiableCssParentNode implements CssAt
         return $this->span;
     }
 
-    public function accept($visitor)
+    public function accept(ModifiableCssVisitor $visitor)
     {
         return $visitor->visitCssAtRule($this);
     }
@@ -90,10 +81,7 @@ final class ModifiableCssAtRule extends ModifiableCssParentNode implements CssAt
         return $other instanceof ModifiableCssAtRule && EquatableUtil::equals($this->name, $other->name) && EquatableUtil::equals($this->value, $other->value) && $this->childless === $other->childless;
     }
 
-    /**
-     * @phpstan-return ModifiableCssAtRule
-     */
-    public function copyWithoutChildren(): ModifiableCssParentNode
+    public function copyWithoutChildren(): ModifiableCssAtRule
     {
         return new ModifiableCssAtRule($this->name, $this->span, $this->childless, $this->value);
     }

--- a/src/Ast/Css/ModifiableCssComment.php
+++ b/src/Ast/Css/ModifiableCssComment.php
@@ -13,6 +13,7 @@
 namespace ScssPhp\ScssPhp\Ast\Css;
 
 use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+use ScssPhp\ScssPhp\Visitor\ModifiableCssVisitor;
 
 /**
  * A modifiable version of {@see CssComment} for use in the evaluation step.
@@ -21,17 +22,9 @@ use ScssPhp\ScssPhp\SourceSpan\FileSpan;
  */
 final class ModifiableCssComment extends ModifiableCssNode implements CssComment
 {
-    /**
-     * @var string
-     * @readonly
-     */
-    private $text;
+    private readonly string $text;
 
-    /**
-     * @var FileSpan
-     * @readonly
-     */
-    private $span;
+    private readonly FileSpan $span;
 
     public function __construct(string $text, FileSpan $span)
     {
@@ -54,7 +47,7 @@ final class ModifiableCssComment extends ModifiableCssNode implements CssComment
         return $this->text[2] === '!';
     }
 
-    public function accept($visitor)
+    public function accept(ModifiableCssVisitor $visitor)
     {
         return $visitor->visitCssComment($this);
     }

--- a/src/Ast/Css/ModifiableCssDeclaration.php
+++ b/src/Ast/Css/ModifiableCssDeclaration.php
@@ -15,6 +15,7 @@ namespace ScssPhp\ScssPhp\Ast\Css;
 use ScssPhp\ScssPhp\SourceSpan\FileSpan;
 use ScssPhp\ScssPhp\Value\SassString;
 use ScssPhp\ScssPhp\Value\Value;
+use ScssPhp\ScssPhp\Visitor\ModifiableCssVisitor;
 
 /**
  * A modifiable version of {@see CssDeclaration} for use in the evaluation step.
@@ -25,40 +26,23 @@ final class ModifiableCssDeclaration extends ModifiableCssNode implements CssDec
 {
     /**
      * @var CssValue<string>
-     * @readonly
      */
-    private $name;
+    private readonly CssValue $name;
 
     /**
      * @var CssValue<Value>
-     * @readonly
      */
-    private $value;
+    private readonly CssValue $value;
 
-    /**
-     * @var bool
-     * @readonly
-     */
-    private $parsedAsCustomProperty;
+    private readonly bool $parsedAsCustomProperty;
 
-    /**
-     * @var FileSpan
-     * @readonly
-     */
-    private $valueSpanForMap;
+    private readonly FileSpan $valueSpanForMap;
 
-    /**
-     * @var FileSpan
-     * @readonly
-     */
-    private $span;
+    private readonly FileSpan $span;
 
     /**
      * @param CssValue<string> $name
-     * @param CssValue<Value>  $value
-     * @param bool             $parsedAsCustomProperty
-     * @param FileSpan         $valueSpanForMap
-     * @param FileSpan         $span
+     * @param CssValue<Value> $value
      */
     public function __construct(CssValue $name, CssValue $value, FileSpan $span, bool $parsedAsCustomProperty, ?FileSpan $valueSpanForMap = null) {
         $this->name = $name;
@@ -105,10 +89,10 @@ final class ModifiableCssDeclaration extends ModifiableCssNode implements CssDec
 
     public function isCustomProperty(): bool
     {
-        return 0 === strpos($this->name->getValue(), '--');
+        return str_starts_with($this->name->getValue(), '--');
     }
 
-    public function accept($visitor)
+    public function accept(ModifiableCssVisitor $visitor)
     {
         return $visitor->visitCssDeclaration($this);
     }

--- a/src/Ast/Css/ModifiableCssDeclaration.php
+++ b/src/Ast/Css/ModifiableCssDeclaration.php
@@ -57,7 +57,7 @@ final class ModifiableCssDeclaration extends ModifiableCssNode implements CssDec
             }
 
             if (!$value->getValue() instanceof SassString) {
-                throw new \InvalidArgumentException(sprintf('If parsedAsCustomProperty is true, value must contain a SassString (was %s).', get_class($value->getValue())));
+                throw new \InvalidArgumentException(sprintf('If parsedAsCustomProperty is true, value must contain a SassString (was %s).', get_debug_type($value->getValue())));
             }
         }
     }

--- a/src/Ast/Css/ModifiableCssImport.php
+++ b/src/Ast/Css/ModifiableCssImport.php
@@ -13,6 +13,7 @@
 namespace ScssPhp\ScssPhp\Ast\Css;
 
 use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+use ScssPhp\ScssPhp\Visitor\ModifiableCssVisitor;
 
 /**
  * A modifiable version of {@see CssImport} for use in the evaluation step.
@@ -27,26 +28,19 @@ final class ModifiableCssImport extends ModifiableCssNode implements CssImport
      * This includes quotes.
      *
      * @var CssValue<string>
-     * @readonly
      */
-    private $url;
+    private readonly CssValue $url;
 
     /**
      * @var CssValue<string>|null
-     * @readonly
      */
-    private $modifiers;
+    private readonly ?CssValue $modifiers;
+
+    private readonly FileSpan $span;
 
     /**
-     * @var FileSpan
-     * @readonly
-     */
-    private $span;
-
-    /**
-     * @param CssValue<string>         $url
-     * @param FileSpan                 $span
-     * @param CssValue<string>|null    $modifiers
+     * @param CssValue<string> $url
+     * @param CssValue<string>|null $modifiers
      */
     public function __construct(CssValue $url, FileSpan $span, ?CssValue $modifiers = null)
     {
@@ -70,7 +64,7 @@ final class ModifiableCssImport extends ModifiableCssNode implements CssImport
         return $this->span;
     }
 
-    public function accept($visitor)
+    public function accept(ModifiableCssVisitor $visitor)
     {
         return $visitor->visitCssImport($this);
     }

--- a/src/Ast/Css/ModifiableCssKeyframeBlock.php
+++ b/src/Ast/Css/ModifiableCssKeyframeBlock.php
@@ -14,6 +14,7 @@ namespace ScssPhp\ScssPhp\Ast\Css;
 
 use ScssPhp\ScssPhp\SourceSpan\FileSpan;
 use ScssPhp\ScssPhp\Util\EquatableUtil;
+use ScssPhp\ScssPhp\Visitor\ModifiableCssVisitor;
 
 /**
  * A modifiable version of {@see CssKeyframeBlock} for use in the evaluation step.
@@ -24,19 +25,13 @@ final class ModifiableCssKeyframeBlock extends ModifiableCssParentNode implement
 {
     /**
      * @var CssValue<list<string>>
-     * @readonly
      */
-    private $selector;
+    private readonly CssValue $selector;
 
-    /**
-     * @var FileSpan
-     * @readonly
-     */
-    private $span;
+    private readonly FileSpan $span;
 
     /**
      * @param CssValue<list<string>> $selector
-     * @param FileSpan               $span
      */
     public function __construct(CssValue $selector, FileSpan $span)
     {
@@ -55,7 +50,7 @@ final class ModifiableCssKeyframeBlock extends ModifiableCssParentNode implement
         return $this->span;
     }
 
-    public function accept($visitor)
+    public function accept(ModifiableCssVisitor $visitor)
     {
         return $visitor->visitCssKeyframeBlock($this);
     }
@@ -65,10 +60,7 @@ final class ModifiableCssKeyframeBlock extends ModifiableCssParentNode implement
         return $other instanceof ModifiableCssKeyframeBlock && EquatableUtil::listEquals($this->selector->getValue(), $other->selector->getValue());
     }
 
-    /**
-     * @phpstan-return ModifiableCssKeyframeBlock
-     */
-    public function copyWithoutChildren(): ModifiableCssParentNode
+    public function copyWithoutChildren(): ModifiableCssKeyframeBlock
     {
         return new ModifiableCssKeyframeBlock($this->selector, $this->span);
     }

--- a/src/Ast/Css/ModifiableCssMediaRule.php
+++ b/src/Ast/Css/ModifiableCssMediaRule.php
@@ -14,6 +14,7 @@ namespace ScssPhp\ScssPhp\Ast\Css;
 
 use ScssPhp\ScssPhp\SourceSpan\FileSpan;
 use ScssPhp\ScssPhp\Util\EquatableUtil;
+use ScssPhp\ScssPhp\Visitor\ModifiableCssVisitor;
 
 /**
  * A modifiable version of {@see CssMediaRule} for use in the evaluation step.
@@ -25,17 +26,12 @@ final class ModifiableCssMediaRule extends ModifiableCssParentNode implements Cs
     /**
      * @var list<CssMediaQuery>
      */
-    private $queries;
+    private readonly array $queries;
+
+    private readonly FileSpan $span;
 
     /**
-     * @var FileSpan
-     * @readonly
-     */
-    private $span;
-
-    /**
-     * @param CssMediaQuery[] $queries
-     * @param FileSpan        $span
+     * @param list<CssMediaQuery> $queries
      */
     public function __construct(array $queries, FileSpan $span)
     {
@@ -54,7 +50,7 @@ final class ModifiableCssMediaRule extends ModifiableCssParentNode implements Cs
         return $this->span;
     }
 
-    public function accept($visitor)
+    public function accept(ModifiableCssVisitor $visitor)
     {
         return $visitor->visitCssMediaRule($this);
     }
@@ -64,7 +60,7 @@ final class ModifiableCssMediaRule extends ModifiableCssParentNode implements Cs
         return $other instanceof ModifiableCssMediaRule && EquatableUtil::listEquals($this->queries, $other->queries);
     }
 
-    public function copyWithoutChildren(): ModifiableCssParentNode
+    public function copyWithoutChildren(): ModifiableCssMediaRule
     {
         return new ModifiableCssMediaRule($this->queries, $this->span);
     }

--- a/src/Ast/Css/ModifiableCssNode.php
+++ b/src/Ast/Css/ModifiableCssNode.php
@@ -26,24 +26,16 @@ use ScssPhp\ScssPhp\Visitor\ModifiableCssVisitor;
  */
 abstract class ModifiableCssNode implements CssNode
 {
-    /**
-     * @var ModifiableCssParentNode|null
-     */
-    private $parent;
+    private ?ModifiableCssParentNode $parent = null;
 
     /**
      * The index of `$this` in parent's children.
      *
      * This makes {@see remove} more efficient.
-     *
-     * @var int|null
      */
-    private $indexInParent;
+    private ?int $indexInParent = null;
 
-    /**
-     * @var bool
-     */
-    private $groupEnd = false;
+    private bool $groupEnd = false;
 
     public function getParent(): ?ModifiableCssParentNode
     {
@@ -115,7 +107,7 @@ abstract class ModifiableCssNode implements CssNode
      *
      * @return T
      */
-    abstract public function accept($visitor);
+    abstract public function accept(ModifiableCssVisitor $visitor);
 
     /**
      * Removes $this from {@see parent}'s child list.

--- a/src/Ast/Css/ModifiableCssParentNode.php
+++ b/src/Ast/Css/ModifiableCssParentNode.php
@@ -22,7 +22,7 @@ abstract class ModifiableCssParentNode extends ModifiableCssNode implements CssP
     /**
      * @var list<ModifiableCssNode>
      */
-    private $children;
+    private array $children;
 
     /**
      * @param list<ModifiableCssNode> $children

--- a/src/Ast/Css/ModifiableCssStyleRule.php
+++ b/src/Ast/Css/ModifiableCssStyleRule.php
@@ -16,6 +16,7 @@ use ScssPhp\ScssPhp\Ast\Selector\SelectorList;
 use ScssPhp\ScssPhp\SourceSpan\FileSpan;
 use ScssPhp\ScssPhp\Util\Box;
 use ScssPhp\ScssPhp\Util\EquatableUtil;
+use ScssPhp\ScssPhp\Visitor\ModifiableCssVisitor;
 
 /**
  * A modifiable version of {@see CssStyleRule} for use in the evaluation step.
@@ -29,21 +30,12 @@ final class ModifiableCssStyleRule extends ModifiableCssParentNode implements Cs
      * store, which may update it over time as new extensions are applied.
      *
      * @var Box<SelectorList>
-     * @readonly
      */
-    private $selector;
+    private readonly Box $selector;
 
-    /**
-     * @var SelectorList
-     * @readonly
-     */
-    private $originalSelector;
+    private readonly SelectorList $originalSelector;
 
-    /**
-     * @var FileSpan
-     * @readonly
-     */
-    private $span;
+    private readonly FileSpan $span;
 
     /**
      * @param Box<SelectorList> $selector
@@ -71,7 +63,7 @@ final class ModifiableCssStyleRule extends ModifiableCssParentNode implements Cs
         return $this->span;
     }
 
-    public function accept($visitor)
+    public function accept(ModifiableCssVisitor $visitor)
     {
         return $visitor->visitCssStyleRule($this);
     }
@@ -81,10 +73,7 @@ final class ModifiableCssStyleRule extends ModifiableCssParentNode implements Cs
         return $other instanceof ModifiableCssStyleRule && EquatableUtil::equals($this->selector, $other->selector);
     }
 
-    /**
-     * @phpstan-return ModifiableCssStyleRule
-     */
-    public function copyWithoutChildren(): ModifiableCssParentNode
+    public function copyWithoutChildren(): ModifiableCssStyleRule
     {
         return new ModifiableCssStyleRule($this->selector, $this->span, $this->originalSelector);
     }

--- a/src/Ast/Css/ModifiableCssStylesheet.php
+++ b/src/Ast/Css/ModifiableCssStylesheet.php
@@ -13,6 +13,7 @@
 namespace ScssPhp\ScssPhp\Ast\Css;
 
 use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+use ScssPhp\ScssPhp\Visitor\ModifiableCssVisitor;
 
 /**
  * A modifiable version of {@see CssStylesheet} for use in the evaluation step.
@@ -21,14 +22,9 @@ use ScssPhp\ScssPhp\SourceSpan\FileSpan;
  */
 final class ModifiableCssStylesheet extends ModifiableCssParentNode implements CssStylesheet
 {
-    /**
-     * @var FileSpan
-     * @readonly
-     */
-    private $span;
+    private readonly FileSpan $span;
 
     /**
-     * @param FileSpan $span
      * @param list<ModifiableCssNode> $children
      */
     public function __construct(FileSpan $span, array $children = [])
@@ -42,7 +38,7 @@ final class ModifiableCssStylesheet extends ModifiableCssParentNode implements C
         return $this->span;
     }
 
-    public function accept($visitor)
+    public function accept(ModifiableCssVisitor $visitor)
     {
         return $visitor->visitCssStylesheet($this);
     }
@@ -52,10 +48,7 @@ final class ModifiableCssStylesheet extends ModifiableCssParentNode implements C
         return $other instanceof ModifiableCssStylesheet;
     }
 
-    /**
-     * @phpstan-return ModifiableCssStylesheet
-     */
-    public function copyWithoutChildren(): ModifiableCssParentNode
+    public function copyWithoutChildren(): ModifiableCssStylesheet
     {
         return new ModifiableCssStylesheet($this->span);
     }

--- a/src/Ast/Css/ModifiableCssSupportsRule.php
+++ b/src/Ast/Css/ModifiableCssSupportsRule.php
@@ -14,6 +14,7 @@ namespace ScssPhp\ScssPhp\Ast\Css;
 
 use ScssPhp\ScssPhp\SourceSpan\FileSpan;
 use ScssPhp\ScssPhp\Util\EquatableUtil;
+use ScssPhp\ScssPhp\Visitor\ModifiableCssVisitor;
 
 /**
  * A modifiable version of {@see CssSupportsRule} for use in the evaluation step.
@@ -24,19 +25,13 @@ final class ModifiableCssSupportsRule extends ModifiableCssParentNode implements
 {
     /**
      * @var CssValue<string>
-     * @readonly
      */
-    private $condition;
+    private readonly CssValue$condition;
 
-    /**
-     * @var FileSpan
-     * @readonly
-     */
-    private $span;
+    private readonly FileSpan $span;
 
     /**
      * @param CssValue<string> $condition
-     * @param FileSpan         $span
      */
     public function __construct(CssValue $condition, FileSpan $span)
     {
@@ -55,7 +50,7 @@ final class ModifiableCssSupportsRule extends ModifiableCssParentNode implements
         return $this->span;
     }
 
-    public function accept($visitor)
+    public function accept(ModifiableCssVisitor $visitor)
     {
         return $visitor->visitCssSupportsRule($this);
     }
@@ -65,10 +60,7 @@ final class ModifiableCssSupportsRule extends ModifiableCssParentNode implements
         return $other instanceof ModifiableCssSupportsRule && EquatableUtil::equals($this->condition, $other->condition);
     }
 
-    /**
-     * @phpstan-return ModifiableCssSupportsRule
-     */
-    public function copyWithoutChildren(): ModifiableCssParentNode
+    public function copyWithoutChildren(): ModifiableCssSupportsRule
     {
         return new ModifiableCssSupportsRule($this->condition, $this->span);
     }

--- a/src/Ast/FakeAstNode.php
+++ b/src/Ast/FakeAstNode.php
@@ -22,17 +22,16 @@ use ScssPhp\ScssPhp\SourceSpan\FileSpan;
 final class FakeAstNode implements AstNode
 {
     /**
-     * @var callable(): FileSpan
-     * @readonly
+     * @var \Closure(): FileSpan
      */
-    private $callback;
+    private readonly \Closure $callback;
 
     /**
      * @param callable(): FileSpan $callback
      */
     public function __construct(callable $callback)
     {
-        $this->callback = $callback;
+        $this->callback = $callback(...);
     }
 
     public function getSpan(): FileSpan

--- a/src/Ast/Sass/Argument.php
+++ b/src/Ast/Sass/Argument.php
@@ -23,23 +23,11 @@ use ScssPhp\ScssPhp\Util\SpanUtil;
  */
 final class Argument implements SassNode, SassDeclaration
 {
-    /**
-     * @var string
-     * @readonly
-     */
-    private $name;
+    private readonly string $name;
 
-    /**
-     * @var Expression|null
-     * @readonly
-     */
-    private $defaultValue;
+    private readonly ?Expression $defaultValue;
 
-    /**
-     * @var FileSpan
-     * @readonly
-     */
-    private $span;
+    private readonly FileSpan $span;
 
     public function __construct(string $name, FileSpan $span, ?Expression $defaultValue = null)
     {

--- a/src/Ast/Sass/ArgumentDeclaration.php
+++ b/src/Ast/Sass/ArgumentDeclaration.php
@@ -27,26 +27,15 @@ final class ArgumentDeclaration implements SassNode
 {
     /**
      * @var list<Argument>
-     * @readonly
      */
-    private $arguments;
+    private readonly array $arguments;
 
-    /**
-     * @var string|null
-     * @readonly
-     */
-    private $restArgument;
+    private readonly ?string $restArgument;
 
-    /**
-     * @var FileSpan
-     * @readonly
-     */
-    private $span;
+    private readonly FileSpan $span;
 
     /**
      * @param list<Argument> $arguments
-     * @param FileSpan      $span
-     * @param string|null $restArgument
      */
     public function __construct(array $arguments, FileSpan $span, ?string $restArgument = null)
     {
@@ -97,7 +86,6 @@ final class ArgumentDeclaration implements SassNode
     }
 
     /**
-     * @param int                  $positional
      * @param array<string, mixed> $names Only keys are relevant
      *
      * @throws SassScriptException if $positional and $names aren't valid for this argument declaration.
@@ -177,10 +165,7 @@ final class ArgumentDeclaration implements SassNode
      * Returns whether $positional and $names are valid for this argument
      * declaration.
      *
-     * @param int                  $positional
      * @param array<string, mixed> $names Only keys are relevant
-     *
-     * @return bool
      */
     public function matches(int $positional, array $names): bool
     {

--- a/src/Ast/Sass/ArgumentDeclaration.php
+++ b/src/Ast/Sass/ArgumentDeclaration.php
@@ -125,9 +125,7 @@ final class ArgumentDeclaration implements SassNode
         }
 
         if ($nameUsed < \count($names)) {
-            $unknownNames = array_values(array_diff(array_keys($names), array_map(function ($argument) {
-                return $argument->getName();
-            }, $this->arguments)));
+            $unknownNames = array_values(array_diff(array_keys($names), array_map(fn($argument) => $argument->getName(), $this->arguments)));
             $lastName = array_pop($unknownNames);
             $message = sprintf(
                 'No argument%s named $%s%s.',

--- a/src/Ast/Sass/ArgumentInvocation.php
+++ b/src/Ast/Sass/ArgumentInvocation.php
@@ -25,39 +25,23 @@ final class ArgumentInvocation implements SassNode
 {
     /**
      * @var list<Expression>
-     * @readonly
      */
-    private $positional;
+    private readonly array $positional;
 
     /**
      * @var array<string, Expression>
-     * @readonly
      */
-    private $named;
+    private readonly array $named;
 
-    /**
-     * @var Expression|null
-     * @readonly
-     */
-    private $rest;
+    private readonly ?Expression $rest;
 
-    /**
-     * @var Expression|null
-     */
-    private $keywordRest;
+    private readonly ?Expression $keywordRest;
 
-    /**
-     * @var FileSpan
-     * @readonly
-     */
-    private $span;
+    private readonly FileSpan $span;
 
     /**
      * @param list<Expression>          $positional
      * @param array<string, Expression> $named
-     * @param FileSpan                  $span
-     * @param Expression|null           $rest
-     * @param Expression|null           $keywordRest
      */
     public function __construct(array $positional, array $named, FileSpan $span, ?Expression $rest = null, ?Expression $keywordRest = null)
     {

--- a/src/Ast/Sass/AtRootQuery.php
+++ b/src/Ast/Sass/AtRootQuery.php
@@ -31,11 +31,8 @@ final class AtRootQuery
 {
     /**
      * Whether the query includes or excludes rules with the specified names.
-     *
-     * @var bool
-     * @readonly
      */
-    private $include;
+    private readonly bool $include;
 
     /**
      * The names of the rules included or excluded by this query.
@@ -44,25 +41,18 @@ final class AtRootQuery
      * or excluded, and "rule" indicates style rules are included or excluded.
      *
      * @var string[]
-     * @readonly
      */
-    private $names;
+    private readonly array $names;
 
     /**
      * Whether this includes or excludes *all* rules.
-     *
-     * @var bool
-     * @readonly
      */
-    private $all;
+    private readonly bool $all;
 
     /**
      * Whether this includes or excludes style rules.
-     *
-     * @var bool
-     * @readonly
      */
-    private $rule;
+    private readonly bool $rule;
 
     /**
      * Parses an at-root query from $contents.
@@ -78,7 +68,6 @@ final class AtRootQuery
 
     /**
      * @param string[] $names
-     * @param bool     $include
      */
     public static function create(array $names, bool $include): AtRootQuery
     {
@@ -95,9 +84,6 @@ final class AtRootQuery
 
     /**
      * @param string[] $names
-     * @param bool     $include
-     * @param bool     $all
-     * @param bool     $rule
      */
     private function __construct(array $names, bool $include, bool $all, bool $rule)
     {

--- a/src/Ast/Sass/ConfiguredVariable.php
+++ b/src/Ast/Sass/ConfiguredVariable.php
@@ -22,29 +22,13 @@ use ScssPhp\ScssPhp\Util\SpanUtil;
  */
 final class ConfiguredVariable implements SassNode, SassDeclaration
 {
-    /**
-     * @var string
-     * @readonly
-     */
-    private $name;
+    private readonly string $name;
 
-    /**
-     * @var Expression
-     * @readonly
-     */
-    private $expression;
+    private readonly Expression $expression;
 
-    /**
-     * @var FileSpan
-     * @readonly
-     */
-    private $span;
+    private readonly FileSpan $span;
 
-    /**
-     * @var bool
-     * @readonly
-     */
-    private $guarded;
+    private readonly bool $guarded;
 
     public function __construct(string $name, Expression $expression, FileSpan $span, bool $guarded = false)
     {

--- a/src/Ast/Sass/Expression/BinaryOperationExpression.php
+++ b/src/Ast/Sass/Expression/BinaryOperationExpression.php
@@ -24,35 +24,18 @@ use ScssPhp\ScssPhp\Visitor\ExpressionVisitor;
  */
 final class BinaryOperationExpression implements Expression
 {
-    /**
-     * @var BinaryOperator::*
-     * @readonly
-     */
-    private $operator;
+    private readonly BinaryOperator $operator;
 
-    /**
-     * @var Expression
-     * @readonly
-     */
-    private $left;
+    private readonly Expression $left;
 
-    /**
-     * @var Expression
-     * @readonly
-     */
-    private $right;
+    private readonly Expression $right;
 
     /**
      * Whether this is a dividedBy operation that may be interpreted as slash-separated numbers.
-     *
-     * @var bool
      */
-    private $allowsSlash = false;
+    private bool $allowsSlash = false;
 
-    /**
-     * @param BinaryOperator::* $operator
-     */
-    public function __construct(string $operator, Expression $left, Expression $right)
+    public function __construct(BinaryOperator $operator, Expression $left, Expression $right)
     {
         $this->operator = $operator;
         $this->left = $left;
@@ -70,10 +53,7 @@ final class BinaryOperationExpression implements Expression
         return $operation;
     }
 
-    /**
-     * @return BinaryOperator::*
-     */
-    public function getOperator(): string
+    public function getOperator(): BinaryOperator
     {
         return $this->operator;
     }
@@ -139,7 +119,7 @@ final class BinaryOperationExpression implements Expression
     {
         $buffer = '';
 
-        $leftNeedsParens = ($this->left instanceof BinaryOperationExpression && BinaryOperator::getPrecedence($this->left->getOperator()) < BinaryOperator::getPrecedence($this->operator)) || ($this->left instanceof ListExpression && !$this->left->hasBrackets() && \count($this->left->getContents()) > 1);
+        $leftNeedsParens = ($this->left instanceof BinaryOperationExpression && $this->left->getOperator()->getPrecedence() < $this->operator->getPrecedence()) || ($this->left instanceof ListExpression && !$this->left->hasBrackets() && \count($this->left->getContents()) > 1);
         if ($leftNeedsParens) {
             $buffer .= '(';
         }
@@ -149,10 +129,10 @@ final class BinaryOperationExpression implements Expression
         }
 
         $buffer .= ' ';
-        $buffer .= $this->operator;
+        $buffer .= $this->operator->getOperator();
         $buffer .= ' ';
 
-        $rightNeedsParens = ($this->right instanceof BinaryOperationExpression && BinaryOperator::getPrecedence($this->right->getOperator()) <= BinaryOperator::getPrecedence($this->operator) && !($this->right->operator === $this->operator && BinaryOperator::isAssociative($this->operator))) || ($this->right instanceof ListExpression && !$this->right->hasBrackets() && \count($this->right->getContents()) > 1);
+        $rightNeedsParens = ($this->right instanceof BinaryOperationExpression && $this->right->getOperator()->getPrecedence() <= $this->operator->getPrecedence() && !($this->right->operator === $this->operator && $this->operator->isAssociative())) || ($this->right instanceof ListExpression && !$this->right->hasBrackets() && \count($this->right->getContents()) > 1);
         if ($rightNeedsParens) {
             $buffer .= '(';
         }

--- a/src/Ast/Sass/Expression/BinaryOperator.php
+++ b/src/Ast/Sass/Expression/BinaryOperator.php
@@ -15,79 +15,69 @@ namespace ScssPhp\ScssPhp\Ast\Sass\Expression;
 /**
  * @internal
  */
-final class BinaryOperator
+enum BinaryOperator
 {
-    const SINGLE_EQUALS = '=';
-    const OR = 'or';
-    const AND = 'and';
-    const EQUALS = '==';
-    const NOT_EQUALS = '!=';
-    const GREATER_THAN = '>';
-    const GREATER_THAN_OR_EQUALS = '>=';
-    const LESS_THAN = '<';
-    const LESS_THAN_OR_EQUALS = '<=';
-    const PLUS = '+';
-    const MINUS = '-';
-    const TIMES = '*';
-    const DIVIDED_BY = '/';
-    const MODULO = '%';
+    case SINGLE_EQUALS;
+    case OR;
+    case AND;
+    case EQUALS;
+    case NOT_EQUALS;
+    case GREATER_THAN;
+    case GREATER_THAN_OR_EQUALS;
+    case LESS_THAN;
+    case LESS_THAN_OR_EQUALS;
+    case PLUS;
+    case MINUS;
+    case TIMES;
+    case DIVIDED_BY;
+    case MODULO;
 
     /**
-     * @param BinaryOperator::* $operator
+     * The Sass syntax for this operator
      */
-    public static function getPrecedence(string $operator): int
+    public function getOperator(): string
     {
-        switch ($operator) {
-            case self::SINGLE_EQUALS:
-                return 0;
+        return match ($this) {
+            self::SINGLE_EQUALS => '=',
+            self::OR => 'or',
+            self::AND => 'and',
+            self::EQUALS => '==',
+            self::NOT_EQUALS => '!=',
+            self::GREATER_THAN => '>',
+            self::GREATER_THAN_OR_EQUALS => '>=',
+            self::LESS_THAN => '<',
+            self::LESS_THAN_OR_EQUALS => '<=',
+            self::PLUS => '+',
+            self::MINUS => '-',
+            self::TIMES => '*',
+            self::DIVIDED_BY => '/',
+            self::MODULO => '%',
+        };
+    }
 
-            case self::OR:
-                return 1;
-
-            case self::AND:
-                return 2;
-
-            case self::EQUALS:
-            case self::NOT_EQUALS:
-                return 3;
-
-            case self::GREATER_THAN:
-            case self::GREATER_THAN_OR_EQUALS:
-            case self::LESS_THAN:
-            case self::LESS_THAN_OR_EQUALS:
-                return 4;
-
-            case self::PLUS:
-            case self::MINUS:
-                return 5;
-
-            case self::TIMES:
-            case self::DIVIDED_BY:
-            case self::MODULO:
-                return 6;
-        }
-
-        throw new \InvalidArgumentException(sprintf('Unknown operator "%s".', $operator));
+    public function getPrecedence(): int
+    {
+        return match ($this) {
+            self::SINGLE_EQUALS => 0,
+            self::OR => 1,
+            self::AND => 2,
+            self::EQUALS, self::NOT_EQUALS => 3,
+            self::GREATER_THAN, self::GREATER_THAN_OR_EQUALS, self::LESS_THAN, self::LESS_THAN_OR_EQUALS => 4,
+            self::PLUS, self::MINUS => 5,
+            self::TIMES, self::DIVIDED_BY, self::MODULO => 6,
+        };
     }
 
     /**
      * Whether this operation has the [associative property].
      *
      * [associative property]: https://en.wikipedia.org/wiki/Associative_property
-     *
-     * @param BinaryOperator::* $operator
      */
-    public static function isAssociative(string $operator): bool
+    public function isAssociative(): bool
     {
-        switch ($operator) {
-            case self::OR:
-            case self::AND:
-            case self::PLUS:
-            case self::TIMES:
-                return true;
-
-            default:
-                return false;
-        }
+        return match ($this) {
+            self::OR, self::AND, self::PLUS, self::TIMES => true,
+            default => false,
+        };
     }
 }

--- a/src/Ast/Sass/Expression/BooleanExpression.php
+++ b/src/Ast/Sass/Expression/BooleanExpression.php
@@ -23,17 +23,9 @@ use ScssPhp\ScssPhp\Visitor\ExpressionVisitor;
  */
 final class BooleanExpression implements Expression
 {
-    /**
-     * @var bool
-     * @readonly
-     */
-    private $value;
+    private readonly bool $value;
 
-    /**
-     * @var FileSpan
-     * @readonly
-     */
-    private $span;
+    private readonly FileSpan $span;
 
     public function __construct(bool $value, FileSpan $span)
     {

--- a/src/Ast/Sass/Expression/ColorExpression.php
+++ b/src/Ast/Sass/Expression/ColorExpression.php
@@ -24,17 +24,9 @@ use ScssPhp\ScssPhp\Visitor\ExpressionVisitor;
  */
 final class ColorExpression implements Expression
 {
-    /**
-     * @var SassColor
-     * @readonly
-     */
-    private $value;
+    private readonly SassColor $value;
 
-    /**
-     * @var FileSpan
-     * @readonly
-     */
-    private $span;
+    private readonly FileSpan $span;
 
     public function __construct(SassColor $value, FileSpan $span)
     {

--- a/src/Ast/Sass/Expression/FunctionExpression.php
+++ b/src/Ast/Sass/Expression/FunctionExpression.php
@@ -32,34 +32,21 @@ final class FunctionExpression implements Expression, CallableInvocation, SassRe
 {
     /**
      * The name of the function being invoked, with underscores left as-is.
-     *
-     * @var string
-     * @readonly
      */
-    private $originalName;
+    private readonly string $originalName;
 
     /**
      * The arguments to pass to the function.
-     *
-     * @var ArgumentInvocation
-     * @readonly
      */
-    private $arguments;
+    private readonly ArgumentInvocation $arguments;
 
     /**
      * The namespace of the function being invoked, or `null` if it's invoked
      * without a namespace.
-     *
-     * @var string|null
-     * @readonly
      */
-    private $namespace;
+    private readonly ?string $namespace;
 
-    /**
-     * @var FileSpan
-     * @readonly
-     */
-    private $span;
+    private readonly FileSpan $span;
 
     public function __construct(string $originalName, ArgumentInvocation $arguments, FileSpan $span, ?string $namespace = null)
     {
@@ -69,9 +56,6 @@ final class FunctionExpression implements Expression, CallableInvocation, SassRe
         $this->namespace = $namespace;
     }
 
-    /**
-     * @return string
-     */
     public function getOriginalName(): string
     {
         return $this->originalName;

--- a/src/Ast/Sass/Expression/IfExpression.php
+++ b/src/Ast/Sass/Expression/IfExpression.php
@@ -32,22 +32,12 @@ final class IfExpression implements Expression, CallableInvocation
 {
     /**
      * The arguments passed to `if()`.
-     *
-     * @var ArgumentInvocation
-     * @readonly
      */
-    private $arguments;
+    private readonly ArgumentInvocation $arguments;
 
-    /**
-     * @var FileSpan
-     * @readonly
-     */
-    private $span;
+    private readonly FileSpan $span;
 
-    /**
-     * @var ArgumentDeclaration|null
-     */
-    private static $declaration;
+    private static ?ArgumentDeclaration $declaration;
 
     public function __construct(ArgumentInvocation $arguments, FileSpan $span)
     {

--- a/src/Ast/Sass/Expression/InterpolatedFunctionExpression.php
+++ b/src/Ast/Sass/Expression/InterpolatedFunctionExpression.php
@@ -30,25 +30,15 @@ final class InterpolatedFunctionExpression implements Expression, CallableInvoca
 {
     /**
      * The name of the function being invoked.
-     *
-     * @var Interpolation
-     * @readonly
      */
-    private $name;
+    private readonly Interpolation $name;
 
     /**
      * The arguments to pass to the function.
-     *
-     * @var ArgumentInvocation
-     * @readonly
      */
-    private $arguments;
+    private readonly ArgumentInvocation $arguments;
 
-    /**
-     * @var FileSpan
-     * @readonly
-     */
-    private $span;
+    private readonly FileSpan $span;
 
     public function __construct(Interpolation $name, ArgumentInvocation $arguments, FileSpan $span)
     {

--- a/src/Ast/Sass/Expression/IsCalculationSafeVisitor.php
+++ b/src/Ast/Sass/Expression/IsCalculationSafeVisitor.php
@@ -56,9 +56,7 @@ final class IsCalculationSafeVisitor implements ExpressionVisitor
 
     public function visitListExpression(ListExpression $node): bool
     {
-        return $node->getSeparator() === ListSeparator::SPACE && !$node->hasBrackets() && \count($node->getContents()) > 1 && ListUtil::every($node->getContents(), function (Expression $expression) {
-            return $expression->accept($this);
-        });
+        return $node->getSeparator() === ListSeparator::SPACE && !$node->hasBrackets() && \count($node->getContents()) > 1 && ListUtil::every($node->getContents(), fn(Expression $expression) => $expression->accept($this));
     }
 
     public function visitMapExpression(MapExpression $node): bool

--- a/src/Ast/Sass/Expression/IsCalculationSafeVisitor.php
+++ b/src/Ast/Sass/Expression/IsCalculationSafeVisitor.php
@@ -100,9 +100,9 @@ final class IsCalculationSafeVisitor implements ExpressionVisitor
         $text = $node->getText()->getInitialPlain();
 
         // !important
-        return 0 !== strpos($text, '!')
+        return !str_starts_with($text, '!')
             // ID-style identifiers
-            && 0 !== strpos($text, '#')
+            && !str_starts_with($text, '#')
             // Unicode ranges
             && ($text[1] ?? null) !== '+'
             // url()

--- a/src/Ast/Sass/Expression/ListExpression.php
+++ b/src/Ast/Sass/Expression/ListExpression.php
@@ -85,9 +85,10 @@ final class ListExpression implements Expression
             $buffer .= '(';
         }
 
-        $buffer .= implode($this->separator === ListSeparator::COMMA ? ', ' : ' ', array_map(function ($element) {
-            return $this->elementNeedsParens($element) ? "($element)" : (string) $element;
-        }, $this->contents));
+        $buffer .= implode(
+            $this->separator === ListSeparator::COMMA ? ', ' : ' ',
+            array_map(fn($element) => $this->elementNeedsParens($element) ? "($element)" : (string) $element, $this->contents)
+        );
 
         if ($this->hasBrackets()) {
             $buffer .= ']';

--- a/src/Ast/Sass/Expression/ListExpression.php
+++ b/src/Ast/Sass/Expression/ListExpression.php
@@ -25,36 +25,22 @@ use ScssPhp\ScssPhp\Visitor\ExpressionVisitor;
 final class ListExpression implements Expression
 {
     /**
-     * @var Expression[]
-     * @readonly
+     * @var list<Expression>
      */
-    private $contents;
+    private readonly array $contents;
 
-    /**
-     * @var ListSeparator::*
-     * @readonly
-     */
-    private $separator;
+    private readonly ListSeparator $separator;
 
-    /**
-     * @var FileSpan
-     * @readonly
-     */
-    private $span;
+    private readonly FileSpan $span;
 
-    /**
-     * @var bool
-     * @readonly
-     */
-    private $brackets;
+    private readonly bool $brackets;
 
     /**
      * ListExpression constructor.
      *
-     * @param Expression[] $contents
-     * @param ListSeparator::* $separator
+     * @param list<Expression> $contents
      */
-    public function __construct(array $contents, string $separator, FileSpan $span, bool $brackets = false)
+    public function __construct(array $contents, ListSeparator $separator, FileSpan $span, bool $brackets = false)
     {
         $this->contents = $contents;
         $this->separator = $separator;
@@ -63,17 +49,14 @@ final class ListExpression implements Expression
     }
 
     /**
-     * @return Expression[]
+     * @return list<Expression>
      */
     public function getContents(): array
     {
         return $this->contents;
     }
 
-    /**
-     * @return ListSeparator::*
-     */
-    public function getSeparator(): string
+    public function getSeparator(): ListSeparator
     {
         return $this->separator;
     }

--- a/src/Ast/Sass/Expression/MapExpression.php
+++ b/src/Ast/Sass/Expression/MapExpression.php
@@ -59,8 +59,6 @@ final class MapExpression implements Expression
 
     public function __toString(): string
     {
-        return '(' . implode(', ', array_map(function ($pair) {
-            return $pair[0] . ': ' . $pair[1];
-        }, $this->pairs)) . ')';
+        return '(' . implode(', ', array_map(fn($pair) => $pair[0] . ': ' . $pair[1], $this->pairs)) . ')';
     }
 }

--- a/src/Ast/Sass/Expression/MapExpression.php
+++ b/src/Ast/Sass/Expression/MapExpression.php
@@ -25,15 +25,10 @@ final class MapExpression implements Expression
 {
     /**
      * @var list<array{Expression, Expression}>
-     * @readonly
      */
-    private $pairs;
+    private readonly array $pairs;
 
-    /**
-     * @var FileSpan
-     * @readonly
-     */
-    private $span;
+    private readonly FileSpan $span;
 
     /**
      * @param list<array{Expression, Expression}> $pairs

--- a/src/Ast/Sass/Expression/NullExpression.php
+++ b/src/Ast/Sass/Expression/NullExpression.php
@@ -23,11 +23,7 @@ use ScssPhp\ScssPhp\Visitor\ExpressionVisitor;
  */
 final class NullExpression implements Expression
 {
-    /**
-     * @var FileSpan
-     * @readonly
-     */
-    private $span;
+    private readonly FileSpan $span;
 
     public function __construct(FileSpan $span)
     {

--- a/src/Ast/Sass/Expression/NumberExpression.php
+++ b/src/Ast/Sass/Expression/NumberExpression.php
@@ -24,23 +24,11 @@ use ScssPhp\ScssPhp\Visitor\ExpressionVisitor;
  */
 final class NumberExpression implements Expression
 {
-    /**
-     * @var float
-     * @readonly
-     */
-    private $value;
+    private readonly float $value;
 
-    /**
-     * @var FileSpan
-     * @readonly
-     */
-    private $span;
+    private readonly FileSpan $span;
 
-    /**
-     * @var string|null
-     * @readonly
-     */
-    private $unit;
+    private readonly ?string $unit;
 
     public function __construct(float $value, FileSpan $span, ?string $unit = null)
     {

--- a/src/Ast/Sass/Expression/ParenthesizedExpression.php
+++ b/src/Ast/Sass/Expression/ParenthesizedExpression.php
@@ -23,17 +23,9 @@ use ScssPhp\ScssPhp\Visitor\ExpressionVisitor;
  */
 final class ParenthesizedExpression implements Expression
 {
-    /**
-     * @var Expression
-     * @readonly
-     */
-    private $expression;
+    private readonly Expression $expression;
 
-    /**
-     * @var FileSpan
-     * @readonly
-     */
-    private $span;
+    private readonly FileSpan $span;
 
     public function __construct(Expression $expression, FileSpan $span)
     {

--- a/src/Ast/Sass/Expression/SelectorExpression.php
+++ b/src/Ast/Sass/Expression/SelectorExpression.php
@@ -23,11 +23,7 @@ use ScssPhp\ScssPhp\Visitor\ExpressionVisitor;
  */
 final class SelectorExpression implements Expression
 {
-    /**
-     * @var FileSpan
-     * @readonly
-     */
-    private $span;
+    private readonly FileSpan $span;
 
     public function __construct(FileSpan $span)
     {

--- a/src/Ast/Sass/Expression/StringExpression.php
+++ b/src/Ast/Sass/Expression/StringExpression.php
@@ -26,17 +26,9 @@ use ScssPhp\ScssPhp\Visitor\ExpressionVisitor;
  */
 final class StringExpression implements Expression
 {
-    /**
-     * @var Interpolation
-     * @readonly
-     */
-    private $text;
+    private readonly Interpolation $text;
 
-    /**
-     * @var bool
-     * @readonly
-     */
-    private $quotes;
+    private readonly bool $quotes;
 
     public function __construct(Interpolation $text, bool $quotes = false)
     {
@@ -151,8 +143,6 @@ final class StringExpression implements Expression
 
     /**
      * @param array<string|Expression> $parts
-     *
-     * @return string
      */
     private static function bestQuote(array $parts): string
     {
@@ -163,11 +153,11 @@ final class StringExpression implements Expression
                 continue;
             }
 
-            if (false !== strpos($part, "'")) {
+            if (str_contains($part, "'")) {
                 return '"';
             }
 
-            if (false !== strpos($part, '"')) {
+            if (str_contains($part, '"')) {
                 $containsDoubleQuote = true;
             }
         }

--- a/src/Ast/Sass/Expression/SupportsExpression.php
+++ b/src/Ast/Sass/Expression/SupportsExpression.php
@@ -27,11 +27,7 @@ use ScssPhp\ScssPhp\Visitor\ExpressionVisitor;
  */
 final class SupportsExpression implements Expression
 {
-    /**
-     * @var SupportsCondition
-     * @readonly
-     */
-    private $condition;
+    private readonly SupportsCondition $condition;
 
     public function __construct(SupportsCondition $condition)
     {

--- a/src/Ast/Sass/Expression/UnaryOperationExpression.php
+++ b/src/Ast/Sass/Expression/UnaryOperationExpression.php
@@ -23,38 +23,20 @@ use ScssPhp\ScssPhp\Visitor\ExpressionVisitor;
  */
 final class UnaryOperationExpression implements Expression
 {
-    /**
-     * @var UnaryOperator::*
-     * @readonly
-     */
-    private $operator;
+    private readonly UnaryOperator $operator;
 
-    /**
-     * @var Expression
-     * @readonly
-     */
-    private $operand;
+    private readonly Expression $operand;
 
-    /**
-     * @var FileSpan
-     * @readonly
-     */
-    private $span;
+    private readonly FileSpan $span;
 
-    /**
-     * @param UnaryOperator::* $operator
-     */
-    public function __construct(string $operator, Expression $operand, FileSpan $span)
+    public function __construct(UnaryOperator $operator, Expression $operand, FileSpan $span)
     {
         $this->operator = $operator;
         $this->operand = $operand;
         $this->span = $span;
     }
 
-    /**
-     * @return UnaryOperator::*
-     */
-    public function getOperator()
+    public function getOperator(): UnaryOperator
     {
         return $this->operator;
     }
@@ -76,7 +58,7 @@ final class UnaryOperationExpression implements Expression
 
     public function __toString(): string
     {
-        $buffer = $this->operator;
+        $buffer = $this->operator->getOperator();
         if ($this->operator === UnaryOperator::NOT) {
             $buffer .= ' ';
         }

--- a/src/Ast/Sass/Expression/UnaryOperator.php
+++ b/src/Ast/Sass/Expression/UnaryOperator.php
@@ -15,10 +15,23 @@ namespace ScssPhp\ScssPhp\Ast\Sass\Expression;
 /**
  * @internal
  */
-final class UnaryOperator
+enum UnaryOperator
 {
-    const PLUS = '+';
-    const MINUS = '-';
-    const DIVIDE = '/';
-    const NOT = 'not';
+    case PLUS;
+    case MINUS;
+    case DIVIDE;
+    case NOT;
+
+    /**
+     * The Sass syntax for this operator
+     */
+    public function getOperator(): string
+    {
+        return match($this) {
+            self::PLUS => '+',
+            self::MINUS => '-',
+            self::DIVIDE => '/',
+            self::NOT => 'not',
+        };
+    }
 }

--- a/src/Ast/Sass/Expression/ValueExpression.php
+++ b/src/Ast/Sass/Expression/ValueExpression.php
@@ -27,17 +27,9 @@ use ScssPhp\ScssPhp\Visitor\ExpressionVisitor;
  */
 final class ValueExpression implements Expression
 {
-    /**
-     * @var Value
-     * @readonly
-     */
-    private $value;
+    private readonly Value $value;
 
-    /**
-     * @var FileSpan
-     * @readonly
-     */
-    private $span;
+    private readonly FileSpan $span;
 
     public function __construct(Value $value, FileSpan $span)
     {

--- a/src/Ast/Sass/Expression/VariableExpression.php
+++ b/src/Ast/Sass/Expression/VariableExpression.php
@@ -27,26 +27,16 @@ final class VariableExpression implements Expression, SassReference
 {
     /**
      * The name of this variable, with underscores converted to hyphens.
-     *
-     * @var string
-     * @readonly
      */
-    private $name;
+    private readonly string $name;
 
     /**
      * The namespace of the variable being referenced, or `null` if it's
      * referenced without a namespace.
-     *
-     * @var string|null
-     * @readonly
      */
-    private $namespace;
+    private ?string $namespace;
 
-    /**
-     * @var FileSpan
-     * @readonly
-     */
-    private $span;
+    private readonly FileSpan $span;
 
     public function __construct(string $name, FileSpan $span, ?string $namespace = null)
     {

--- a/src/Ast/Sass/Import/DynamicImport.php
+++ b/src/Ast/Sass/Import/DynamicImport.php
@@ -42,7 +42,7 @@ final class DynamicImport implements Import
 
     public function getUrl(): UriInterface
     {
-        return Uri::createFromString($this->urlString);
+        return Uri::new($this->urlString);
     }
 
     public function getUrlString(): string

--- a/src/Ast/Sass/Import/DynamicImport.php
+++ b/src/Ast/Sass/Import/DynamicImport.php
@@ -12,6 +12,8 @@
 
 namespace ScssPhp\ScssPhp\Ast\Sass\Import;
 
+use League\Uri\Contracts\UriInterface;
+use League\Uri\Uri;
 use ScssPhp\ScssPhp\Ast\Sass\Expression\StringExpression;
 use ScssPhp\ScssPhp\Ast\Sass\Import;
 use ScssPhp\ScssPhp\SourceSpan\FileSpan;
@@ -27,22 +29,20 @@ final class DynamicImport implements Import
      * The URI of the file to import.
      *
      * If this is relative, it's relative to the containing file.
-     *
-     * @var string
-     * @readonly
      */
-    private $urlString;
+    private readonly string $urlString;
 
-    /**
-     * @var FileSpan
-     * @readonly
-     */
-    private $span;
+    private readonly FileSpan $span;
 
     public function __construct(string $urlString, FileSpan $span)
     {
         $this->urlString = $urlString;
         $this->span = $span;
+    }
+
+    public function getUrl(): UriInterface
+    {
+        return Uri::createFromString($this->urlString);
     }
 
     public function getUrlString(): string

--- a/src/Ast/Sass/Import/StaticImport.php
+++ b/src/Ast/Sass/Import/StaticImport.php
@@ -27,26 +27,16 @@ final class StaticImport implements Import
      * The URL for this import.
      *
      * This already contains quotes.
-     *
-     * @var Interpolation
-     * @readonly
      */
-    private $url;
+    private readonly Interpolation $url;
 
     /**
      * The modifiers (such as media or supports queries) attached to this import,
      * or `null` if none are attached.
-     *
-     * @var Interpolation|null
-     * @readonly
      */
-    private $modifiers;
+    private readonly ?Interpolation $modifiers;
 
-    /**
-     * @var FileSpan
-     * @readonly
-     */
-    private $span;
+    private readonly FileSpan $span;
 
     public function __construct(Interpolation $url, FileSpan $span, ?Interpolation $modifiers = null)
     {

--- a/src/Ast/Sass/Interpolation.php
+++ b/src/Ast/Sass/Interpolation.php
@@ -24,15 +24,10 @@ final class Interpolation implements SassNode
 {
     /**
      * @var list<string|Expression>
-     * @readonly
      */
-    private $contents;
+    private readonly array $contents;
 
-    /**
-     * @var FileSpan
-     * @readonly
-     */
-    private $span;
+    private readonly FileSpan $span;
 
     /**
      * Creates a new {@see Interpolation} by concatenating a sequence of strings,

--- a/src/Ast/Sass/Interpolation.php
+++ b/src/Ast/Sass/Interpolation.php
@@ -134,8 +134,6 @@ final class Interpolation implements SassNode
 
     public function __toString(): string
     {
-        return implode('', array_map(function ($value) {
-            return \is_string($value) ? $value : '#{' . $value .'}';
-        }, $this->contents));
+        return implode('', array_map(fn($value) => \is_string($value) ? $value : '#{' . $value .'}', $this->contents));
     }
 }

--- a/src/Ast/Sass/Interpolation.php
+++ b/src/Ast/Sass/Interpolation.php
@@ -47,7 +47,7 @@ final class Interpolation implements SassNode
             } elseif ($element instanceof Interpolation) {
                 $buffer->addInterpolation($element);
             } else {
-                throw new \InvalidArgumentException(sprintf('The elements in $contents may only contains strings, Expressions, or Interpolations, "%s" given.', \is_object($element) ? get_class($element) : gettype($element)));
+                throw new \InvalidArgumentException(sprintf('The elements in $contents may only contains strings, Expressions, or Interpolations, "%s" given.', get_debug_type($element)));
             }
         }
 

--- a/src/Ast/Sass/Statement/AtRootRule.php
+++ b/src/Ast/Sass/Statement/AtRootRule.php
@@ -28,17 +28,9 @@ use ScssPhp\ScssPhp\Visitor\StatementVisitor;
  */
 final class AtRootRule extends ParentStatement
 {
-    /**
-     * @var Interpolation|null
-     * @readonly
-     */
-    private $query;
+    private readonly ?Interpolation $query;
 
-    /**
-     * @var FileSpan
-     * @readonly
-     */
-    private $span;
+    private readonly FileSpan $span;
 
     /**
      * @param Statement[] $children

--- a/src/Ast/Sass/Statement/AtRule.php
+++ b/src/Ast/Sass/Statement/AtRule.php
@@ -26,23 +26,11 @@ use ScssPhp\ScssPhp\Visitor\StatementVisitor;
  */
 final class AtRule extends ParentStatement
 {
-    /**
-     * @var Interpolation
-     * @readonly
-     */
-    private $name;
+    private readonly Interpolation $name;
 
-    /**
-     * @var Interpolation|null
-     * @readonly
-     */
-    private $value;
+    private readonly ?Interpolation $value;
 
-    /**
-     * @var FileSpan
-     * @readonly
-     */
-    private $span;
+    private readonly FileSpan $span;
 
     /**
      * @param Statement[]|null $children

--- a/src/Ast/Sass/Statement/CallableDeclaration.php
+++ b/src/Ast/Sass/Statement/CallableDeclaration.php
@@ -26,29 +26,13 @@ use ScssPhp\ScssPhp\SourceSpan\FileSpan;
  */
 abstract class CallableDeclaration extends ParentStatement
 {
-    /**
-     * @var string
-     * @readonly
-     */
-    private $name;
+    private readonly string $name;
 
-    /**
-     * @var ArgumentDeclaration
-     * @readonly
-     */
-    private $arguments;
+    private readonly ArgumentDeclaration $arguments;
 
-    /**
-     * @var SilentComment|null
-     * @readonly
-     */
-    private $comment;
+    private readonly ?SilentComment $comment;
 
-    /**
-     * @var FileSpan
-     * @readonly
-     */
-    private $span;
+    private readonly FileSpan $span;
 
     /**
      * @param Statement[] $children
@@ -75,9 +59,6 @@ abstract class CallableDeclaration extends ParentStatement
         return $this->arguments;
     }
 
-    /**
-     * @return SilentComment|null
-     */
     final public function getComment(): ?SilentComment
     {
         return $this->comment;

--- a/src/Ast/Sass/Statement/ContentRule.php
+++ b/src/Ast/Sass/Statement/ContentRule.php
@@ -31,17 +31,10 @@ final class ContentRule implements Statement
      * The arguments pass to this `@content` rule.
      *
      * This will be an empty invocation if `@content` has no arguments.
-     *
-     * @var ArgumentInvocation
-     * @readonly
      */
-    private $arguments;
+    private readonly ArgumentInvocation $arguments;
 
-    /**
-     * @var FileSpan
-     * @readonly
-     */
-    private $span;
+    private readonly FileSpan $span;
 
     public function __construct(ArgumentInvocation $arguments, FileSpan $span)
     {

--- a/src/Ast/Sass/Statement/DebugRule.php
+++ b/src/Ast/Sass/Statement/DebugRule.php
@@ -26,17 +26,9 @@ use ScssPhp\ScssPhp\Visitor\StatementVisitor;
  */
 final class DebugRule implements Statement
 {
-    /**
-     * @var Expression
-     * @readonly
-     */
-    private $expression;
+    private readonly Expression $expression;
 
-    /**
-     * @var FileSpan
-     * @readonly
-     */
-    private $span;
+    private readonly FileSpan $span;
 
     public function __construct(Expression $expression, FileSpan $span)
     {

--- a/src/Ast/Sass/Statement/Declaration.php
+++ b/src/Ast/Sass/Statement/Declaration.php
@@ -28,28 +28,17 @@ use ScssPhp\ScssPhp\Visitor\StatementVisitor;
  */
 final class Declaration extends ParentStatement
 {
-    /**
-     * @var Interpolation
-     * @readonly
-     */
-    private $name;
+    private readonly Interpolation $name;
 
     /**
      * The value of this declaration.
      *
      * If {@see getChildren} is `null`, this is never `null`. Otherwise, it may or may
      * not be `null`.
-     *
-     * @var Expression|null
-     * @readonly
      */
-    private $value;
+    private readonly ?Expression $value;
 
-    /**
-     * @var FileSpan
-     * @readonly
-     */
-    private $span;
+    private readonly FileSpan $span;
 
     /**
      * @param Statement[]|null $children
@@ -96,7 +85,7 @@ final class Declaration extends ParentStatement
      */
     public function isCustomProperty(): bool
     {
-        return 0 === strpos($this->name->getInitialPlain(), '--');
+        return str_starts_with($this->name->getInitialPlain(), '--');
     }
 
     public function getSpan(): FileSpan

--- a/src/Ast/Sass/Statement/EachRule.php
+++ b/src/Ast/Sass/Statement/EachRule.php
@@ -74,6 +74,6 @@ final class EachRule extends ParentStatement
 
     public function __toString(): string
     {
-        return '@each ' . implode(', ', array_map(function ($variable) { return '$' . $variable; }, $this->variables)) . ' in ' . $this->list . ' {' . implode(' ', $this->getChildren()) . '}';
+        return '@each ' . implode(', ', array_map(fn($variable) => '$' . $variable, $this->variables)) . ' in ' . $this->list . ' {' . implode(' ', $this->getChildren()) . '}';
     }
 }

--- a/src/Ast/Sass/Statement/EachRule.php
+++ b/src/Ast/Sass/Statement/EachRule.php
@@ -29,25 +29,16 @@ use ScssPhp\ScssPhp\Visitor\StatementVisitor;
 final class EachRule extends ParentStatement
 {
     /**
-     * @var string[]
-     * @readonly
+     * @var list<string>
      */
-    private $variables;
+    private readonly array $variables;
+
+    private readonly Expression $list;
+
+    private readonly FileSpan $span;
 
     /**
-     * @var Expression
-     * @readonly
-     */
-    private $list;
-
-    /**
-     * @var FileSpan
-     * @readonly
-     */
-    private $span;
-
-    /**
-     * @param string[]    $variables
+     * @param list<string> $variables
      * @param Statement[] $children
      */
     public function __construct(array $variables, Expression $list, array $children, FileSpan $span)
@@ -59,7 +50,7 @@ final class EachRule extends ParentStatement
     }
 
     /**
-     * @return string[]
+     * @return list<string>
      */
     public function getVariables(): array
     {

--- a/src/Ast/Sass/Statement/ErrorRule.php
+++ b/src/Ast/Sass/Statement/ErrorRule.php
@@ -26,17 +26,9 @@ use ScssPhp\ScssPhp\Visitor\StatementVisitor;
  */
 final class ErrorRule implements Statement
 {
-    /**
-     * @var Expression
-     * @readonly
-     */
-    private $expression;
+    private readonly Expression $expression;
 
-    /**
-     * @var FileSpan
-     * @readonly
-     */
-    private $span;
+    private readonly FileSpan $span;
 
     public function __construct(Expression $expression, FileSpan $span)
     {

--- a/src/Ast/Sass/Statement/ExtendRule.php
+++ b/src/Ast/Sass/Statement/ExtendRule.php
@@ -26,23 +26,11 @@ use ScssPhp\ScssPhp\Visitor\StatementVisitor;
  */
 final class ExtendRule implements Statement
 {
-    /**
-     * @var Interpolation
-     * @readonly
-     */
-    private $selector;
+    private readonly Interpolation $selector;
 
-    /**
-     * @var FileSpan
-     * @readonly
-     */
-    private $span;
+    private readonly FileSpan $span;
 
-    /**
-     * @var bool
-     * @readonly
-     */
-    private $optional;
+    private readonly bool $optional;
 
     public function __construct(Interpolation $selector, FileSpan $span, bool $optional = false)
     {

--- a/src/Ast/Sass/Statement/ForRule.php
+++ b/src/Ast/Sass/Statement/ForRule.php
@@ -28,35 +28,15 @@ use ScssPhp\ScssPhp\Visitor\StatementVisitor;
  */
 final class ForRule extends ParentStatement
 {
-    /**
-     * @var string
-     * @readonly
-     */
-    private $variable;
+    private readonly string $variable;
 
-    /**
-     * @var Expression
-     * @readonly
-     */
-    private $from;
+    private readonly Expression $from;
 
-    /**
-     * @var Expression
-     * @readonly
-     */
-    private $to;
+    private readonly Expression $to;
 
-    /**
-     * @var bool
-     * @readonly
-     */
-    private $exclusive;
+    private readonly bool $exclusive;
 
-    /**
-     * @var FileSpan
-     * @readonly
-     */
-    private $span;
+    private readonly FileSpan $span;
 
     /**
      * @param Statement[] $children

--- a/src/Ast/Sass/Statement/IfClause.php
+++ b/src/Ast/Sass/Statement/IfClause.php
@@ -22,11 +22,7 @@ use ScssPhp\ScssPhp\Ast\Sass\Statement;
  */
 final class IfClause extends IfRuleClause
 {
-    /**
-     * @var Expression
-     * @readonly
-     */
-    private $expression;
+    private readonly Expression $expression;
 
     /**
      * @param Statement[] $children

--- a/src/Ast/Sass/Statement/IfRule.php
+++ b/src/Ast/Sass/Statement/IfRule.php
@@ -26,25 +26,16 @@ use ScssPhp\ScssPhp\Visitor\StatementVisitor;
 final class IfRule implements Statement
 {
     /**
-     * @var IfClause[]
-     * @readonly
+     * @var list<IfClause>
      */
-    private $clauses;
+    private readonly array $clauses;
+
+    private readonly ?ElseClause $lastClause;
+
+    private readonly FileSpan $span;
 
     /**
-     * @var ElseClause|null
-     * @readonly
-     */
-    private $lastClause;
-
-    /**
-     * @var FileSpan
-     * @readonly
-     */
-    private $span;
-
-    /**
-     * @param IfClause[] $clauses
+     * @param list<IfClause> $clauses
      */
     public function __construct(array $clauses, FileSpan $span, ?ElseClause $lastClause = null)
     {
@@ -60,7 +51,7 @@ final class IfRule implements Statement
      * statements executed. If no expression evaluates to `true`, `lastClause`
      * will be executed if it's not `null`.
      *
-     * @return IfClause[]
+     * @return list<IfClause>
      */
     public function getClauses(): array
     {
@@ -71,8 +62,6 @@ final class IfRule implements Statement
      * The final, unconditional `@else` clause.
      *
      * This is `null` if there is no unconditional `@else`.
-     *
-     * @return ElseClause|null
      */
     public function getLastClause(): ?ElseClause
     {

--- a/src/Ast/Sass/Statement/ImportRule.php
+++ b/src/Ast/Sass/Statement/ImportRule.php
@@ -25,19 +25,14 @@ use ScssPhp\ScssPhp\Visitor\StatementVisitor;
 final class ImportRule implements Statement
 {
     /**
-     * @var Import[]
-     * @readonly
+     * @var list<Import>
      */
-    private $imports;
+    private readonly array $imports;
+
+    private readonly FileSpan $span;
 
     /**
-     * @var FileSpan
-     * @readonly
-     */
-    private $span;
-
-    /**
-     * @param Import[] $imports
+     * @param list<Import> $imports
      */
     public function __construct(array $imports, FileSpan $span)
     {
@@ -46,7 +41,7 @@ final class ImportRule implements Statement
     }
 
     /**
-     * @return Import[]
+     * @return list<Import>
      */
     public function getImports(): array
     {

--- a/src/Ast/Sass/Statement/IncludeRule.php
+++ b/src/Ast/Sass/Statement/IncludeRule.php
@@ -27,37 +27,17 @@ use ScssPhp\ScssPhp\Visitor\StatementVisitor;
  */
 final class IncludeRule implements Statement, CallableInvocation, SassReference
 {
-    /**
-     * @var string|null
-     * @readonly
-     */
-    private $namespace;
+    private readonly ?string $namespace;
 
-    /**
-     * @var string
-     * @readonly
-     */
-    private $name;
+    private readonly string $name;
 
-    /**
-     * @var ArgumentInvocation
-     * @readonly
-     */
-    private $arguments;
+    private readonly ArgumentInvocation $arguments;
 
-    /**
-     * @var ContentBlock|null
-     * @readonly
-     */
-    private $content;
+    private readonly ?ContentBlock $content;
 
-    /**
-     * @var FileSpan
-     * @readonly
-     */
-    private $span;
+    private readonly FileSpan $span;
 
-    public function __construct(string $name, ArgumentInvocation $arguments, FileSpan $span, ?string $namespace = null,?ContentBlock $content = null)
+    public function __construct(string $name, ArgumentInvocation $arguments, FileSpan $span, ?string $namespace = null, ?ContentBlock $content = null)
     {
         $this->name = $name;
         $this->arguments = $arguments;

--- a/src/Ast/Sass/Statement/LoudComment.php
+++ b/src/Ast/Sass/Statement/LoudComment.php
@@ -24,11 +24,7 @@ use ScssPhp\ScssPhp\Visitor\StatementVisitor;
  */
 final class LoudComment implements Statement
 {
-    /**
-     * @var Interpolation
-     * @readonly
-     */
-    private $text;
+    private readonly Interpolation $text;
 
     public function __construct(Interpolation $text)
     {

--- a/src/Ast/Sass/Statement/MediaRule.php
+++ b/src/Ast/Sass/Statement/MediaRule.php
@@ -26,17 +26,9 @@ use ScssPhp\ScssPhp\Visitor\StatementVisitor;
  */
 final class MediaRule extends ParentStatement
 {
-    /**
-     * @var Interpolation
-     * @readonly
-     */
-    private $query;
+    private readonly Interpolation $query;
 
-    /**
-     * @var FileSpan
-     * @readonly
-     */
-    private $span;
+    private readonly FileSpan $span;
 
     /**
      * @param Statement[] $children

--- a/src/Ast/Sass/Statement/MixinRule.php
+++ b/src/Ast/Sass/Statement/MixinRule.php
@@ -30,10 +30,8 @@ final class MixinRule extends CallableDeclaration implements SassDeclaration
 {
     /**
      * Whether the mixin contains a `@content` rule.
-     *
-     * @var bool|null
      */
-    private $content;
+    private ?bool $content;
 
     /**
      * @param Statement[] $children

--- a/src/Ast/Sass/Statement/ParentStatement.php
+++ b/src/Ast/Sass/Statement/ParentStatement.php
@@ -30,15 +30,10 @@ abstract class ParentStatement implements Statement
 {
     /**
      * @var T
-     * @readonly
      */
-    private $children;
+    private readonly ?array $children;
 
-    /**
-     * @var bool
-     * @readonly
-     */
-    private $declarations;
+    private readonly bool $declarations;
 
     /**
      * @param T $children
@@ -74,7 +69,7 @@ abstract class ParentStatement implements Statement
     /**
      * @return T
      */
-    final public function getChildren()
+    final public function getChildren(): ?array
     {
         return $this->children;
     }

--- a/src/Ast/Sass/Statement/ReturnRule.php
+++ b/src/Ast/Sass/Statement/ReturnRule.php
@@ -26,17 +26,9 @@ use ScssPhp\ScssPhp\Visitor\StatementVisitor;
  */
 final class ReturnRule implements Statement
 {
-    /**
-     * @var Expression
-     * @readonly
-     */
-    private $expression;
+    private readonly Expression $expression;
 
-    /**
-     * @var FileSpan
-     * @readonly
-     */
-    private $span;
+    private readonly FileSpan $span;
 
     public function __construct(Expression $expression, FileSpan $span)
     {

--- a/src/Ast/Sass/Statement/SilentComment.php
+++ b/src/Ast/Sass/Statement/SilentComment.php
@@ -23,17 +23,9 @@ use ScssPhp\ScssPhp\Visitor\StatementVisitor;
  */
 final class SilentComment implements Statement
 {
-    /**
-     * @var string
-     * @readonly
-     */
-    private $text;
+    private readonly string $text;
 
-    /**
-     * @var FileSpan
-     * @readonly
-     */
-    private $span;
+    private readonly FileSpan $span;
 
     public function __construct(string $text, FileSpan $span)
     {

--- a/src/Ast/Sass/Statement/StyleRule.php
+++ b/src/Ast/Sass/Statement/StyleRule.php
@@ -28,17 +28,9 @@ use ScssPhp\ScssPhp\Visitor\StatementVisitor;
  */
 final class StyleRule extends ParentStatement
 {
-    /**
-     * @var Interpolation
-     * @readonly
-     */
-    private $selector;
+    private readonly Interpolation $selector;
 
-    /**
-     * @var FileSpan
-     * @readonly
-     */
-    private $span;
+    private readonly FileSpan $span;
 
     /**
      * @param Statement[] $children

--- a/src/Ast/Sass/Statement/Stylesheet.php
+++ b/src/Ast/Sass/Statement/Stylesheet.php
@@ -33,17 +33,9 @@ use ScssPhp\ScssPhp\Visitor\StatementVisitor;
  */
 final class Stylesheet extends ParentStatement
 {
-    /**
-     * @var bool
-     * @readonly
-     */
-    private $plainCss;
+    private readonly bool $plainCss;
 
-    /**
-     * @var FileSpan
-     * @readonly
-     */
-    private $span;
+    private readonly FileSpan $span;
 
     /**
      * @param Statement[] $children
@@ -71,25 +63,15 @@ final class Stylesheet extends ParentStatement
     }
 
     /**
-     * @param Syntax::* $syntax
-     *
      * @throws SassFormatException when parsing fails
      */
-    public static function parse(string $contents, string $syntax, ?LoggerInterface $logger = null, ?string $sourceUrl = null): self
+    public static function parse(string $contents, Syntax $syntax, ?LoggerInterface $logger = null, ?string $sourceUrl = null): self
     {
-        switch ($syntax) {
-            case Syntax::SASS:
-                return self::parseSass($contents, $logger, $sourceUrl);
-
-            case Syntax::SCSS:
-                return self::parseScss($contents, $logger, $sourceUrl);
-
-            case Syntax::CSS:
-                return self::parseCss($contents, $logger, $sourceUrl);
-
-            default:
-                throw new \InvalidArgumentException("Unknown syntax $syntax.");
-        }
+        return match($syntax) {
+            Syntax::SASS => self::parseSass($contents, $logger, $sourceUrl),
+            Syntax::SCSS => self::parseScss($contents, $logger, $sourceUrl),
+            Syntax::CSS => self::parseCss($contents, $logger, $sourceUrl),
+        };
     }
 
     /**

--- a/src/Ast/Sass/Statement/SupportsRule.php
+++ b/src/Ast/Sass/Statement/SupportsRule.php
@@ -26,17 +26,9 @@ use ScssPhp\ScssPhp\Visitor\StatementVisitor;
  */
 final class SupportsRule extends ParentStatement
 {
-    /**
-     * @var SupportsCondition
-     * @readonly
-     */
-    private $condition;
+    private readonly SupportsCondition $condition;
 
-    /**
-     * @var FileSpan
-     * @readonly
-     */
-    private $span;
+    private readonly FileSpan $span;
 
     /**
      * @param Statement[] $children

--- a/src/Ast/Sass/Statement/VariableDeclaration.php
+++ b/src/Ast/Sass/Statement/VariableDeclaration.php
@@ -29,47 +29,19 @@ use ScssPhp\ScssPhp\Visitor\StatementVisitor;
  */
 final class VariableDeclaration implements Statement, SassDeclaration
 {
-    /**
-     * @var string|null
-     * @readonly
-     */
-    private $namespace;
+    private readonly ?string $namespace;
 
-    /**
-     * @var string
-     * @readonly
-     */
-    private $name;
+    private readonly string $name;
 
-    /**
-     * @var SilentComment|null
-     * @readonly
-     */
-    private $comment;
+    private readonly ?SilentComment $comment;
 
-    /**
-     * @var Expression
-     * @readonly
-     */
-    private $expression;
+    private readonly Expression $expression;
 
-    /**
-     * @var bool
-     * @readonly
-     */
-    private $guarded;
+    private readonly bool $guarded;
 
-    /**
-     * @var bool
-     * @readonly
-     */
-    private $global;
+    private readonly bool $global;
 
-    /**
-     * @var FileSpan
-     * @readonly
-     */
-    private $span;
+    private readonly FileSpan $span;
 
     public function __construct(string $name, Expression $expression, FileSpan $span, ?string $namespace = null, bool $guarded = false, bool $global = false, ?SilentComment $comment = null)
     {

--- a/src/Ast/Sass/Statement/WarnRule.php
+++ b/src/Ast/Sass/Statement/WarnRule.php
@@ -26,17 +26,9 @@ use ScssPhp\ScssPhp\Visitor\StatementVisitor;
  */
 final class WarnRule implements Statement
 {
-    /**
-     * @var Expression
-     * @readonly
-     */
-    private $expression;
+    private readonly Expression $expression;
 
-    /**
-     * @var FileSpan
-     * @readonly
-     */
-    private $span;
+    private readonly FileSpan $span;
 
     public function __construct(Expression $expression, FileSpan $span)
     {

--- a/src/Ast/Sass/Statement/WhileRule.php
+++ b/src/Ast/Sass/Statement/WhileRule.php
@@ -29,17 +29,9 @@ use ScssPhp\ScssPhp\Visitor\StatementVisitor;
  */
 final class WhileRule extends ParentStatement
 {
-    /**
-     * @var Expression
-     * @readonly
-     */
-    private $condition;
+    private readonly Expression $condition;
 
-    /**
-     * @var FileSpan
-     * @readonly
-     */
-    private $span;
+    private readonly FileSpan $span;
 
     /**
      * @param Statement[] $children

--- a/src/Ast/Sass/SupportsCondition/SupportsAnything.php
+++ b/src/Ast/Sass/SupportsCondition/SupportsAnything.php
@@ -26,17 +26,10 @@ final class SupportsAnything implements SupportsCondition
 {
     /**
      * The contents of the condition.
-     *
-     * @var Interpolation
-     * @readonly
      */
-    private $contents;
+    private readonly Interpolation $contents;
 
-    /**
-     * @var FileSpan
-     * @readonly
-     */
-    private $span;
+    private readonly FileSpan $span;
 
     public function __construct(Interpolation $contents, FileSpan $span)
     {

--- a/src/Ast/Sass/SupportsCondition/SupportsDeclaration.php
+++ b/src/Ast/Sass/SupportsCondition/SupportsDeclaration.php
@@ -16,7 +16,6 @@ use ScssPhp\ScssPhp\Ast\Sass\Expression;
 use ScssPhp\ScssPhp\Ast\Sass\Expression\StringExpression;
 use ScssPhp\ScssPhp\Ast\Sass\SupportsCondition;
 use ScssPhp\ScssPhp\SourceSpan\FileSpan;
-use ScssPhp\ScssPhp\Util\StringUtil;
 
 /**
  * A condition that selects for browsers where a given declaration is
@@ -71,7 +70,7 @@ final class SupportsDeclaration implements SupportsCondition
      */
     public function isCustomProperty(): bool
     {
-        return $this->name instanceof StringExpression && !$this->name->hasQuotes() && StringUtil::startsWith($this->name->getText()->getInitialPlain(), '--');
+        return $this->name instanceof StringExpression && !$this->name->hasQuotes() && str_starts_with($this->name->getText()->getInitialPlain(), '--');
     }
 
     public function __toString(): string

--- a/src/Ast/Sass/SupportsCondition/SupportsDeclaration.php
+++ b/src/Ast/Sass/SupportsCondition/SupportsDeclaration.php
@@ -28,25 +28,15 @@ final class SupportsDeclaration implements SupportsCondition
 {
     /**
      * The name of the declaration being tested.
-     *
-     * @var Expression
-     * @readonly
      */
-    private $name;
+    private readonly Expression $name;
 
     /**
      * The value of the declaration being tested.
-     *
-     * @var Expression
-     * @readonly
      */
-    private $value;
+    private readonly Expression $value;
 
-    /**
-     * @var FileSpan
-     * @readonly
-     */
-    private $span;
+    private readonly FileSpan $span;
 
     public function __construct(Expression $name, Expression $value, FileSpan $span)
     {

--- a/src/Ast/Sass/SupportsCondition/SupportsFunction.php
+++ b/src/Ast/Sass/SupportsCondition/SupportsFunction.php
@@ -25,25 +25,15 @@ final class SupportsFunction implements SupportsCondition
 {
     /**
      * The name of the function.
-     *
-     * @var Interpolation
-     * @readonly
      */
-    private $name;
+    private readonly Interpolation $name;
 
     /**
      * The arguments of the function.
-     *
-     * @var Interpolation
-     * @readonly
      */
-    private $arguments;
+    private readonly Interpolation $arguments;
 
-    /**
-     * @var FileSpan
-     * @readonly
-     */
-    private $span;
+    private readonly FileSpan $span;
 
     public function __construct(Interpolation $name, Interpolation $arguments, FileSpan $span)
     {

--- a/src/Ast/Sass/SupportsCondition/SupportsInterpolation.php
+++ b/src/Ast/Sass/SupportsCondition/SupportsInterpolation.php
@@ -25,17 +25,10 @@ final class SupportsInterpolation implements SupportsCondition
 {
     /**
      * The expression in the interpolation.
-     *
-     * @var Expression
-     * @readonly
      */
-    private $expression;
+    private readonly Expression $expression;
 
-    /**
-     * @var FileSpan
-     * @readonly
-     */
-    private $span;
+    private readonly FileSpan $span;
 
     public function __construct(Expression $expression, FileSpan $span)
     {

--- a/src/Ast/Sass/SupportsCondition/SupportsNegation.php
+++ b/src/Ast/Sass/SupportsCondition/SupportsNegation.php
@@ -24,17 +24,10 @@ final class SupportsNegation implements SupportsCondition
 {
     /**
      * The condition that's been negated.
-     *
-     * @var SupportsCondition
-     * @readonly
      */
-    private $condition;
+    private readonly SupportsCondition $condition;
 
-    /**
-     * @var FileSpan
-     * @readonly
-     */
-    private $span;
+    private readonly FileSpan $span;
 
     public function __construct(SupportsCondition $condition, FileSpan $span)
     {

--- a/src/Ast/Sass/SupportsCondition/SupportsOperation.php
+++ b/src/Ast/Sass/SupportsCondition/SupportsOperation.php
@@ -24,31 +24,17 @@ final class SupportsOperation implements SupportsCondition
 {
     /**
      * The left-hand operand.
-     *
-     * @var SupportsCondition
-     * @readonly
      */
-    private $left;
+    private readonly SupportsCondition $left;
 
     /**
      * The right-hand operand.
-     *
-     * @var SupportsCondition
-     * @readonly
      */
-    private $right;
+    private readonly SupportsCondition $right;
 
-    /**
-     * @var string
-     * @readonly
-     */
-    private $operator;
+    private readonly string $operator;
 
-    /**
-     * @var FileSpan
-     * @readonly
-     */
-    private $span;
+    private readonly FileSpan $span;
 
     public function __construct(SupportsCondition $left, SupportsCondition $right, string $operator, FileSpan $span)
     {

--- a/src/Ast/Selector/AttributeOperator.php
+++ b/src/Ast/Selector/AttributeOperator.php
@@ -17,37 +17,49 @@ namespace ScssPhp\ScssPhp\Ast\Selector;
  *
  * @internal
  */
-final class AttributeOperator
+enum AttributeOperator
 {
     /**
      * The attribute value exactly equals the given value.
      */
-    public const EQUAL = '=';
+    case EQUAL;
 
     /**
      * The attribute value is a whitespace-separated list of words, one of which
      * is the given value.
      */
-    public const INCLUDE = '~=';
+    case INCLUDE;
 
     /**
      * The attribute value is either exactly the given value, or starts with the
      * given value followed by a dash.
      */
-    public const DASH = '|=';
+    case DASH;
 
     /**
      * The attribute value begins with the given value.
      */
-    public const PREFIX = '^=';
+    case PREFIX;
 
     /**
      * The attribute value ends with the given value.
      */
-    public const SUFFIX = '$=';
+    case SUFFIX;
 
     /**
      * The attribute value contains the given value.
      */
-    public const SUBSTRING = '*=';
+    case SUBSTRING;
+
+    public function getText(): string
+    {
+        return match($this) {
+            self::EQUAL => '=',
+            self::INCLUDE => '~=',
+            self::DASH => '|=',
+            self::PREFIX => '^=',
+            self::SUFFIX => '$=',
+            self::SUBSTRING => '*=',
+        };
+    }
 }

--- a/src/Ast/Selector/AttributeSelector.php
+++ b/src/Ast/Selector/AttributeSelector.php
@@ -27,23 +27,16 @@ final class AttributeSelector extends SimpleSelector
 {
     /**
      * The name of the attribute being selected for.
-     *
-     * @var QualifiedName
-     * @readonly
      */
-    private $name;
+    private readonly QualifiedName $name;
 
     /**
      * The operator that defines the semantics of {@see value}.
      *
      * If this is `null`, this matches any element with the given property,
      * regardless of this value. It's `null` if and only if {@see value} is `null`.
-     *
-     * @var string|null
-     * @phpstan-var AttributeOperator::*|null
-     * @readonly
      */
-    private $op;
+    private readonly ?AttributeOperator $op;
 
     /**
      * An assertion about the value of {@see name}.
@@ -52,11 +45,8 @@ final class AttributeSelector extends SimpleSelector
      *
      * If this is `null`, this matches any element with the given property,
      * regardless of this value. It's `null` if and only if {@see op} is `null`.
-     *
-     * @var string|null
-     * @readonly
      */
-    private $value;
+    private readonly ?string $value;
 
     /**
      * The modifier which indicates how the attribute selector should be
@@ -67,11 +57,8 @@ final class AttributeSelector extends SimpleSelector
      * [case-sensitivity]: https://www.w3.org/TR/selectors-4/#attribute-case
      *
      * If {@see op} is `null`, this is always `null` as well.
-     *
-     * @var string|null
-     * @readonly
      */
-    private $modifier;
+    private readonly ?string $modifier;
 
     /**
      * Creates an attribute selector that matches any element with a property of
@@ -85,18 +72,13 @@ final class AttributeSelector extends SimpleSelector
     /**
      * Creates an attribute selector that matches an element with a property
      * named $name, whose value matches $value based on the semantics of $op.
-     *
-     * @phpstan-param AttributeOperator::*|null $op
      */
-    public static function withOperator(QualifiedName $name, ?string $op, ?string $value, FileSpan $span, ?string $modifier = null): AttributeSelector
+    public static function withOperator(QualifiedName $name, ?AttributeOperator $op, ?string $value, FileSpan $span, ?string $modifier = null): AttributeSelector
     {
         return new AttributeSelector($name, $span, $op, $value, $modifier);
     }
 
-    /**
-     * @phpstan-param AttributeOperator::*|null $op
-     */
-    private function __construct(QualifiedName $name, FileSpan $span, ?string $op, ?string $value, ?string $modifier)
+    private function __construct(QualifiedName $name, FileSpan $span, ?AttributeOperator $op, ?string $value, ?string $modifier)
     {
         $this->name = $name;
         $this->op = $op;
@@ -110,10 +92,7 @@ final class AttributeSelector extends SimpleSelector
         return $this->name;
     }
 
-    /**
-     * @phpstan-return AttributeOperator::*|null
-     */
-    public function getOp(): ?string
+    public function getOp(): ?AttributeOperator
     {
         return $this->op;
     }

--- a/src/Ast/Selector/ClassSelector.php
+++ b/src/Ast/Selector/ClassSelector.php
@@ -27,11 +27,8 @@ final class ClassSelector extends SimpleSelector
 {
     /**
      * The class name this selects for.
-     *
-     * @var string
-     * @readonly
      */
-    private $name;
+    private readonly string $name;
 
     public function __construct(string $name, FileSpan $span)
     {

--- a/src/Ast/Selector/Combinator.php
+++ b/src/Ast/Selector/Combinator.php
@@ -18,23 +18,32 @@ namespace ScssPhp\ScssPhp\Ast\Selector;
  *
  * @internal
  */
-final class Combinator
+enum Combinator
 {
     /**
      * Matches the right-hand selector if it's immediately adjacent to the
      * left-hand selector in the DOM tree.
      */
-    public const NEXT_SIBLING = '+';
+    case NEXT_SIBLING;
 
     /**
      * Matches the right-hand selector if it's a direct child of the left-hand
      * selector in the DOM tree.
      */
-    public const CHILD = '>';
+    case CHILD;
 
     /**
      * Matches the right-hand selector if it comes after the left-hand selector
      * in the DOM tree.
      */
-    public const FOLLOWING_SIBLING = '~';
+    case FOLLOWING_SIBLING;
+
+    public function getText(): string
+    {
+        return match ($this) {
+            self::NEXT_SIBLING => '+',
+            self::CHILD => '>',
+            self::FOLLOWING_SIBLING => '~',
+        };
+    }
 }

--- a/src/Ast/Selector/ComplexSelector.php
+++ b/src/Ast/Selector/ComplexSelector.php
@@ -39,11 +39,9 @@ final class ComplexSelector extends Selector
      * it's more than one element, that means it's invalid CSS; however, we still
      * support this for backwards-compatibility purposes.
      *
-     * @var list<CssValue<string>>
-     * @phpstan-var list<CssValue<Combinator::*>>
-     * @readonly
+     * @var list<CssValue<Combinator>>
      */
-    private $leadingCombinators;
+    private readonly array $leadingCombinators;
 
     /**
      * The components of this selector.
@@ -58,28 +56,19 @@ final class ComplexSelector extends Selector
      * This isn't valid CSS, but Sass supports it for CSS hack purposes.
      *
      * @var list<ComplexSelectorComponent>
-     * @readonly
      */
-    private $components;
+    private readonly array $components;
 
     /**
      * Whether a line break should be emitted *before* this selector.
-     *
-     * @var bool
-     * @readonly
      */
-    private $lineBreak;
+    private readonly bool $lineBreak;
+
+    private ?int $specificity = null;
 
     /**
-     * @var int|null
-     */
-    private $specificity;
-
-    /**
-     * @param list<CssValue<string>>         $leadingCombinators
+     * @param list<CssValue<Combinator>>     $leadingCombinators
      * @param list<ComplexSelectorComponent> $components
-     *
-     * @phpstan-param list<CssValue<Combinator::*>> $leadingCombinators
      */
     public function __construct(array $leadingCombinators, array $components, FileSpan $span, bool $lineBreak = false)
     {
@@ -108,8 +97,7 @@ final class ComplexSelector extends Selector
     }
 
     /**
-     * @return list<CssValue<string>>
-     * @phpstan-return list<CssValue<Combinator::*>>
+     * @return list<CssValue<Combinator>>
      */
     public function getLeadingCombinators(): array
     {
@@ -205,9 +193,7 @@ final class ComplexSelector extends Selector
      * If $forceLineBreak is `true`, this will mark the new complex selector as
      * having a line break.
      *
-     * @param list<CssValue<string>> $combinators
-     *
-     * @phpstan-param list<CssValue<Combinator::*>> $combinators
+     * @param list<CssValue<Combinator>> $combinators
      */
     public function withAdditionalCombinators(array $combinators, bool $forceLineBreak = false): ComplexSelector
     {

--- a/src/Ast/Selector/ComplexSelectorComponent.php
+++ b/src/Ast/Selector/ComplexSelectorComponent.php
@@ -28,11 +28,8 @@ final class ComplexSelectorComponent implements Equatable
 {
     /**
      * This component's compound selector.
-     *
-     * @var CompoundSelector
-     * @readonly
      */
-    private $selector;
+    private readonly CompoundSelector $selector;
 
     /**
      * This selector's combinators.
@@ -41,22 +38,14 @@ final class ComplexSelectorComponent implements Equatable
      * combinator. If it's more than one element, that means it's invalid CSS;
      * however, we still support this for backwards-compatibility purposes.
      *
-     * @var list<CssValue<string>>
-     * @phpstan-var list<CssValue<Combinator::*>>
-     * @readonly
+     * @var list<CssValue<Combinator>>
      */
-    private $combinators;
+    private readonly array $combinators;
+
+    private readonly FileSpan $span;
 
     /**
-     * @var FileSpan
-     * @readonly
-     */
-    private $span;
-
-    /**
-     * @param list<CssValue<string>> $combinators
-     *
-     * @phpstan-param list<CssValue<Combinator::*>> $combinators
+     * @param list<CssValue<Combinator>> $combinators
      */
     public function __construct(CompoundSelector $selector, array $combinators, FileSpan $span)
     {
@@ -76,8 +65,7 @@ final class ComplexSelectorComponent implements Equatable
     }
 
     /**
-     * @return list<CssValue<string>>
-     * @phpstan-return list<CssValue<Combinator::*>>
+     * @return list<CssValue<Combinator>>
      */
     public function getCombinators(): array
     {
@@ -93,9 +81,7 @@ final class ComplexSelectorComponent implements Equatable
      * Returns a copy of $this with $combinators added to the end of
      * `$this->combinators`.
      *
-     * @param list<CssValue<string>> $combinators
-     *
-     * @phpstan-param list<CssValue<Combinator::*>> $combinators
+     * @param list<CssValue<Combinator>> $combinators
      */
     public function withAdditionalCombinators(array $combinators): ComplexSelectorComponent
     {

--- a/src/Ast/Selector/CompoundSelector.php
+++ b/src/Ast/Selector/CompoundSelector.php
@@ -37,12 +37,9 @@ final class CompoundSelector extends Selector
      *
      * @var list<SimpleSelector>
      */
-    private $components;
+    private readonly array $components;
 
-    /**
-     * @var int|null
-     */
-    private $specificity;
+    private ?int $specificity = null;
 
     /**
      * Parses a compound selector from $contents.

--- a/src/Ast/Selector/IDSelector.php
+++ b/src/Ast/Selector/IDSelector.php
@@ -26,11 +26,8 @@ final class IDSelector extends SimpleSelector
 {
     /**
      * The ID name this selects for.
-     *
-     * @var string
-     * @readonly
      */
-    private $name;
+    private readonly string $name;
 
     public function __construct(string $name, FileSpan $span)
     {

--- a/src/Ast/Selector/IsBogusVisitor.php
+++ b/src/Ast/Selector/IsBogusVisitor.php
@@ -23,11 +23,8 @@ final class IsBogusVisitor extends AnySelectorVisitor
 {
     /**
      * Whether to consider selectors with leading combinators as bogus.
-     *
-     * @var bool
-     * @readonly
      */
-    private $includeLeadingCombinator;
+    private readonly bool $includeLeadingCombinator;
 
     public function __construct(bool $includeLeadingCombinator)
     {

--- a/src/Ast/Selector/IsInvisibleVisitor.php
+++ b/src/Ast/Selector/IsInvisibleVisitor.php
@@ -23,11 +23,8 @@ final class IsInvisibleVisitor extends AnySelectorVisitor
 {
     /**
      * Whether to consider selectors with bogus combinators invisible.
-     *
-     * @var bool
-     * @readonly
      */
-    private $includeBogus;
+    private readonly bool $includeBogus;
 
     public function __construct(bool $includeBogus)
     {

--- a/src/Ast/Selector/ParentSelector.php
+++ b/src/Ast/Selector/ParentSelector.php
@@ -31,11 +31,8 @@ final class ParentSelector extends SimpleSelector
      *
      * This is assumed to be a valid identifier suffix. It may be `null`,
      * indicating that the parent selector will not be modified.
-     *
-     * @var string|null
-     * @readonly
      */
-    private $suffix;
+    private readonly ?string $suffix;
 
     public function __construct(FileSpan $span, ?string $suffix = null)
     {

--- a/src/Ast/Selector/PlaceholderSelector.php
+++ b/src/Ast/Selector/PlaceholderSelector.php
@@ -29,11 +29,8 @@ final class PlaceholderSelector extends SimpleSelector
 {
     /**
      * The name of the placeholder.
-     *
-     * @var string
-     * @readonly
      */
-    private $name;
+    private readonly string $name;
 
     public function __construct(string $name, FileSpan $span)
     {

--- a/src/Ast/Selector/PseudoSelector.php
+++ b/src/Ast/Selector/PseudoSelector.php
@@ -31,58 +31,35 @@ final class PseudoSelector extends SimpleSelector
 {
     /**
      * The name of this selector.
-     *
-     * @var string
-     * @readonly
      */
-    private $name;
+    private readonly string $name;
 
     /**
      * Like {@see name}, but without any vendor prefixes.
-     *
-     * @var string
-     * @readonly
      */
-    private $normalizedName;
+    private readonly string $normalizedName;
 
-    /**
-     * @var bool
-     * @readonly
-     */
-    private $isClass;
+    private readonly bool $isClass;
 
-    /**
-     * @var bool
-     * @readonly
-     */
-    private $isSyntacticClass;
+    private readonly bool $isSyntacticClass;
 
     /**
      * The non-selector argument passed to this selector.
      *
      * This is `null` if there's no argument. If {@see argument} and {@see selector} are
      * both non-`null`, the selector follows the argument.
-     *
-     * @var string|null
-     * @readonly
      */
-    private $argument;
+    private readonly ?string $argument;
 
     /**
      * The selector argument passed to this selector.
      *
      * This is `null` if there's no selector. If {@see argument} and {@see selector} are
      * both non-`null`, the selector follows the argument.
-     *
-     * @var SelectorList|null
-     * @readonly
      */
-    private $selector;
+    private readonly ?SelectorList $selector;
 
-    /**
-     * @var int|null
-     */
-    private $specificity;
+    private ?int $specificity = null;
 
     public function __construct(string $name, FileSpan $span, bool $element = false, ?string $argument = null, ?SelectorList $selector = null)
     {

--- a/src/Ast/Selector/QualifiedName.php
+++ b/src/Ast/Selector/QualifiedName.php
@@ -25,11 +25,8 @@ final class QualifiedName implements Equatable
 {
     /**
      * The identifier name.
-     *
-     * @var string
-     * @readonly
      */
-    private $name;
+    private readonly string $name;
 
     /**
      * The namespace name.
@@ -37,11 +34,8 @@ final class QualifiedName implements Equatable
      * If this is `null`, {@see name} belongs to the default namespace. If it's the
      * empty string, {@see name} belongs to no namespace. If it's `*`, {@see name} belongs
      * to any namespace. Otherwise, {@see name} belongs to the given namespace.
-     *
-     * @var string|null
-     * @readonly
      */
-    private $namespace;
+    private readonly ?string $namespace;
 
     public function __construct(string $name, ?string $namespace = null)
     {

--- a/src/Ast/Selector/Selector.php
+++ b/src/Ast/Selector/Selector.php
@@ -32,11 +32,7 @@ use ScssPhp\ScssPhp\Warn;
  */
 abstract class Selector implements AstNode, Equatable
 {
-    /**
-     * @var FileSpan
-     * @readonly
-     */
-    private $span;
+    private readonly FileSpan $span;
 
     public function __construct(FileSpan $span)
     {

--- a/src/Ast/Selector/SelectorList.php
+++ b/src/Ast/Selector/SelectorList.php
@@ -44,9 +44,8 @@ final class SelectorList extends Selector
      * This is never empty.
      *
      * @var list<ComplexSelector>
-     * @readonly
      */
-    private $components;
+    private readonly array $components;
 
     /**
      * Parses a selector list from $contents.
@@ -318,9 +317,7 @@ final class SelectorList extends Selector
      * Returns a copy of `this` with $combinators added to the end of each
      * complex selector in {@see components}].
      *
-     * @param list<CssValue<string>> $combinators
-     *
-     * @phpstan-param list<CssValue<Combinator::*>> $combinators
+     * @param list<CssValue<Combinator>> $combinators
      */
     public function withAdditionalCombinators(array $combinators): SelectorList
     {

--- a/src/Ast/Selector/SelectorList.php
+++ b/src/Ast/Selector/SelectorList.php
@@ -165,9 +165,7 @@ final class SelectorList extends Selector
                     return [$complex];
                 }
 
-                return array_map(function (ComplexSelector $parentComplex) use ($complex) {
-                    return $parentComplex->concatenate($complex, $complex->getSpan());
-                }, $parent->getComponents());
+                return array_map(fn(ComplexSelector $parentComplex) => $parentComplex->concatenate($complex, $complex->getSpan()), $parent->getComponents());
             }
 
             /** @var list<ComplexSelector> $newComplexes */
@@ -325,9 +323,7 @@ final class SelectorList extends Selector
             return $this;
         }
 
-        return new SelectorList(array_map(function (ComplexSelector $complex) use ($combinators) {
-            return $complex->withAdditionalCombinators($combinators);
-        }, $this->components), $this->getSpan());
+        return new SelectorList(array_map(fn(ComplexSelector $complex) => $complex->withAdditionalCombinators($combinators), $this->components), $this->getSpan());
     }
 
     /**

--- a/src/Ast/Selector/TypeSelector.php
+++ b/src/Ast/Selector/TypeSelector.php
@@ -27,11 +27,8 @@ final class TypeSelector extends SimpleSelector
 {
     /**
      * The element name being selected.
-     *
-     * @var QualifiedName
-     * @readonly
      */
-    private $name;
+    private readonly QualifiedName $name;
 
     public function __construct(QualifiedName $name, FileSpan $span)
     {

--- a/src/Ast/Selector/UniversalSelector.php
+++ b/src/Ast/Selector/UniversalSelector.php
@@ -30,11 +30,8 @@ final class UniversalSelector extends SimpleSelector
      * it's the empty string, this matches all elements that aren't in any
      * namespace. If it's `*`, this matches all elements in any namespace.
      * Otherwise, it matches all elements in the given namespace.
-     *
-     * @var string|null
-     * @readonly
      */
-    private $namespace;
+    private readonly ?string $namespace;
 
     public function __construct(FileSpan $span, ?string $namespace = null)
     {

--- a/src/Collection/Map.php
+++ b/src/Collection/Map.php
@@ -27,17 +27,14 @@ use ScssPhp\ScssPhp\Value\Value;
  */
 final class Map implements \Countable, \IteratorAggregate
 {
-    /**
-     * @var bool
-     */
-    private $modifiable = true;
+    private bool $modifiable = true;
 
     // TODO implement a better internal storage to allow reading keys in O(1).
 
     /**
      * @var array<int, array{Value, T}>
      */
-    private $pairs = [];
+    private array $pairs = [];
 
     /**
      * Returns a modifiable version of the Map.

--- a/src/Extend/ExtendUtil.php
+++ b/src/Extend/ExtendUtil.php
@@ -364,9 +364,7 @@ final class ExtendUtil
         foreach ($lcs as $group) {
             $newChoice = [];
             /** @var list<list<list<ComplexSelectorComponent>>> $chunks */
-            $chunks = self::chunks($groups1, $groups2, function ($sequence) use ($group) {
-                return self::complexIsParentSuperselector($sequence[0], $group);
-            });
+            $chunks = self::chunks($groups1, $groups2, fn($sequence) => self::complexIsParentSuperselector($sequence[0], $group));
             foreach ($chunks as $chunk) {
                 $flattened = [];
                 foreach ($chunk as $chunkGroup) {
@@ -385,9 +383,7 @@ final class ExtendUtil
 
         $newChoice = [];
         /** @var list<list<list<ComplexSelectorComponent>>> $chunks */
-        $chunks = self::chunks($groups1, $groups2, function ($sequence) {
-            return count($sequence) === 0;
-        });
+        $chunks = self::chunks($groups1, $groups2, fn($sequence) => count($sequence) === 0);
         foreach ($chunks as $chunk) {
             $flattened = [];
             foreach ($chunk as $chunkGroup) {
@@ -402,9 +398,7 @@ final class ExtendUtil
             $choices[] = $finalCombinator;
         }
 
-        $choices = array_filter($choices, function ($choice) {
-            return $choice !== [];
-        });
+        $choices = array_filter($choices, fn($choice) => $choice !== []);
 
         $paths = self::paths($choices);
 

--- a/src/Extend/ExtendUtil.php
+++ b/src/Extend/ExtendUtil.php
@@ -452,15 +452,10 @@ final class ExtendUtil
      *
      * Returns `null` if the combinator lists can't be unified.
      *
-     * @param list<CssValue<string>>|null $combinators1
-     * @param list<CssValue<string>>|null $combinators2
+     * @param list<CssValue<Combinator>>|null $combinators1
+     * @param list<CssValue<Combinator>>|null $combinators2
      *
-     * @return list<CssValue<string>>|null
-     *
-     * @phpstan-param list<CssValue<Combinator::*>> $combinators1
-     * @phpstan-param list<CssValue<Combinator::*>> $combinators2
-     *
-     * @phpstan-return list<CssValue<Combinator::*>>|null
+     * @return list<CssValue<Combinator>>|null
      */
     private static function mergeLeadingCombinators(?array $combinators1, ?array $combinators2): ?array
     {
@@ -970,7 +965,7 @@ final class ExtendUtil
     }
 
     /**
-     * @phpstan-param CssValue<Combinator::*>|null $previous
+     * @param CssValue<Combinator>|null $previous
      * @param list<ComplexSelectorComponent> $parents
      */
     private static function compatibleWithPreviousCombinator(?CssValue $previous, array $parents): bool
@@ -993,7 +988,7 @@ final class ExtendUtil
         // only if they're all siblings.
         foreach ($parents as $component) {
             $firstCombinator = $component->getCombinators()[0] ?? null;
-            $firstCombinatorValue = $firstCombinator === null ? null : $firstCombinator->getValue();
+            $firstCombinatorValue = $firstCombinator?->getValue();
 
             if ($firstCombinatorValue !== Combinator::FOLLOWING_SIBLING && $firstCombinatorValue !== Combinator::NEXT_SIBLING) {
                 return false;
@@ -1008,8 +1003,8 @@ final class ExtendUtil
      *
      * That is, whether `X $combinator1 Y` is a superselector of `X $combinator2 Y`.
      *
-     * @phpstan-param CssValue<Combinator::*>|null $combinator1
-     * @phpstan-param CssValue<Combinator::*>|null $combinator2
+     * @param CssValue<Combinator>|null $combinator1
+     * @param CssValue<Combinator>|null $combinator2
      */
     private static function isSupercombinator(?CssValue $combinator1, ?CssValue $combinator2): bool
     {

--- a/src/OutputStyle.php
+++ b/src/OutputStyle.php
@@ -2,6 +2,9 @@
 
 namespace ScssPhp\ScssPhp;
 
+/**
+ * TODO convert to an enum with appropriate forward-compat/backward-compat APIs in 1.x
+ */
 final class OutputStyle
 {
     const EXPANDED = 'expanded';

--- a/src/Parser/AtRootQueryParser.php
+++ b/src/Parser/AtRootQueryParser.php
@@ -27,7 +27,7 @@ final class AtRootQueryParser extends Parser
      */
     public function parse(): AtRootQuery
     {
-        try {
+        return $this->wrapSpanFormatException(function () {
             $this->scanner->expectChar('(');
             $this->whitespace();
             $include = $this->scanIdentifier('with');
@@ -49,8 +49,6 @@ final class AtRootQueryParser extends Parser
             $this->scanner->expectDone();
 
             return AtRootQuery::create($atRules, $include);
-        } catch (FormatException $e) {
-            throw $this->wrapException($e);
-        }
+        });
     }
 }

--- a/src/Parser/FormatException.php
+++ b/src/Parser/FormatException.php
@@ -19,11 +19,7 @@ use ScssPhp\ScssPhp\SourceSpan\FileSpan;
  */
 final class FormatException extends \Exception
 {
-    /**
-     * @var FileSpan
-     * @readonly
-     */
-    private $span;
+    private readonly FileSpan $span;
 
     public function __construct(string $message, FileSpan $span, ?\Throwable $previous = null)
     {

--- a/src/Parser/InterpolationBuffer.php
+++ b/src/Parser/InterpolationBuffer.php
@@ -23,15 +23,12 @@ use ScssPhp\ScssPhp\SourceSpan\FileSpan;
  */
 final class InterpolationBuffer
 {
-    /**
-     * @var string
-     */
-    private $text = '';
+    private string $text = '';
 
     /**
      * @var list<string|Expression>
      */
-    private $contents = [];
+    private array $contents = [];
 
     /**
      * Returns the substring of the buffer string after the last interpolation.

--- a/src/Parser/InterpolationMap.php
+++ b/src/Parser/InterpolationMap.php
@@ -59,7 +59,13 @@ final class InterpolationMap
         }
     }
 
-    // TODO implement mapException
+    public function mapException(FormatException $exception): FormatException
+    {
+        $source = $this->mapSpan($exception->getSpan());
+
+        // TODO implement the Multi-span support here
+        return new FormatException($exception->getMessage(), $source, $exception);
+    }
 
     public function mapSpan(FileSpan $target): FileSpan
     {

--- a/src/Parser/InterpolationMap.php
+++ b/src/Parser/InterpolationMap.php
@@ -26,11 +26,7 @@ use ScssPhp\ScssPhp\Util\Character;
  */
 final class InterpolationMap
 {
-    /**
-     * @var Interpolation
-     * @readonly
-     */
-    private $interpolation;
+    private readonly Interpolation $interpolation;
 
     /**
      * Locations in the generated string.
@@ -42,7 +38,7 @@ final class InterpolationMap
      *
      * @var list<SourceLocation>
      */
-    private $targetLocations;
+    private readonly array $targetLocations;
 
     /**
      * @param list<SourceLocation> $targetLocations

--- a/src/Parser/KeyframeSelectorParser.php
+++ b/src/Parser/KeyframeSelectorParser.php
@@ -29,7 +29,7 @@ final class KeyframeSelectorParser extends Parser
      */
     public function parse(): array
     {
-        try {
+        return $this->wrapSpanFormatException(function () {
             $selectors = [];
 
             do {
@@ -49,9 +49,7 @@ final class KeyframeSelectorParser extends Parser
             $this->scanner->expectDone();
 
             return $selectors;
-        } catch (FormatException $e) {
-            throw $this->wrapException($e);
-        }
+        });
     }
 
     private function percentage(): string

--- a/src/Parser/LineScanner.php
+++ b/src/Parser/LineScanner.php
@@ -22,12 +22,12 @@ final class LineScanner extends StringScanner
     /**
      * @var int
      */
-    private $line = 0;
+    private int $line = 0;
 
     /**
      * @var int
      */
-    private $column = 0;
+    private int $column = 0;
 
     /**
      * Whether the current position is between a CR character and an LF

--- a/src/Parser/MediaQueryParser.php
+++ b/src/Parser/MediaQueryParser.php
@@ -29,7 +29,7 @@ final class MediaQueryParser extends Parser
      */
     public function parse(): array
     {
-        try {
+        return $this->wrapSpanFormatException(function () {
             $queries = [];
 
             do {
@@ -40,9 +40,7 @@ final class MediaQueryParser extends Parser
             $this->scanner->expectDone();
 
             return $queries;
-        } catch (FormatException $e) {
-            throw $this->wrapException($e);
-        }
+        });
     }
 
     /**

--- a/src/Parser/Parser.php
+++ b/src/Parser/Parser.php
@@ -891,9 +891,7 @@ class Parser
 
         $interpolationMap = $this->interpolationMap;
 
-        return new LazyFileSpan(static function () use ($interpolationMap, $span) {
-            return $interpolationMap->mapSpan($span);
-        });
+        return new LazyFileSpan(static fn() => $interpolationMap->mapSpan($span));
     }
 
     /**

--- a/src/Parser/Parser.php
+++ b/src/Parser/Parser.php
@@ -382,13 +382,13 @@ class Parser
 
                 case '"':
                 case "'":
-                    $buffer .= $this->rawText([$this, 'string']);
+                    $buffer .= $this->rawText($this->string(...));
                     $wroteNewline = false;
                     break;
 
                 case '/':
                     if ($this->scanner->peekChar(1) === '*') {
-                        $buffer .= $this->rawText([$this, 'loudComment']);
+                        $buffer .= $this->rawText($this->loudComment(...));
                     } else {
                         $buffer .= $this->scanner->readChar();
                     }
@@ -578,7 +578,7 @@ class Parser
                 assert(\is_int($value));
             }
 
-            $this->scanCharIf([Character::class, 'isWhitespace']);
+            $this->scanCharIf(Character::isWhitespace(...));
             $valueText = Util::mbChr($value);
         } else {
             $valueText = $this->scanner->readUtf8Char();
@@ -868,7 +868,7 @@ class Parser
     /**
      * Runs $consumer and returns the source text that it consumes.
      *
-     * @param callable(): void $consumer
+     * @param callable(): (mixed|void) $consumer
      */
     protected function rawText(callable $consumer): string
     {

--- a/src/Parser/Parser.php
+++ b/src/Parser/Parser.php
@@ -846,7 +846,7 @@ class Parser
      */
     protected function expectIdentifier(string $text, ?string $name = null, bool $caseSensitive = false): void
     {
-        $name = $name ?? "\"$text\"";
+        $name ??= "\"$text\"";
 
         $start = $this->scanner->getPosition();
 
@@ -908,10 +908,8 @@ class Parser
      * Throws an error associated with $position.
      *
      * @throws FormatException
-     *
-     * @return never-returns
      */
-    protected function error(string $message, FileSpan $span, ?\Throwable $previous = null): void
+    protected function error(string $message, FileSpan $span, ?\Throwable $previous = null): never
     {
         throw new FormatException($message, $span, $previous);
     }

--- a/src/Parser/SelectorParser.php
+++ b/src/Parser/SelectorParser.php
@@ -50,17 +50,9 @@ final class SelectorParser extends Parser
      */
     private const SELECTOR_PSEUDO_ELEMENTS = ['slotted'];
 
-    /**
-     * @var bool
-     * @readonly
-     */
-    private $allowParent;
+    private readonly bool $allowParent;
 
-    /**
-     * @var bool
-     * @readonly
-     */
-    private $allowPlaceholder;
+    private readonly bool $allowPlaceholder;
 
     public function __construct(string $contents, ?LoggerInterface $logger = null, ?string $url = null, bool $allowParent = true, ?InterpolationMap $interpolationMap = null, bool $allowPlaceholder = true)
     {
@@ -254,7 +246,7 @@ final class SelectorParser extends Parser
     private function simpleSelector(?bool $allowParent = null): SimpleSelector
     {
         $start = $this->scanner->getPosition();
-        $allowParent = $allowParent ?? $this->allowParent;
+        $allowParent ??= $this->allowParent;
 
         switch ($this->scanner->peekChar()) {
             case '[':

--- a/src/Parser/SelectorParser.php
+++ b/src/Parser/SelectorParser.php
@@ -175,7 +175,7 @@ final class SelectorParser extends Parser
 
         $componentStart = $this->scanner->getPosition();
         $lastCompound = null;
-        /** @var list<CssValue<Combinator::*>> $combinators */
+        /** @var list<CssValue<Combinator>> $combinators */
         $combinators = [];
 
         $initialCombinators = null;
@@ -351,10 +351,8 @@ final class SelectorParser extends Parser
 
     /**
      * Consumes an attribute selector's operator.
-     *
-     * @phpstan-return AttributeOperator::*
      */
-    private function attributeOperator(): string
+    private function attributeOperator(): AttributeOperator
     {
         $start = $this->scanner->getPosition();
 

--- a/src/Parser/SelectorParser.php
+++ b/src/Parser/SelectorParser.php
@@ -71,7 +71,7 @@ final class SelectorParser extends Parser
 
     public function parse(): SelectorList
     {
-        try {
+        return $this->wrapSpanFormatException(function () {
             $selector = $this->selectorList();
 
             if (!$this->scanner->isDone()) {
@@ -79,14 +79,12 @@ final class SelectorParser extends Parser
             }
 
             return $selector;
-        } catch (FormatException $e) {
-            throw $this->wrapException($e);
-        }
+        });
     }
 
     public function parseComplexSelector(): ComplexSelector
     {
-        try {
+        return $this->wrapSpanFormatException(function () {
             $complex = $this->complexSelector();
 
             if (!$this->scanner->isDone()) {
@@ -94,14 +92,12 @@ final class SelectorParser extends Parser
             }
 
             return $complex;
-        } catch (FormatException $e) {
-            throw $this->wrapException($e);
-        }
+        });
     }
 
     public function parseCompoundSelector(): CompoundSelector
     {
-        try {
+        return $this->wrapSpanFormatException(function () {
             $compound = $this->compoundSelector();
 
             if (!$this->scanner->isDone()) {
@@ -109,14 +105,12 @@ final class SelectorParser extends Parser
             }
 
             return $compound;
-        } catch (FormatException $e) {
-            throw $this->wrapException($e);
-        }
+        });
     }
 
     public function parseSimpleSelector(): SimpleSelector
     {
-        try {
+        return $this->wrapSpanFormatException(function () {
             $simple = $this->simpleSelector();
 
             if (!$this->scanner->isDone()) {
@@ -124,9 +118,7 @@ final class SelectorParser extends Parser
             }
 
             return $simple;
-        } catch (FormatException $e) {
-            throw $this->wrapException($e);
-        }
+        });
     }
 
     /**

--- a/src/Parser/StringScanner.php
+++ b/src/Parser/StringScanner.php
@@ -21,8 +21,8 @@ use ScssPhp\ScssPhp\SourceSpan\SourceFile;
  * The scanner only supports UTF-8 strings.
  *
  * Differences with Dart:
- * - reading a character is reading a byte, not an UTF-16 code unit (as PHP strings are not UTF-16). The
- *   {@see readUtf8Char} method can be used to consume an UTF-8 char.
+ * - reading a character is reading a byte, not a UTF-16 code unit (as PHP strings are not UTF-16). The
+ *   {@see readUtf8Char} method can be used to consume a UTF-8 char.
  * - characters are represented as a single-char string, not as an integer with their UTF-16 char code
  * - offsets are based on bytes, not on UTF-16 code units. In practice, parsing Sass generally needs
  *   to peak following chars only when already knowing that the current char is an ASCII one, which
@@ -36,22 +36,11 @@ use ScssPhp\ScssPhp\SourceSpan\SourceFile;
  */
 class StringScanner
 {
-    /**
-     * @var string
-     * @readonly
-     */
-    private $string;
+    private readonly string $string;
 
-    /**
-     * @var int
-     */
-    private $position = 0;
+    private int $position = 0;
 
-    /**
-     * @var SourceFile
-     * @readonly
-     */
-    private $sourceFile;
+    private readonly SourceFile $sourceFile;
 
     public function __construct(string $content, ?string $sourceUrl = null)
     {
@@ -76,9 +65,7 @@ class StringScanner
 
     public function spanFrom(int $start, ?int $end = null): FileSpan
     {
-        $end = $end ?? $this->position;
-
-        return $this->sourceFile->span($start, $end);
+        return $this->sourceFile->span($start, $end ?? $this->position);
     }
 
     /**
@@ -133,9 +120,7 @@ class StringScanner
     }
 
     /**
-     * Consumes the next character in the string if it the provided character.
-     *
-     * @param string $char
+     * Consumes the next character in the string if it is the provided character.
      *
      * @return bool Whether the character was consumed.
      *
@@ -158,8 +143,6 @@ class StringScanner
 
     /**
      * Consumes the provided string if it appears at the current position.
-     *
-     * @param string $string
      *
      * @return bool Whether the string was consumed.
      *
@@ -198,11 +181,6 @@ class StringScanner
      * the expected name of the character being matched; if it's `null`, the
      * character itself is used instead.
      *
-     * @param string      $character
-     * @param string|null $name
-     *
-     * @return void
-     *
      * @throws FormatException
      *
      * @phpstan-impure
@@ -221,10 +199,6 @@ class StringScanner
     }
 
     /**
-     * @param string $string
-     *
-     * @return void
-     *
      * @throws FormatException
      *
      * @phpstan-impure
@@ -256,10 +230,6 @@ class StringScanner
      * The offset can be negative to peek already seen characters.
      * Returns null if the offset goes out of range.
      * This does not affect the position or the last match.
-     *
-     * @param int $offset
-     *
-     * @return string|null
      */
     public function peekChar(int $offset = 0): ?string
     {
@@ -276,11 +246,6 @@ class StringScanner
      * Returns the substring of the string between $start and $end (excluded).
      *
      * $end defaults to the current position.
-     *
-     * @param int      $start
-     * @param int|null $end
-     *
-     * @return string
      */
     public function substring(int $start, ?int $end = null): string
     {
@@ -297,8 +262,6 @@ class StringScanner
 
     /**
      * The scanner's current (zero-based) line number.
-     *
-     * @return int
      */
     public function getLine(): int
     {
@@ -307,8 +270,6 @@ class StringScanner
 
     /**
      * The scanner's current (zero-based) column number.
-     *
-     * @return int
      */
     public function getColumn(): int
     {
@@ -316,18 +277,12 @@ class StringScanner
     }
 
     /**
-     * @param string   $message
-     * @param int|null $position
-     * @param int|null $length
-     *
      * @throws FormatException
-     *
-     * @return never-returns
      */
-    public function error(string $message, ?int $position = null, ?int $length = null)
+    public function error(string $message, ?int $position = null, ?int $length = null): never
     {
-        $position = $position ?? $this->position;
-        $length = $length ?? 0;
+        $position ??= $this->position;
+        $length ??= 0;
 
         $span = $this->sourceFile->span($position, $position + $length);
 
@@ -335,13 +290,9 @@ class StringScanner
     }
 
     /**
-     * @param string $message
-     *
      * @throws FormatException
-     *
-     * @return never-returns
      */
-    private function fail(string $message)
+    private function fail(string $message): never
     {
         $this->error("expected $message.");
     }

--- a/src/Parser/StylesheetParser.php
+++ b/src/Parser/StylesheetParser.php
@@ -1195,10 +1195,10 @@ abstract class StylesheetParser extends Parser
         // Backwards-compatibility for implementations that allow absolute Windows
         // paths in imports.
         if (Path::isWindowsAbsolute($url) && !self::isRootRelativeUrl($url)) {
-            return (string) Uri::createFromWindowsPath($url);
+            return (string) Uri::fromWindowsPath($url);
         }
 
-        Uri::createFromString($url);
+        Uri::new($url);
         return $url;
     }
 

--- a/src/Parser/StylesheetParser.php
+++ b/src/Parser/StylesheetParser.php
@@ -195,7 +195,7 @@ abstract class StylesheetParser extends Parser
      */
     public function parse(): Stylesheet
     {
-        try {
+        return $this->wrapSpanFormatException(function () {
             $start = $this->scanner->getPosition();
 
             // Allow a byte-order mark at the beginning of the document.
@@ -222,14 +222,12 @@ abstract class StylesheetParser extends Parser
             }
 
             return new Stylesheet($statements, $this->scanner->spanFrom($start), $this->isPlainCss());
-        } catch (FormatException $e) {
-            throw $this->wrapException($e);
-        }
+        });
     }
 
     public function parseArgumentDeclaration(): ArgumentDeclaration
     {
-        try {
+        return $this->wrapSpanFormatException(function () {
             $this->scanner->expectChar('@', '@-rule');
             $this->identifier();
             $this->whitespace();
@@ -241,9 +239,7 @@ abstract class StylesheetParser extends Parser
             $this->scanner->expectDone();
 
             return $arguments;
-        } catch (FormatException $e) {
-            throw $this->wrapException($e);
-        }
+        });
     }
 
     /**
@@ -845,7 +841,7 @@ abstract class StylesheetParser extends Parser
                 // function. If so, throw a more helpful error message.
                 try {
                     $statement = $this->declarationOrStyleRule();
-                } catch (FormatException $e) {
+                } catch (FormatException) {
                     throw $variableDeclarationError;
                 }
 

--- a/src/Parser/StylesheetParser.php
+++ b/src/Parser/StylesheetParser.php
@@ -2819,7 +2819,7 @@ WARNING;
         $this->scanner->expectChar('+');
 
         $firstRangeLength = 0;
-        while ($this->scanCharIf([Character::class, 'isHex'])) {
+        while ($this->scanCharIf(Character::isHex(...))) {
             $firstRangeLength++;
         }
 
@@ -2841,7 +2841,7 @@ WARNING;
         if ($this->scanner->scanChar('-')) {
             $secondRangeStart = $this->scanner->getPosition();
             $secondRangeLength = 0;
-            while ($this->scanCharIf([Character::class, 'isHex'])) {
+            while ($this->scanCharIf(Character::isHex(...))) {
                 $secondRangeLength++;
             }
 

--- a/src/Parser/StylesheetParser.php
+++ b/src/Parser/StylesheetParser.php
@@ -1498,7 +1498,7 @@ abstract class StylesheetParser extends Parser
                         // A url-prefix with no argument, or with an empty string as an
                         // argument, is not (yet) deprecated.
                         $trailing = $buffer->getTrailingString();
-                        if (!StringUtil::endsWith($trailing, 'url-prefix()') && !StringUtil::endsWith($trailing, "url-prefix('')") && !StringUtil::endsWith($trailing, 'url-prefix("")')) {
+                        if (!str_ends_with($trailing, 'url-prefix()') && !str_ends_with($trailing, "url-prefix('')") && !str_ends_with($trailing, 'url-prefix("")')) {
                             $needsDeprecationWarning = true;
                         }
                         break;
@@ -3913,7 +3913,7 @@ WARNING;
 
     private function supportsDeclarationValue(Expression $name, int $start): SupportsDeclaration
     {
-        if ($name instanceof StringExpression && !$name->hasQuotes() && StringUtil::startsWith($name->getText()->getInitialPlain(), '--')) {
+        if ($name instanceof StringExpression && !$name->hasQuotes() && str_starts_with($name->getText()->getInitialPlain(), '--')) {
             $value = new StringExpression($this->interpolatedDeclarationValue());
         } else {
             $this->whitespace();

--- a/src/Parser/StylesheetParser.php
+++ b/src/Parser/StylesheetParser.php
@@ -93,60 +93,44 @@ abstract class StylesheetParser extends Parser
 {
     /**
      * The silent comment this parser encountered previously.
-     *
-     * @var SilentComment|null
      */
-    protected $lastSilentComment;
+    protected ?SilentComment $lastSilentComment = null;
 
     /**
      * Whether we've consumed a rule other than `@charset`, `@forward`, or `@use`.
-     *
-     * @var bool
      */
-    private $isUseAllowed = true;
+    private bool $isUseAllowed = true;
 
     /**
      * Whether the parser is currently parsing the contents of a mixin declaration.
-     *
-     * @var bool
      */
-    private $inMixin = false;
+    private bool $inMixin = false;
 
     /**
      * Whether the parser is currently parsing a content block passed to a mixin.
-     *
-     * @var bool
      */
-    private $inContentBlock = false;
+    private bool $inContentBlock = false;
 
     /**
      * Whether the parser is currently parsing a control directive such as `@if`
      * or `@each`.
-     *
-     * @var bool
      */
-    private $inControlDirective = false;
+    private bool $inControlDirective = false;
 
     /**
      * Whether the parser is currently parsing an unknown rule.
-     *
-     * @var bool
      */
-    private $inUnknownAtRule = false;
+    private bool $inUnknownAtRule = false;
 
     /**
      * Whether the parser is currently parsing a style rule.
-     *
-     * @var bool
      */
-    private $inStyleRule = false;
+    private bool $inStyleRule = false;
 
     /**
      * Whether the parser is currently within a parenthesized expression.
-     *
-     * @var bool
      */
-    private $inParentheses = false;
+    private bool $inParentheses = false;
 
     /**
      * A map from all variable names that are assigned with `!global` in the
@@ -159,35 +143,11 @@ abstract class StylesheetParser extends Parser
      *
      * @var array<string, VariableDeclaration>
      */
-    private $globalVariables = [];
-
-    /**
-     * @var \Closure
-     * @readonly
-     */
-    private $statementCallable;
-
-    /**
-     * @var \Closure
-     * @readonly
-     */
-    private $declarationChildCallable;
-
-    /**
-     * @var \Closure
-     * @readonly
-     */
-    private $functionChildCallable;
+    private array $globalVariables = [];
 
     public function __construct(string $contents, ?LoggerInterface $logger = null, ?string $sourceUrl = null)
     {
         parent::__construct($contents, $logger, $sourceUrl);
-
-        // Store callables for some private methods, to ensure they pass callable typehints when passed
-        // to parent methods expecting a callable, due to the semantic of PHP array callables.
-        $this->statementCallable = \Closure::fromCallable([$this, 'statement']);
-        $this->declarationChildCallable = \Closure::fromCallable([$this, 'declarationChild']);
-        $this->functionChildCallable = \Closure::fromCallable([$this, 'functionChild']);
     }
 
     /**
@@ -253,7 +213,7 @@ abstract class StylesheetParser extends Parser
     {
         switch ($this->scanner->peekChar()) {
             case '@':
-                return $this->atRule($this->statementCallable, $root);
+                return $this->atRule($this->statement(...), $root);
 
             case '+':
                 if (!$this->isIndented()) {
@@ -415,10 +375,8 @@ abstract class StylesheetParser extends Parser
      * couldn't consume a declaration and that selector parsing should be
      * attempted; or it can return a {@see Declaration} or a {@see VariableDeclaration},
      * indicating that it successfully consumed a declaration.
-     *
-     * @return Statement|InterpolationBuffer
      */
-    private function declarationOrBuffer()
+    private function declarationOrBuffer(): Statement|InterpolationBuffer
     {
         $start = $this->scanner->getPosition();
         $nameBuffer = new InterpolationBuffer();
@@ -430,7 +388,7 @@ abstract class StylesheetParser extends Parser
         if ($first === ':' || $first === '*' || $first === '.' || ($first === '#' && $this->scanner->peekChar(1) !== '{')) {
             $startsWithPunctuation = true;
             $nameBuffer->write($this->scanner->readChar());
-            $nameBuffer->write($this->rawText([$this, 'whitespace']));
+            $nameBuffer->write($this->rawText($this->whitespace(...)));
         }
 
         if (!$this->lookingAtInterpolatedIdentifier()) {
@@ -448,10 +406,10 @@ abstract class StylesheetParser extends Parser
         $this->isUseAllowed = false;
 
         if ($this->scanner->matches('/*')) {
-            $nameBuffer->write($this->rawText([$this, 'loudComment']));
+            $nameBuffer->write($this->rawText($this->loudComment(...)));
         }
 
-        $midBuffer = $this->rawText([$this, 'whitespace']);
+        $midBuffer = $this->rawText($this->whitespace(...));
         $beforeColon = $this->scanner->getPosition();
 
         if (!$this->scanner->scanChar(':')) {
@@ -467,7 +425,7 @@ abstract class StylesheetParser extends Parser
         // Parse custom properties as declarations no matter what.
         $name = $nameBuffer->buildInterpolation($this->scanner->spanFrom($start, $beforeColon));
 
-        if (0 === strpos($name->getInitialPlain(), '--')) {
+        if (str_starts_with($name->getInitialPlain(), '--')) {
             $value = new StringExpression($this->interpolatedDeclarationValue());
             $this->expectStatementSeparator('custom property');
 
@@ -487,10 +445,10 @@ abstract class StylesheetParser extends Parser
             return $nameBuffer;
         }
 
-        $postColonWhitespace = $this->rawText([$this, 'whitespace']);
+        $postColonWhitespace = $this->rawText($this->whitespace(...));
 
         if ($this->lookingAtChildren()) {
-            return $this->withChildren($this->declarationChildCallable, $start, function (array $children, FileSpan $span) use ($name) {
+            return $this->withChildren($this->declarationChild(...), $start, function (array $children, FileSpan $span) use ($name) {
                 return Declaration::nested($name, $children, $span);
             });
         }
@@ -539,7 +497,7 @@ abstract class StylesheetParser extends Parser
         }
 
         if ($this->lookingAtChildren()) {
-            return $this->withChildren($this->declarationChildCallable, $start, function (array $children, FileSpan $span) use ($name, $value) {
+            return $this->withChildren($this->declarationChild(...), $start, function (array $children, FileSpan $span) use ($name, $value) {
                 return Declaration::nested($name, $children, $span, $value);
             });
         }
@@ -557,10 +515,8 @@ abstract class StylesheetParser extends Parser
      * consume a variable declaration and that property declaration or selector
      * parsing should be attempted; or it can return a {@see VariableDeclaration},
      * indicating that it successfully consumed a variable declaration.
-     *
-     * @return Interpolation|VariableDeclaration
      */
-    private function variableDeclarationOrInterpolation()
+    private function variableDeclarationOrInterpolation(): Interpolation|VariableDeclaration
     {
         if (!$this->lookingAtIdentifier()) {
             return $this->interpolatedIdentifier();
@@ -607,7 +563,7 @@ abstract class StylesheetParser extends Parser
         $wasInStyleRule = $this->inStyleRule;
         $this->inStyleRule = true;
 
-        return $this->withChildren($this->statementCallable, $start, function (array $children) use ($wasInStyleRule, $start, $interpolation) {
+        return $this->withChildren($this->statement(...), $start, function (array $children) use ($wasInStyleRule, $start, $interpolation) {
             $this->inStyleRule = $wasInStyleRule;
 
             return new StyleRule($interpolation, $children, $this->scanner->spanFrom($start));
@@ -634,7 +590,7 @@ abstract class StylesheetParser extends Parser
         if ($first === ':' || $first === '*' || $first === '.' || ($first === '#' && $this->scanner->peekChar(1) !== '{')) {
             $nameBuffer = new InterpolationBuffer();
             $nameBuffer->write($this->scanner->readChar());
-            $nameBuffer->write($this->rawText([$this, 'whitespace']));
+            $nameBuffer->write($this->rawText($this->whitespace(...)));
             $nameBuffer->addInterpolation($this->interpolatedIdentifier());
             $name = $nameBuffer->buildInterpolation($this->scanner->spanFrom($start));
         } elseif (!$this->isPlainCss()) {
@@ -652,7 +608,7 @@ abstract class StylesheetParser extends Parser
         $this->whitespace();
         $this->scanner->expectChar(':');
 
-        if ($parseCustomProperties && 0 === strpos($name->getInitialPlain(), '--')) {
+        if ($parseCustomProperties && str_starts_with($name->getInitialPlain(), '--')) {
             $value = new StringExpression($this->interpolatedDeclarationValue());
             $this->expectStatementSeparator('custom property');
 
@@ -666,7 +622,7 @@ abstract class StylesheetParser extends Parser
                 $this->scanner->error("Nested declarations aren't allowed in plain CSS.");
             }
 
-            return $this->withChildren($this->declarationChildCallable, $start, function (array $children, FileSpan $span) use ($name) {
+            return $this->withChildren($this->declarationChild(...), $start, function (array $children, FileSpan $span) use ($name) {
                 return Declaration::nested($name, $children, $span);
             });
         }
@@ -678,7 +634,7 @@ abstract class StylesheetParser extends Parser
                 $this->scanner->error("Nested declarations aren't allowed in plain CSS.");
             }
 
-            return $this->withChildren($this->declarationChildCallable, $start, function (array $children, FileSpan $span) use ($name, $value) {
+            return $this->withChildren($this->declarationChild(...), $start, function (array $children, FileSpan $span) use ($name, $value) {
                 return Declaration::nested($name, $children, $span, $value);
             });
         }
@@ -798,21 +754,21 @@ abstract class StylesheetParser extends Parser
             case 'debug':
                 return $this->debugRule($start);
             case 'each':
-                return $this->eachRule($start, $this->declarationChildCallable);
+                return $this->eachRule($start, $this->declarationChild(...));
             case 'else':
                 $this->disallowedAtRule($start);
             case 'error':
                 return $this->errorRule($start);
             case 'for':
-                return $this->forRule($start, $this->declarationChildCallable);
+                return $this->forRule($start, $this->declarationChild(...));
             case 'if':
-                return $this->ifRule($start, $this->declarationChildCallable);
+                return $this->ifRule($start, $this->declarationChild(...));
             case 'include':
                 return $this->includeRule($start);
             case 'warn':
                 return $this->warnRule($start);
             case 'while':
-                return $this->whileRule($start, $this->declarationChildCallable);
+                return $this->whileRule($start, $this->declarationChild(...));
             default:
                 $this->disallowedAtRule($start);
         }
@@ -855,21 +811,21 @@ abstract class StylesheetParser extends Parser
             case 'debug':
                 return $this->debugRule($start);
             case 'each':
-                return $this->eachRule($start, $this->functionChildCallable);
+                return $this->eachRule($start, $this->functionChild(...));
             case 'else':
                 $this->disallowedAtRule($start);
             case 'error':
                 return $this->errorRule($start);
             case 'for':
-                return $this->forRule($start, $this->functionChildCallable);
+                return $this->forRule($start, $this->functionChild(...));
             case 'if':
-                return $this->ifRule($start, $this->functionChildCallable);
+                return $this->ifRule($start, $this->functionChild(...));
             case 'return':
                 return $this->returnRule($start);
             case 'warn':
                 return $this->warnRule($start);
             case 'while':
-                return $this->whileRule($start, $this->functionChildCallable);
+                return $this->whileRule($start, $this->functionChild(...));
             default:
                 $this->disallowedAtRule($start);
         }
@@ -899,13 +855,13 @@ abstract class StylesheetParser extends Parser
             $query = $this->atRootQuery();
             $this->whitespace();
 
-            return $this->withChildren($this->statementCallable, $start, function (array $children, FileSpan $span) use ($query) {
+            return $this->withChildren($this->statement(...), $start, function (array $children, FileSpan $span) use ($query) {
                 return new AtRootRule($children, $span, $query);
             });
         }
 
         if ($this->lookingAtChildren()) {
-            return $this->withChildren($this->statementCallable, $start, function (array $children, FileSpan $span) {
+            return $this->withChildren($this->statement(...), $start, function (array $children, FileSpan $span) {
                 return new AtRootRule($children, $span);
             });
         }
@@ -1080,7 +1036,7 @@ abstract class StylesheetParser extends Parser
 
         $this->whitespace();
 
-        return $this->withChildren($this->functionChildCallable, $start, function (array $children, FileSpan $span) use ($name, $precedingComment, $arguments) {
+        return $this->withChildren($this->functionChild(...), $start, function (array $children, FileSpan $span) use ($name, $precedingComment, $arguments) {
             return new FunctionRule($name, $arguments, $span, $children, $precedingComment);
         });
     }
@@ -1268,7 +1224,7 @@ abstract class StylesheetParser extends Parser
             return false;
         }
 
-        if (substr($url, -4) === '.css') {
+        if (str_ends_with($url, '.css')) {
             return true;
         }
 
@@ -1280,7 +1236,7 @@ abstract class StylesheetParser extends Parser
             return false;
         }
 
-        return 0 === strpos($url, 'http://') || 0 === strpos($url, 'https://');
+        return str_starts_with($url, 'http://') || str_starts_with($url, 'https://');
     }
 
     /**
@@ -1442,7 +1398,7 @@ abstract class StylesheetParser extends Parser
             $wasInContentBlock = $this->inContentBlock;
             $this->inContentBlock = true;
 
-            $content = $this->withChildren($this->statementCallable, $start, function (array $children, FileSpan $span) use ($contentArguments) {
+            $content = $this->withChildren($this->statement(...), $start, function (array $children, FileSpan $span) use ($contentArguments) {
                 return new ContentBlock($contentArguments, $children, $span);
             });
 
@@ -1470,7 +1426,7 @@ abstract class StylesheetParser extends Parser
     {
         $query = $this->mediaQueryList();
 
-        return $this->withChildren($this->statementCallable, $start, function (array $children, FileSpan $span) use ($query) {
+        return $this->withChildren($this->statement(...), $start, function (array $children, FileSpan $span) use ($query) {
             return new MediaRule($query, $children, $span);
         });
     }
@@ -1501,7 +1457,7 @@ abstract class StylesheetParser extends Parser
         $this->whitespace();
         $this->inMixin = true;
 
-        return $this->withChildren($this->statementCallable, $start, function (array $children, FileSpan $span) use ($name, $arguments, $precedingComment) {
+        return $this->withChildren($this->statement(...), $start, function (array $children, FileSpan $span) use ($name, $arguments, $precedingComment) {
             $this->inMixin = false;
 
             return new MixinRule($name, $arguments, $span, $children, $precedingComment);
@@ -1580,12 +1536,12 @@ abstract class StylesheetParser extends Parser
             }
 
             $buffer->write(',');
-            $buffer->write($this->rawText([$this, 'whitespace']));
+            $buffer->write($this->rawText($this->whitespace(...)));
         }
 
         $value = $buffer->buildInterpolation($this->scanner->spanFrom($valueStart));
 
-        return $this->withChildren($this->statementCallable, $start, function (array $children, FileSpan $span) use ($name, $value, $needsDeprecationWarning) {
+        return $this->withChildren($this->statement(...), $start, function (array $children, FileSpan $span) use ($name, $value, $needsDeprecationWarning) {
             if ($needsDeprecationWarning) {
                 $this->logger->warn("@-moz-document is deprecated and support will be removed in Dart Sass 2.0.0.\n\nFor details, see https://sass-lang.com/d/moz-document.", true, $span);
             }
@@ -1617,7 +1573,7 @@ abstract class StylesheetParser extends Parser
         $condition = $this->supportsCondition();
         $this->whitespace();
 
-        return $this->withChildren($this->statementCallable, $start, function (array $children, FileSpan $span) use ($condition) {
+        return $this->withChildren($this->statement(...), $start, function (array $children, FileSpan $span) use ($condition) {
             return new SupportsRule($condition, $children, $span);
         });
     }
@@ -1674,7 +1630,7 @@ abstract class StylesheetParser extends Parser
         }
 
         if ($this->lookingAtChildren()) {
-            $rule = $this->withChildren($this->statementCallable, $start, function (array $children, FileSpan $span) use ($name, $value) {
+            $rule = $this->withChildren($this->statement(...), $start, function (array $children, FileSpan $span) use ($name, $value) {
                 return new AtRule($name, $span, $value, $children);
             });
         } else {
@@ -1822,7 +1778,6 @@ abstract class StylesheetParser extends Parser
      * Consumes an expression.
      *
      * @param (callable(): bool)|null $until
-     *
      * @phpstan-impure
      */
     private function expression(?callable $until = null, bool $singleEquals = false, bool $bracketList = false): Expression
@@ -3400,7 +3355,7 @@ WARNING;
 
                 case '/':
                     if ($this->scanner->peekChar(1) === '*') {
-                        $buffer->write($this->rawText([$this, 'loudComment']));
+                        $buffer->write($this->rawText($this->loudComment(...)));
                     } else {
                         $buffer->write($this->scanner->readChar());
                     }

--- a/src/Serializer/SerializeResult.php
+++ b/src/Serializer/SerializeResult.php
@@ -19,11 +19,7 @@ namespace ScssPhp\ScssPhp\Serializer;
  */
 final class SerializeResult
 {
-    /**
-     * @var string
-     * @readonly
-     */
-    private $css;
+    private readonly string $css;
 
     public function __construct(string $css)
     {

--- a/src/Serializer/SerializeVisitor.php
+++ b/src/Serializer/SerializeVisitor.php
@@ -212,7 +212,7 @@ final class SerializeVisitor implements CssVisitor, ValueVisitor, SelectorVisito
                 $this->buffer->writeChar(' ');
             }
 
-            $this->writeBetween($node->getQueries(), $this->getCommaSeparator(), [$this, 'visitMediaQuery']);
+            $this->writeBetween($node->getQueries(), $this->getCommaSeparator(), $this->visitMediaQuery(...));
         });
 
         $this->writeOptionalSpace();
@@ -265,7 +265,7 @@ final class SerializeVisitor implements CssVisitor, ValueVisitor, SelectorVisito
         $this->writeIndentation();
 
         $this->for($node->getSelector(), function () use ($node) {
-            $this->writeBetween($node->getSelector()->getValue(), $this->getCommaSeparator(), [$this->buffer, 'write']);
+            $this->writeBetween($node->getSelector()->getValue(), $this->getCommaSeparator(), $this->buffer->write(...));
         });
         $this->writeOptionalSpace();
         $this->visitChildren($node);
@@ -293,7 +293,7 @@ final class SerializeVisitor implements CssVisitor, ValueVisitor, SelectorVisito
         } else {
             $operator = $query->isConjunction() ? 'and' : 'or';
 
-            $this->writeBetween($query->getConditions(), $this->compressed ? "$operator " : " $operator ", [$this->buffer, 'write']);
+            $this->writeBetween($query->getConditions(), $this->compressed ? "$operator " : " $operator ", $this->buffer->write(...));
         }
     }
 

--- a/src/Serializer/SerializeVisitor.php
+++ b/src/Serializer/SerializeVisitor.php
@@ -1201,7 +1201,7 @@ final class SerializeVisitor implements CssVisitor, ValueVisitor, SelectorVisito
 
         if ($value !== null) {
             assert($attribute->getOp() !== null);
-            $this->buffer->write($attribute->getOp());
+            $this->buffer->write($attribute->getOp()->getText());
 
             // Emit identifiers that start with `--` with quotes, because IE11
             // doesn't consider them to be valid identifiers.
@@ -1260,7 +1260,7 @@ final class SerializeVisitor implements CssVisitor, ValueVisitor, SelectorVisito
      * Writes $combinators to {@see buffer}, with spaces in between in expanded
      * mode.
      *
-     * @param list<CssValue<Combinator::*>> $combinators
+     * @param list<CssValue<Combinator>> $combinators
      */
     private function writeCombinators(array $combinators): void
     {

--- a/src/Serializer/SerializeVisitor.php
+++ b/src/Serializer/SerializeVisitor.php
@@ -208,7 +208,7 @@ final class SerializeVisitor implements CssVisitor, ValueVisitor, SelectorVisito
 
             $firstQuery = $node->getQueries()[0];
 
-            if (!$this->compressed || $firstQuery->getModifier() !== null || $firstQuery->getType() !== null || (\count($firstQuery->getConditions()) === 1) && StringUtil::startsWith($firstQuery->getConditions()[0], '(not ')) {
+            if (!$this->compressed || $firstQuery->getModifier() !== null || $firstQuery->getType() !== null || (\count($firstQuery->getConditions()) === 1) && str_starts_with($firstQuery->getConditions()[0], '(not ')) {
                 $this->buffer->writeChar(' ');
             }
 
@@ -286,7 +286,7 @@ final class SerializeVisitor implements CssVisitor, ValueVisitor, SelectorVisito
             }
         }
 
-        if (\count($query->getConditions()) === 1 && StringUtil::startsWith($query->getConditions()[0], '(not ')) {
+        if (\count($query->getConditions()) === 1 && str_starts_with($query->getConditions()[0], '(not ')) {
             $this->buffer->write('not ');
             $condition = $query->getConditions()[0];
             $this->buffer->write(substr($condition, \strlen('(not '), \strlen($condition) - (\strlen('(not ') + 1)));

--- a/src/Serializer/SerializeVisitor.php
+++ b/src/Serializer/SerializeVisitor.php
@@ -13,11 +13,18 @@
 namespace ScssPhp\ScssPhp\Serializer;
 
 use ScssPhp\ScssPhp\Ast\AstNode;
+use ScssPhp\ScssPhp\Ast\Css\CssAtRule;
 use ScssPhp\ScssPhp\Ast\Css\CssComment;
 use ScssPhp\ScssPhp\Ast\Css\CssDeclaration;
+use ScssPhp\ScssPhp\Ast\Css\CssImport;
+use ScssPhp\ScssPhp\Ast\Css\CssKeyframeBlock;
 use ScssPhp\ScssPhp\Ast\Css\CssMediaQuery;
+use ScssPhp\ScssPhp\Ast\Css\CssMediaRule;
 use ScssPhp\ScssPhp\Ast\Css\CssNode;
 use ScssPhp\ScssPhp\Ast\Css\CssParentNode;
+use ScssPhp\ScssPhp\Ast\Css\CssStyleRule;
+use ScssPhp\ScssPhp\Ast\Css\CssStylesheet;
+use ScssPhp\ScssPhp\Ast\Css\CssSupportsRule;
 use ScssPhp\ScssPhp\Ast\Css\CssValue;
 use ScssPhp\ScssPhp\Ast\Selector\AttributeSelector;
 use ScssPhp\ScssPhp\Ast\Selector\ClassSelector;
@@ -120,7 +127,7 @@ final class SerializeVisitor implements CssVisitor, ValueVisitor, SelectorVisito
         return $this->buffer;
     }
 
-    public function visitCssStylesheet($node): void
+    public function visitCssStylesheet(CssStylesheet $node): void
     {
         $previous = null;
 
@@ -154,7 +161,7 @@ final class SerializeVisitor implements CssVisitor, ValueVisitor, SelectorVisito
         }
     }
 
-    public function visitCssComment($node): void
+    public function visitCssComment(CssComment $node): void
     {
         $this->for($node, function () use ($node) {
             // Preserve comments that start with `/*!`.
@@ -182,7 +189,7 @@ final class SerializeVisitor implements CssVisitor, ValueVisitor, SelectorVisito
         });
     }
 
-    public function visitCssAtRule($node): void
+    public function visitCssAtRule(CssAtRule $node): void
     {
         $this->writeIndentation();
 
@@ -204,7 +211,7 @@ final class SerializeVisitor implements CssVisitor, ValueVisitor, SelectorVisito
         });
     }
 
-    public function visitCssMediaRule($node): void
+    public function visitCssMediaRule(CssMediaRule $node): void
     {
         $this->writeIndentation();
 
@@ -224,7 +231,7 @@ final class SerializeVisitor implements CssVisitor, ValueVisitor, SelectorVisito
         $this->visitChildren($node);
     }
 
-    public function visitCssImport($node): void
+    public function visitCssImport(CssImport $node): void
     {
         $this->writeIndentation();
 
@@ -265,7 +272,7 @@ final class SerializeVisitor implements CssVisitor, ValueVisitor, SelectorVisito
         }
     }
 
-    public function visitCssKeyframeBlock($node): void
+    public function visitCssKeyframeBlock(CssKeyframeBlock $node): void
     {
         $this->writeIndentation();
 
@@ -302,7 +309,7 @@ final class SerializeVisitor implements CssVisitor, ValueVisitor, SelectorVisito
         }
     }
 
-    public function visitCssStyleRule($node): void
+    public function visitCssStyleRule(CssStyleRule $node): void
     {
         $this->writeIndentation();
 
@@ -313,7 +320,7 @@ final class SerializeVisitor implements CssVisitor, ValueVisitor, SelectorVisito
         $this->visitChildren($node);
     }
 
-    public function visitCssSupportsRule($node): void
+    public function visitCssSupportsRule(CssSupportsRule $node): void
     {
         $this->writeIndentation();
 
@@ -330,7 +337,7 @@ final class SerializeVisitor implements CssVisitor, ValueVisitor, SelectorVisito
         $this->visitChildren($node);
     }
 
-    public function visitCssDeclaration($node): void
+    public function visitCssDeclaration(CssDeclaration $node): void
     {
         $this->writeIndentation();
         $this->write($node->getName());

--- a/src/Serializer/SimpleStringBuffer.php
+++ b/src/Serializer/SimpleStringBuffer.php
@@ -17,10 +17,7 @@ namespace ScssPhp\ScssPhp\Serializer;
  */
 final class SimpleStringBuffer implements StringBuffer
 {
-    /**
-     * @var string
-     */
-    private $text = '';
+    private string $text = '';
 
     public function getLength(): int
     {

--- a/src/Serializer/StringBuffer.php
+++ b/src/Serializer/StringBuffer.php
@@ -15,7 +15,7 @@ namespace ScssPhp\ScssPhp\Serializer;
 /**
  * @internal
  */
-interface StringBuffer
+interface StringBuffer extends \Stringable
 {
     /**
      * Returns the length of the content that has been accumulated so far.
@@ -28,6 +28,4 @@ interface StringBuffer
      * Writes a single char to the buffer.
      */
     public function writeChar(string $char): void;
-
-    public function __toString(): string;
 }

--- a/src/SourceSpan/ConcreteFileSpan.php
+++ b/src/SourceSpan/ConcreteFileSpan.php
@@ -20,28 +20,15 @@ use ScssPhp\ScssPhp\Util\Path;
  */
 final class ConcreteFileSpan implements FileSpan
 {
-    /**
-     * @var SourceFile
-     * @readonly
-     */
-    private $file;
+    private readonly SourceFile $file;
+
+    private readonly int $start;
+
+    private readonly int $end;
 
     /**
-     * @var int
-     * @readonly
-     */
-    private $start;
-
-    /**
-     * @var int
-     * @readonly
-     */
-    private $end;
-
-    /**
-     * @param SourceFile $file
-     * @param int        $start The offset of the beginning of the span.
-     * @param int        $end   The offset of the end of the span.
+     * @param int $start The offset of the beginning of the span.
+     * @param int $end   The offset of the end of the span.
      */
     public function __construct(SourceFile $file, int $start, int $end)
     {

--- a/src/SourceSpan/LazyFileSpan.php
+++ b/src/SourceSpan/LazyFileSpan.php
@@ -23,20 +23,20 @@ use ScssPhp\ScssPhp\SourceSpan\FileSpan;
 class LazyFileSpan implements FileSpan
 {
     /**
-     * @var callable(): FileSpan
+     * @var \Closure(): FileSpan
      * @readonly
      */
-    private $builder;
+    private readonly \Closure $builder;
 
     /**
      * @var FileSpan|null
      */
-    private $span;
+    private ?FileSpan $span = null;
 
     /**
-     * @param callable(): FileSpan $builder
+     * @param \Closure(): FileSpan $builder
      */
-    public function __construct(callable $builder)
+    public function __construct(\Closure $builder)
     {
         $this->builder = $builder;
     }

--- a/src/SourceSpan/SourceFile.php
+++ b/src/SourceSpan/SourceFile.php
@@ -17,23 +17,15 @@ namespace ScssPhp\ScssPhp\SourceSpan;
  */
 final class SourceFile
 {
-    /**
-     * @var string
-     * @readonly
-     */
-    private $string;
+    private readonly string $string;
 
-    /**
-     * @var string|null
-     * @readonly
-     */
-    private $sourceUrl;
+    private readonly ?string $sourceUrl;
 
     /**
      * @var int[]
      * @readonly
      */
-    private $lineStarts;
+    private array $lineStarts;
 
     /**
      * The 0-based last line that was returned by {@see getLine}
@@ -45,7 +37,7 @@ final class SourceFile
      *
      * @var int|null
      */
-    private $cachedLine;
+    private ?int $cachedLine = null;
 
     public function __construct(string $content, ?string $sourceUrl = null)
     {
@@ -68,7 +60,7 @@ final class SourceFile
 
         $this->lineStarts[] = \strlen($content);
 
-        if (substr($content, -1) !== "\n") {
+        if (!str_ends_with($content, "\n")) {
             $this->lineStarts[] = \strlen($content) + 1;
         }
     }
@@ -109,10 +101,6 @@ final class SourceFile
 
     /**
      * The 0-based line
-     *
-     * @param int $position
-     *
-     * @return int
      */
     public function getLine(int $position): int
     {
@@ -161,10 +149,6 @@ final class SourceFile
      *
      * Checks on {@see $cachedLine} and the next line. If it's on the next line, it
      * updates {@see $cachedLine} to point to that.
-     *
-     * @param int $position
-     *
-     * @return bool
      */
     private function isNearCacheLine(int $position): bool
     {
@@ -195,10 +179,6 @@ final class SourceFile
 
     /**
      * The 0-based column of that position
-     *
-     * @param int $position
-     *
-     * @return int
      */
     public function getColumn(int $position): int
     {

--- a/src/SourceSpan/SourceLocation.php
+++ b/src/SourceSpan/SourceLocation.php
@@ -17,17 +17,9 @@ namespace ScssPhp\ScssPhp\SourceSpan;
  */
 final class SourceLocation
 {
-    /**
-     * @var SourceFile
-     * @readonly
-     */
-    private $file;
+    private readonly SourceFile $file;
 
-    /**
-     * @var int
-     * @readonly
-     */
-    private $offset;
+    private readonly int $offset;
 
     public function __construct(SourceFile $file, int $offset)
     {

--- a/src/StackTrace/Frame.php
+++ b/src/StackTrace/Frame.php
@@ -21,41 +21,29 @@ final class Frame
 {
     /**
      * The URI of the file in which the code is located.
-     *
-     * @var string
-     * @readonly
      */
-    private $url;
+    private readonly string $url;
 
     /**
      * The line number on which the code location is located.
      *
      * This can be null, indicating that the line number is unknown or
      * unimportant.
-     *
-     * @var int|null
-     * @readonly
      */
-    private $line;
+    private readonly ?int $line;
 
     /**
      * The column number of the code location.
      *
      * This can be null, indicating that the column number is unknown or
      * unimportant.
-     *
-     * @var int|null
-     * @readonly
      */
-    private $column;
+    private readonly ?int $column;
 
     /**
      * The name of the member in which the code location occurs.
-     *
-     * @var string|null
-     * @readonly
      */
-    private $member;
+    private readonly ?string $member;
 
     public function __construct(string $url, ?int $line, ?int $column, ?string $member)
     {

--- a/src/StackTrace/Trace.php
+++ b/src/StackTrace/Trace.php
@@ -48,8 +48,6 @@ final class Trace
             $longest = max($longest, $length);
         }
 
-        return implode(array_map(function (Frame $frame) use ($longest) {
-            return str_pad($frame->getLocation(), $longest) . ' ' . $frame->getMember() . "\n";
-        }, $this->frames));
+        return implode(array_map(fn(Frame $frame) => str_pad($frame->getLocation(), $longest) . ' ' . $frame->getMember() . "\n", $this->frames));
     }
 }

--- a/src/StackTrace/Trace.php
+++ b/src/StackTrace/Trace.php
@@ -21,7 +21,7 @@ final class Trace
      * @var list<Frame>
      * @readonly
      */
-    private $frames;
+    private readonly array$frames;
 
     /**
      * @param list<Frame> $frames

--- a/src/Syntax.php
+++ b/src/Syntax.php
@@ -12,33 +12,30 @@
 
 namespace ScssPhp\ScssPhp;
 
-final class Syntax
+enum Syntax
 {
     /**
      * The CSS-superset SCSS syntax.
      */
-    const SCSS = 'scss';
+    case SCSS;
 
     /**
      * The whitespace-sensitive indented syntax.
      */
-    const SASS = 'sass';
+    case SASS;
 
     /**
      * The plain CSS syntax, which disallows special Sass features.
      */
-    const CSS = 'css';
+    case CSS;
 
-    /**
-     * @return Syntax::*
-     */
-    public static function forPath(string $path): string
+    public static function forPath(string $path): self
     {
-        if (substr($path, -5) === '.sass') {
+        if (str_ends_with($path, '.sass')) {
             return self::SASS;
         }
 
-        if (substr($path, -4) === '.css') {
+        if (str_ends_with($path, '.css')) {
             return self::CSS;
         }
 

--- a/src/Util.php
+++ b/src/Util.php
@@ -76,10 +76,6 @@ final class Util
 
     /**
      * Encode URI component
-     *
-     * @param string $string
-     *
-     * @return string
      */
     public static function encodeURIComponent(string $string): string
     {
@@ -108,10 +104,6 @@ final class Util
      * Returns $name without a vendor prefix.
      *
      * If $name has no vendor prefix, it's returned as-is.
-     *
-     * @param string $name
-     *
-     * @return string
      */
     public static function unvendor(string $name): string
     {
@@ -140,10 +132,6 @@ final class Util
 
     /**
      * mb_chr() wrapper
-     *
-     * @param int $code
-     *
-     * @return string
      */
     public static function mbChr(int $code): string
     {
@@ -168,10 +156,6 @@ final class Util
 
     /**
      * mb_ord() wrapper
-     *
-     * @param string $string
-     *
-     * @return int
      */
     public static function mbOrd(string $string): int
     {
@@ -205,9 +189,6 @@ final class Util
 
     /**
      * mb_strlen() wrapper
-     *
-     * @param string $string
-     * @return int
      */
     public static function mbStrlen(string $string): int
     {
@@ -225,10 +206,6 @@ final class Util
 
     /**
      * mb_substr() wrapper
-     * @param string $string
-     * @param int $start
-     * @param null|int $length
-     * @return string
      */
     public static function mbSubstr(string $string, int $start, ?int $length = null): string
     {
@@ -262,13 +239,8 @@ final class Util
 
     /**
      * mb_strpos wrapper
-     * @param string $haystack
-     * @param string $needle
-     * @param int $offset
-     *
-     * @return int|false
      */
-    public static function mbStrpos(string $haystack, string $needle, int $offset = 0)
+    public static function mbStrpos(string $haystack, string $needle, int $offset = 0): int|false
     {
         if (\function_exists('mb_strpos')) {
             return mb_strpos($haystack, $needle, $offset, 'UTF-8');

--- a/src/Util/Box.php
+++ b/src/Util/Box.php
@@ -24,9 +24,8 @@ final class Box implements Equatable
 {
     /**
      * @var ModifiableBox<T>
-     * @readonly
      */
-    private $inner;
+    private readonly ModifiableBox $inner;
 
     /**
      * @param ModifiableBox<T> $inner

--- a/src/Util/Character.php
+++ b/src/Util/Character.php
@@ -142,18 +142,11 @@ final class Character
      */
     public static function opposite(string $character): string
     {
-        switch ($character) {
-            case '(':
-                return ')';
-
-            case '{':
-                return '}';
-
-            case '[':
-                return ']';
-
-            default:
-                throw new \InvalidArgumentException(sprintf('Expected a brace character. Got "%s"', $character));
-        }
+        return match ($character) {
+            '(' => ')',
+            '{' => '}',
+            '[' => ']',
+            default => throw new \InvalidArgumentException(sprintf('Expected a brace character. Got "%s"', $character)),
+        };
     }
 }

--- a/src/Util/EquatableUtil.php
+++ b/src/Util/EquatableUtil.php
@@ -47,13 +47,8 @@ final class EquatableUtil
      * Values implementing {@see Equatable} are still compared with `===` first to
      * optimize comparisons to the same object, as an object is always expected to
      * be equal to itself.
-     *
-     * @param mixed $item1
-     * @param mixed $item2
-     *
-     * @return bool
      */
-    public static function equals($item1, $item2): bool
+    public static function equals(mixed $item1, mixed $item2): bool
     {
         if ($item1 === $item2) {
             return true;

--- a/src/Util/ErrorUtil.php
+++ b/src/Util/ErrorUtil.php
@@ -43,7 +43,7 @@ final class ErrorUtil
     public static function checkValidRange(int $start, ?int $end, int $length, ?string $startName = null, ?string $endName = null): void
     {
         if ($start < 0 || $start > $length) {
-            $startName = $startName ?? 'start';
+            $startName ??= 'start';
             $startNameDisplay = $startName ? " $startName" : '';
 
             throw new \OutOfRangeException("Invalid value:$startNameDisplay must be between 0 and $length: $start.");
@@ -52,7 +52,7 @@ final class ErrorUtil
         if ($end !== null) {
 
             if ($end < $start || $end > $length) {
-                $endName = $endName ?? 'end';
+                $endName ??= 'end';
                 $endNameDisplay = $endName ? " $endName" : '';
 
                 throw new \OutOfRangeException("Invalid value:$endNameDisplay must be between $start and $length: $end.");

--- a/src/Util/ListUtil.php
+++ b/src/Util/ListUtil.php
@@ -22,8 +22,6 @@ final class ListUtil
      *
      * @param T[]               $list
      * @param callable(T): bool $callback
-     *
-     * @return bool
      */
     public static function any(array $list, callable $callback): bool
     {
@@ -41,8 +39,6 @@ final class ListUtil
      *
      * @param T[]               $list
      * @param callable(T): bool $callback
-     *
-     * @return bool
      */
     public static function every(array $list, callable $callback): bool
     {

--- a/src/Util/ListUtil.php
+++ b/src/Util/ListUtil.php
@@ -114,9 +114,7 @@ final class ListUtil
     public static function longestCommonSubsequence(array $list1, array $list2, ?callable $select = null): array
     {
         if ($select === null) {
-            $select = function ($element1, $element2) {
-                return EquatableUtil::equals($element1, $element2) ? $element1 : null;
-            };
+            $select = fn($element1, $element2) => EquatableUtil::equals($element1, $element2) ? $element1 : null;
         }
 
         $lengths = array_fill(0, \count($list1) + 1, array_fill(0, \count($list2) + 1, 0));

--- a/src/Util/ModifiableBox.php
+++ b/src/Util/ModifiableBox.php
@@ -26,14 +26,13 @@ final class ModifiableBox
 {
     /**
      * @var T
-     * @readonly
      */
-    private $value;
+    private mixed $value;
 
     /**
      * @param T $value
      */
-    public function __construct($value)
+    public function __construct(mixed $value)
     {
         $this->value = $value;
     }
@@ -49,7 +48,7 @@ final class ModifiableBox
     /**
      * @param T $value
      */
-    public function setValue($value): void
+    public function setValue(mixed $value): void
     {
         $this->value = $value;
     }

--- a/src/Util/NumberUtil.php
+++ b/src/Util/NumberUtil.php
@@ -110,13 +110,6 @@ final class NumberUtil
     }
 
     /**
-     * @param float       $number
-     * @param float       $min
-     * @param float       $max
-     * @param string|null $name
-     *
-     * @return float
-     *
      * @throws \OutOfRangeException
      */
     public static function fuzzyAssertRange(float $number, float $min, float $max, ?string $name = null): float
@@ -136,11 +129,6 @@ final class NumberUtil
      * Returns $num1 / $num2, using Sass's division semantic.
      *
      * Sass allows dividing by 0.
-     *
-     * @param float $num1
-     * @param float $num2
-     *
-     * @return float
      */
     public static function divideLikeSass(float $num1, float $num2): float
     {
@@ -252,7 +240,7 @@ final class NumberUtil
         $base->assertNoUnits('base');
         $exponent->assertNoUnits('exponent');
 
-        return SassNumber::create(pow($base->getValue(), $exponent->getValue()));
+        return SassNumber::create($base->getValue() ** $exponent->getValue());
     }
 
     public static function atan2(SassNumber $x, SassNumber $y): SassNumber

--- a/src/Util/Path.php
+++ b/src/Util/Path.php
@@ -7,11 +7,6 @@ namespace ScssPhp\ScssPhp\Util;
  */
 final class Path
 {
-    /**
-     * @param string $path
-     *
-     * @return bool
-     */
     public static function isAbsolute(string $path): bool
     {
         if ($path === '') {
@@ -29,11 +24,6 @@ final class Path
         return false;
     }
 
-    /**
-     * @param string $path
-     *
-     * @return bool
-     */
     public static function isWindowsAbsolute(string $path): bool
     {
         if ($path === '') {
@@ -67,12 +57,6 @@ final class Path
         return true;
     }
 
-    /**
-     * @param string $part1
-     * @param string $part2
-     *
-     * @return string
-     */
     public static function join(string $part1, string $part2): string
     {
         if ($part1 === '' || self::isAbsolute($part2)) {
@@ -95,10 +79,6 @@ final class Path
 
     /**
      * Returns a pretty URI for a path
-     *
-     * @param string $path
-     *
-     * @return string
      */
     public static function prettyUri(string $path): string
     {
@@ -112,7 +92,7 @@ final class Path
 
         // TODO add support for returning a relative path using ../ in some cases, like Dart's path.prettyUri method
 
-        if (0 === strpos($normalizedPath, $normalizedRootDirectory)) {
+        if (str_starts_with($normalizedPath, $normalizedRootDirectory)) {
             return substr($path, \strlen($normalizedRootDirectory));
         }
 

--- a/src/Util/StringUtil.php
+++ b/src/Util/StringUtil.php
@@ -17,44 +17,6 @@ namespace ScssPhp\ScssPhp\Util;
  */
 final class StringUtil
 {
-    /**
-     * Checks whether $haystack starts with $needle.
-     *
-     * This is a userland implementation of `str_starts_with` of PHP 8+.
-     *
-     * @param string $haystack
-     * @param string $needle
-     *
-     * @return bool
-     */
-    public static function startsWith(string $haystack, string $needle): bool
-    {
-        if (\PHP_VERSION_ID >= 80000) {
-            return str_starts_with($haystack, $needle);
-        }
-
-        return '' === $needle || ('' !== $haystack && 0 === substr_compare($haystack, $needle, 0, \strlen($needle)));
-    }
-
-    /**
-     * Checks whether $haystack ends with $needle.
-     *
-     * This is a userland implementation of `str_ends_with` of PHP 8+.
-     *
-     * @param string $haystack
-     * @param string $needle
-     *
-     * @return bool
-     */
-    public static function endsWith(string $haystack, string $needle): bool
-    {
-        if (\PHP_VERSION_ID >= 80000) {
-            return str_ends_with($haystack, $needle);
-        }
-
-        return '' === $needle || ('' !== $haystack && 0 === substr_compare($haystack, $needle, -\strlen($needle)));
-    }
-
     public static function trimAsciiRight(string $string, bool $excludeEscape = false): string
     {
         $end = self::lastNonWhitespace($string, $excludeEscape);
@@ -92,11 +54,6 @@ final class StringUtil
 
     /**
      * Returns whether $string1 and $string2 are equal, ignoring ASCII case.
-     *
-     * @param string|null $string1
-     * @param string      $string2
-     *
-     * @return bool
      */
     public static function equalsIgnoreCase(?string $string1, string $string2): bool
     {
@@ -118,10 +75,6 @@ final class StringUtil
      * rather than operating on ASCII.
      * Passing an input string in an encoding that it is not ASCII compatible is
      * unsupported, and will probably generate garbage.
-     *
-     * @param string $string
-     *
-     * @return string
      */
     public static function toAsciiLowerCase(string $string): string
     {

--- a/src/Value/CalculationOperation.php
+++ b/src/Value/CalculationOperation.php
@@ -18,54 +18,34 @@ use ScssPhp\ScssPhp\Util\Equatable;
 /**
  * A binary operation that can appear in a {@see SassCalculation}.
  */
-final class CalculationOperation implements Equatable
+final class CalculationOperation implements Equatable, \Stringable
 {
-    /**
-     * @phpstan-var CalculationOperator::*
-     * @readonly
-     */
-    private $operator;
+    private readonly CalculationOperator $operator;
 
     /**
      * The left-hand operand.
      *
      * This is either a {@see SassNumber}, a {@see SassCalculation}, an unquoted
      * {@see SassString}, or a {@see CalculationOperation}.
-     *
-     * @var object
-     * @readonly
      */
-    private $left;
+    private readonly object $left;
 
     /**
      * The right-hand operand.
      *
      * This is either a {@see SassNumber}, a {@see SassCalculation}, an unquoted
      * {@see SassString}, or a {@see CalculationOperation}.
-     *
-     * @var object
-     * @readonly
      */
-    private $right;
+    private readonly object $right;
 
-    /**
-     * @param string $operator
-     * @param object $left
-     * @param object $right
-     *
-     * @phpstan-param CalculationOperator::* $operator
-     */
-    public function __construct(string $operator, object $left, object $right)
+    public function __construct(CalculationOperator $operator, object $left, object $right)
     {
         $this->operator = $operator;
         $this->left = $left;
         $this->right = $right;
     }
 
-    /**
-     * @phpstan-return CalculationOperator::*
-     */
-    public function getOperator(): string
+    public function getOperator(): CalculationOperator
     {
         return $this->operator;
     }

--- a/src/Value/CalculationOperator.php
+++ b/src/Value/CalculationOperator.php
@@ -15,34 +15,35 @@ namespace ScssPhp\ScssPhp\Value;
 /**
  * An enumeration of possible operators for {@see CalculationOperation}.
  */
-final class CalculationOperator
+enum CalculationOperator
 {
-    public const PLUS = '+';
-    public const MINUS = '-';
-    public const TIMES = '*';
-    public const DIVIDED_BY = '/';
+    case PLUS;
+    case MINUS;
+    case TIMES;
+    case DIVIDED_BY;
+
+    public function getOperator(): string
+    {
+        return match ($this) {
+            self::PLUS => '+',
+            self::MINUS => '-',
+            self::TIMES => '*',
+            self::DIVIDED_BY => '/',
+        };
+    }
 
     /**
      * The precedence of the operator
      *
      * An operator with higher precedence binds tighter.
      *
-     * @phpstan-param CalculationOperator::* $operator
-     *
      * @internal
      */
-    public static function getPrecedence(string $operator): int
+    public function getPrecedence(): int
     {
-        switch ($operator) {
-            case self::PLUS:
-            case self::MINUS:
-                return 1;
-
-            case self::TIMES:
-            case self::DIVIDED_BY:
-                return 2;
-        }
-
-        throw new \InvalidArgumentException(sprintf('Unknown operator "%s".', $operator));
+        return match ($this) {
+            self::PLUS, self::MINUS => 1,
+            self::TIMES, self::DIVIDED_BY => 2,
+        };
     }
 }

--- a/src/Value/ColorFormat.php
+++ b/src/Value/ColorFormat.php
@@ -12,11 +12,12 @@
 
 namespace ScssPhp\ScssPhp\Value;
 
+use JiriPudil\SealedClasses\Sealed;
+
 /**
  * @internal
  */
-final class ColorFormat
+#[Sealed(permits: [ColorFormatEnum::class, SpanColorFormat::class])]
+interface ColorFormat
 {
-    const RGB_FUNCTION = 'rgbFunction';
-    const HSL_FUNCTION = 'hslFunction';
 }

--- a/src/Value/ColorFormatEnum.php
+++ b/src/Value/ColorFormatEnum.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Value;
+
+/**
+ * @internal
+ */
+enum ColorFormatEnum implements ColorFormat
+{
+    /**
+     * A color defined using the `rgb()` or `rgba()` functions.
+     */
+    case rgbFunction;
+    /**
+     * A color defined using the `hsl()` or `hsla()` functions.
+     */
+    case hslFunction;
+}

--- a/src/Value/ComplexSassNumber.php
+++ b/src/Value/ComplexSassNumber.php
@@ -21,18 +21,15 @@ final class ComplexSassNumber extends SassNumber
 {
     /**
      * @var list<string>
-     * @readonly
      */
-    private $numeratorUnits;
+    private readonly array $numeratorUnits;
 
     /**
      * @var list<string>
-     * @readonly
      */
-    private $denominatorUnits;
+    private readonly array $denominatorUnits;
 
     /**
-     * @param float                              $value
      * @param list<string>                       $numeratorUnits
      * @param list<string>                       $denominatorUnits
      * @param array{SassNumber, SassNumber}|null $asSlash

--- a/src/Value/ListSeparator.php
+++ b/src/Value/ListSeparator.php
@@ -15,10 +15,20 @@ namespace ScssPhp\ScssPhp\Value;
 /**
  * An enum of list separator types.
  */
-final class ListSeparator
+enum ListSeparator
 {
-    const COMMA = ',';
-    const SPACE = ' ';
-    const SLASH = '/';
-    const UNDECIDED = '';
+    case COMMA;
+    case SPACE;
+    case SLASH;
+    case UNDECIDED;
+
+    public function getSeparator(): ?string
+    {
+        return match ($this) {
+            self::COMMA => ',',
+            self::SPACE => ' ',
+            self::SLASH => '/',
+            self::UNDECIDED => null,
+        };
+    }
 }

--- a/src/Value/SassArgumentList.php
+++ b/src/Value/SassArgumentList.php
@@ -35,13 +35,10 @@ final class SassArgumentList extends SassList
     /**
      * SassArgumentList constructor.
      *
-     * @param list<Value>          $contents
+     * @param list<Value> $contents
      * @param array<string, Value> $keywords
-     * @param string               $separator
-     *
-     * @phpstan-param ListSeparator::* $separator
      */
-    public function __construct(array $contents, array $keywords, string $separator)
+    public function __construct(array $contents, array $keywords, ListSeparator $separator)
     {
         parent::__construct($contents, $separator);
         $this->keywords = $keywords;

--- a/src/Value/SassArgumentList.php
+++ b/src/Value/SassArgumentList.php
@@ -23,14 +23,10 @@ final class SassArgumentList extends SassList
 {
     /**
      * @var array<string, Value>
-     * @readonly
      */
-    private $keywords;
+    private readonly array $keywords;
 
-    /**
-     * @var bool
-     */
-    private $keywordAccessed = false;
+    private bool $keywordAccessed = false;
 
     /**
      * SassArgumentList constructor.

--- a/src/Value/SassBoolean.php
+++ b/src/Value/SassBoolean.php
@@ -19,37 +19,19 @@ use ScssPhp\ScssPhp\Visitor\ValueVisitor;
  */
 final class SassBoolean extends Value
 {
-    /**
-     * @var SassBoolean|null
-     */
-    private static $trueInstance;
+    private static SassBoolean $trueInstance;
 
-    /**
-     * @var SassBoolean|null
-     */
-    private static $falseInstance;
+    private static SassBoolean $falseInstance;
 
-    /**
-     * @var bool
-     * @readonly
-     */
-    private $value;
+    private readonly bool $value;
 
     public static function create(bool $value): SassBoolean
     {
         if ($value) {
-            if (self::$trueInstance === null) {
-                self::$trueInstance = new self(true);
-            }
-
-            return self::$trueInstance;
+            return self::$trueInstance ??= new self(true);
         }
 
-        if (self::$falseInstance === null) {
-            self::$falseInstance = new self(false);
-        }
-
-        return self::$falseInstance;
+        return self::$falseInstance ??= new self(false);
     }
 
     private function __construct(bool $value)

--- a/src/Value/SassCalculation.php
+++ b/src/Value/SassCalculation.php
@@ -994,7 +994,7 @@ WARNING
             throw new SassScriptException("Value $arg can't be used in a calculation.");
         }
 
-        throw new \InvalidArgumentException(sprintf('Unexpected calculation argument %s.', get_class($arg)));
+        throw new \InvalidArgumentException(sprintf('Unexpected calculation argument %s.', get_debug_type($arg)));
     }
 
     /**

--- a/src/Value/SassCalculation.php
+++ b/src/Value/SassCalculation.php
@@ -31,11 +31,8 @@ final class SassCalculation extends Value
 {
     /**
      * The calculation's name, such as `"calc"`.
-     *
-     * @var string
-     * @readonly
      */
-    private $name;
+    private readonly string $name;
 
     /**
      * The calculation's arguments.
@@ -44,18 +41,14 @@ final class SassCalculation extends Value
      * {@see SassString}, or a {@see CalculationOperation}.
      *
      * @var list<object>
-     * @readonly
      */
-    private $arguments;
+    private readonly array $arguments;
 
     /**
      * Creates a new calculation with the given $name and $arguments
      * that will not be simplified.
      *
-     * @param string       $name
      * @param list<object> $arguments
-     *
-     * @return SassCalculation
      *
      * @internal
      */
@@ -73,10 +66,6 @@ final class SassCalculation extends Value
      * This automatically simplifies the calculation, so it may return a
      * {@see SassNumber} rather than a {@see SassCalculation}. It throws an exception if it
      * can determine that the calculation will definitely produce invalid CSS.
-     *
-     * @param object $argument
-     *
-     * @return Value
      *
      * @throws SassScriptException
      */
@@ -107,8 +96,6 @@ final class SassCalculation extends Value
      * can determine that the calculation will definitely produce invalid CSS.
      *
      * @param list<object> $arguments
-     *
-     * @return Value
      *
      * @throws SassScriptException
      */
@@ -156,8 +143,6 @@ final class SassCalculation extends Value
      *
      * @param list<object> $arguments
      *
-     * @return Value
-     *
      * @throws SassScriptException
      */
     public static function max(array $arguments): Value
@@ -203,7 +188,6 @@ final class SassCalculation extends Value
      * can determine that the calculation will definitely produce invalid CSS.
      *
      * @param list<object> $arguments
-     * @return Value
      */
     public static function hypot(array $arguments): Value
     {
@@ -439,15 +423,9 @@ WARNING
      * This may be passed fewer than three arguments, but only if one of the
      * arguments is an unquoted `var()` string.
      *
-     * @param object      $min
-     * @param object|null $value
-     * @param object|null $max
-     *
-     * @return Value
-     *
      * @throws SassScriptException
      */
-    public static function clamp(object $min, object $value = null, object $max = null): Value
+    public static function clamp(object $min, ?object $value = null, ?object $max = null): Value
     {
         if ($value === null && $max !== null) {
             throw new \InvalidArgumentException('If value is null, max must also be null.');
@@ -751,17 +729,9 @@ WARNING
      * Each of $left and $right must be either a {@see SassNumber}, a
      * {@see SassCalculation}, an unquoted {@see SassString}, or a {@see CalculationOperation}.
      *
-     * @param string $operator
-     * @param object $left
-     * @param object $right
-     *
-     * @return object
-     *
-     * @phpstan-param CalculationOperator::* $operator
-     *
      * @throws SassScriptException
      */
-    public static function operate(string $operator, object $left, object $right): object
+    public static function operate(CalculationOperator $operator, object $left, object $right): object
     {
         return self::operateInternal($operator, $left, $right, false, true);
     }
@@ -775,21 +745,11 @@ WARNING
      *
      * If $simplify is `false`, no simplification will be done.
      *
-     * @param string $operator
-     * @param object $left
-     * @param object $right
-     * @param bool   $inLegacySassFunction
-     * @param bool   $simplify
-     *
-     * @return object
-     *
      * @throws SassScriptException
-     *
-     * @phpstan-param CalculationOperator::* $operator
      *
      * @internal
      */
-    public static function operateInternal(string $operator, object $left, object $right, bool $inLegacySassFunction, bool $simplify): object
+    public static function operateInternal(CalculationOperator $operator, object $left, object $right, bool $inLegacySassFunction, bool $simplify): object
     {
         if (!$simplify) {
             return new CalculationOperation($operator, $left, $right);
@@ -824,7 +784,6 @@ WARNING
      * An internal constructor that doesn't perform any validation or
      * simplification.
      *
-     * @param string       $name
      * @param list<object> $arguments
      */
     private function __construct(string $name, array $arguments)
@@ -1148,7 +1107,6 @@ WARNING
      * doesn't contain either a {@see SassString}.
      *
      * @param list<object> $args
-     * @param int          $expectedLength
      *
      * @throws SassScriptException
      */

--- a/src/Value/SassColor.php
+++ b/src/Value/SassColor.php
@@ -24,70 +24,43 @@ final class SassColor extends Value
 {
     /**
      * This color's red channel, between `0` and `255`.
-     *
-     * @var int|null
      */
-    private $red;
+    private ?int $red;
 
     /**
      * This color's blue channel, between `0` and `255`.
-     *
-     * @var int|null
      */
-    private $blue;
+    private ?int $blue;
 
     /**
      * This color's green channel, between `0` and `255`.
-     *
-     * @var int|null
      */
-    private $green;
+    private ?int $green;
 
     /**
      * This color's hue, between `0` and `360`.
-     *
-     * @var float|null
      */
-    private $hue;
+    private ?float $hue;
 
     /**
      * This color's saturation, a percentage between `0` and `100`.
-     *
-     * @var float|null
      */
-    private $saturation;
+    private ?float $saturation;
 
     /**
      * This color's lightness, a percentage between `0` and `100`.
-     *
-     * @var float|null
      */
-    private $lightness;
+    private ?float $lightness;
 
     /**
      * This color's alpha channel, between `0` and `1`.
-     *
-     * @var float
-     * @readonly
      */
-    private $alpha;
+    private readonly float $alpha;
 
-    /**
-     * @var SpanColorFormat|string|null
-     * @phpstan-var SpanColorFormat|ColorFormat::*|null
-     * @readonly
-     */
-    private $format;
+    private readonly ?ColorFormat $format;
 
     /**
      * Creates a RGB color
-     *
-     * @param int $red
-     * @param int $blue
-     * @param int $green
-     * @param float $alpha
-     *
-     * @return SassColor
      *
      * @throws \OutOfRangeException if values are outside the expected range.
      */
@@ -101,19 +74,9 @@ final class SassColor extends Value
      *
      * @internal
      *
-     * @param int $red
-     * @param int $blue
-     * @param int $green
-     * @param float $alpha
-     * @param SpanColorFormat|string|null $format
-     *
-     * @return SassColor
-     *
-     * @phpstan-param SpanColorFormat|ColorFormat::*|null $format
-     *
      * @throws \OutOfRangeException if values are outside the expected range.
      */
-    public static function rgbInternal(int $red, int $green, int $blue, float $alpha = 1.0, $format = null): SassColor
+    public static function rgbInternal(int $red, int $green, int $blue, float $alpha = 1.0, ?ColorFormat $format = null): SassColor
     {
         $alpha = NumberUtil::fuzzyAssertRange($alpha, 0, 1, 'alpha');
 
@@ -125,13 +88,6 @@ final class SassColor extends Value
     }
 
     /**
-     * @param float $hue
-     * @param float $saturation
-     * @param float $lightness
-     * @param float $alpha
-     *
-     * @return SassColor
-     *
      * @throws \OutOfRangeException if values are outside the expected range.
      */
     public static function hsl(float $hue, float $saturation, float $lightness, float $alpha = 1.0): SassColor
@@ -144,19 +100,9 @@ final class SassColor extends Value
      *
      * @internal
      *
-     * @param float $hue
-     * @param float $saturation
-     * @param float $lightness
-     * @param float $alpha
-     * @param SpanColorFormat|string|null $format
-     *
-     * @return SassColor
-     *
      * @throws \OutOfRangeException if values are outside the expected range.
-     *
-     * @phpstan-param SpanColorFormat|ColorFormat::*|null $format
      */
-    public static function hslInternal(float $hue, float $saturation, float $lightness, float $alpha = 1.0, $format = null): SassColor
+    public static function hslInternal(float $hue, float $saturation, float $lightness, float $alpha = 1.0, ColorFormat $format = null): SassColor
     {
         $alpha = NumberUtil::fuzzyAssertRange($alpha, 0, 1, 'alpha');
 
@@ -167,14 +113,6 @@ final class SassColor extends Value
         return new self(null, null, null, $hue, $saturation, $lightness, $alpha, $format);
     }
 
-    /**
-     * @param float $hue
-     * @param float $whiteness
-     * @param float $blackness
-     * @param float $alpha
-     *
-     * @return SassColor
-     */
     public static function hwb(float $hue, float $whiteness, float $blackness, float $alpha = 1.0): SassColor
     {
         $scaledHue = fmod($hue , 360) / 360;
@@ -204,19 +142,8 @@ final class SassColor extends Value
      * If they are all provided, they are expected to be in sync and this not
      * revalidated. This constructor does not revalidate ranges either.
      * Use named factories when this cannot be guaranteed.
-     *
-     * @param int|null       $red
-     * @param int|null       $green
-     * @param int|null       $blue
-     * @param float|null     $hue
-     * @param float|null     $saturation
-     * @param float|null     $lightness
-     * @param float          $alpha
-     * @param SpanColorFormat|string|null $format
-     *
-     * @phpstan-param SpanColorFormat|ColorFormat::*|null $format
      */
-    private function __construct(?int $red, ?int $green, ?int $blue, ?float $hue, ?float $saturation, ?float $lightness, float $alpha, $format = null)
+    private function __construct(?int $red, ?int $green, ?int $blue, ?float $hue, ?float $saturation, ?float $lightness, float $alpha, ?ColorFormat $format = null)
     {
         $this->red = $red;
         $this->green = $green;
@@ -309,11 +236,8 @@ final class SassColor extends Value
      * supported format.
      *
      * @internal
-     *
-     * @return SpanColorFormat|string|null
-     * @phpstan-return SpanColorFormat|ColorFormat::*|null
      */
-    public function getFormat()
+    public function getFormat(): ?ColorFormat
     {
         return $this->format;
     }
@@ -328,50 +252,21 @@ final class SassColor extends Value
         return $this;
     }
 
-    /**
-     * @param int|null $red
-     * @param int|null $green
-     * @param int|null $blue
-     * @param float|null $alpha
-     *
-     * @return SassColor
-     */
     public function changeRgb(?int $red = null, ?int $green = null, ?int $blue = null, ?float $alpha = null): SassColor
     {
         return self::rgb($red ?? $this->getRed(), $green ?? $this->getGreen(), $blue ?? $this->getBlue(), $alpha ?? $this->alpha);
     }
 
-    /**
-     * @param float|null $hue
-     * @param float|null $saturation
-     * @param float|null $lightness
-     * @param float|null $alpha
-     *
-     * @return SassColor
-     */
     public function changeHsl(?float $hue = null, ?float $saturation = null, ?float $lightness = null, ?float $alpha = null): SassColor
     {
         return self::hsl($hue ?? $this->getHue(), $saturation ?? $this->getSaturation(), $lightness ?? $this->getLightness(), $alpha ?? $this->alpha);
     }
 
-    /**
-     * @param float|null $hue
-     * @param float|null $whiteness
-     * @param float|null $blackness
-     * @param float|null $alpha
-     *
-     * @return SassColor
-     */
     public function changeHwb(?float $hue = null, ?float $whiteness = null, ?float $blackness = null, ?float $alpha = null): SassColor
     {
         return self::hwb($hue ?? $this->getHue(), $whiteness ?? $this->getWhiteness(), $blackness ?? $this->getBlackness(), $alpha ?? $this->alpha);
     }
 
-    /**
-     * @param float $alpha
-     *
-     * @return SassColor
-     */
     public function changeAlpha(float $alpha): SassColor
     {
         return new self(
@@ -426,9 +321,6 @@ final class SassColor extends Value
         return $other instanceof SassColor && $this->getRed() === $other->getRed() && $this->getGreen() === $other->getGreen() && $this->getBlue() === $other->getBlue() && $this->alpha === $other->alpha;
     }
 
-    /**
-     * @return void
-     */
     private function rgbToHsl(): void
     {
         $scaledRed = $this->getRed() / 255;
@@ -460,9 +352,6 @@ final class SassColor extends Value
         }
     }
 
-    /**
-     * @return void
-     */
     private function hslToRgb(): void
     {
         $scaledHue = $this->getHue() / 360;

--- a/src/Value/SassList.php
+++ b/src/Value/SassList.php
@@ -25,12 +25,7 @@ class SassList extends Value
      */
     private $contents;
 
-    /**
-     * @var string
-     * @phpstan-var ListSeparator::*
-     * @readonly
-     */
-    private $separator;
+    private readonly ListSeparator $separator;
 
     /**
      * @var bool
@@ -38,27 +33,15 @@ class SassList extends Value
      */
     private $brackets;
 
-    /**
-     * @param string $separator
-     * @param bool   $brackets
-     *
-     * @return SassList
-     *
-     * @phpstan-param ListSeparator::* $separator
-     */
-    public static function createEmpty(string $separator = ListSeparator::UNDECIDED, bool $brackets = false): SassList
+    public static function createEmpty(ListSeparator $separator = ListSeparator::UNDECIDED, bool $brackets = false): SassList
     {
         return new self(array(), $separator, $brackets);
     }
 
     /**
      * @param list<Value> $contents
-     * @param string      $separator
-     * @param bool        $brackets
-     *
-     * @phpstan-param ListSeparator::* $separator
      */
-    public function __construct(array $contents, string $separator, bool $brackets = false)
+    public function __construct(array $contents, ListSeparator $separator, bool $brackets = false)
     {
         if ($separator === ListSeparator::UNDECIDED && count($contents) > 1) {
             throw new \InvalidArgumentException('A list with more than one element must have an explicit separator.');
@@ -69,7 +52,7 @@ class SassList extends Value
         $this->brackets = $brackets;
     }
 
-    public function getSeparator(): string
+    public function getSeparator(): ListSeparator
     {
         return $this->separator;
     }

--- a/src/Value/SassList.php
+++ b/src/Value/SassList.php
@@ -12,26 +12,23 @@
 
 namespace ScssPhp\ScssPhp\Value;
 
+use JiriPudil\SealedClasses\Sealed;
 use ScssPhp\ScssPhp\Visitor\ValueVisitor;
 
 /**
  * A SassScript list.
  */
+#[Sealed(permits: [SassArgumentList::class])]
 class SassList extends Value
 {
     /**
      * @var list<Value>
-     * @readonly
      */
-    private $contents;
+    private readonly array $contents;
 
     private readonly ListSeparator $separator;
 
-    /**
-     * @var bool
-     * @readonly
-     */
-    private $brackets;
+    private readonly bool $brackets;
 
     public static function createEmpty(ListSeparator $separator = ListSeparator::UNDECIDED, bool $brackets = false): SassList
     {

--- a/src/Value/SassMap.php
+++ b/src/Value/SassMap.php
@@ -22,9 +22,8 @@ final class SassMap extends Value
 {
     /**
      * @var Map<Value>
-     * @readonly
      */
-    private $contents;
+    private readonly Map $contents;
 
     /**
      * @param Map<Value> $contents
@@ -41,8 +40,6 @@ final class SassMap extends Value
 
     /**
      * @param Map<Value> $contents
-     *
-     * @return SassMap
      */
     public static function create(Map $contents): SassMap
     {

--- a/src/Value/SassMap.php
+++ b/src/Value/SassMap.php
@@ -59,7 +59,7 @@ final class SassMap extends Value
         return $this->contents;
     }
 
-    public function getSeparator(): string
+    public function getSeparator(): ListSeparator
     {
         return \count($this->contents) === 0 ? ListSeparator::UNDECIDED : ListSeparator::COMMA;
     }

--- a/src/Value/SassNull.php
+++ b/src/Value/SassNull.php
@@ -19,18 +19,11 @@ use ScssPhp\ScssPhp\Visitor\ValueVisitor;
  */
 final class SassNull extends Value
 {
-    /**
-     * @var SassNull|null
-     */
-    private static $instance;
+    private static SassNull $instance;
 
     public static function create(): SassNull
     {
-        if (self::$instance === null) {
-            self::$instance = new self();
-        }
-
-        return self::$instance;
+        return self::$instance ??= new self();
     }
 
     private function __construct()

--- a/src/Value/SassNumber.php
+++ b/src/Value/SassNumber.php
@@ -643,9 +643,7 @@ abstract class SassNumber extends Value
     public function plus(Value $other): Value
     {
         if ($other instanceof SassNumber) {
-            return $this->withValue($this->coerceUnits($other, function ($num1, $num2) {
-                return $num1 + $num2;
-            }));
+            return $this->withValue($this->coerceUnits($other, fn($num1, $num2) => $num1 + $num2));
         }
 
         if (!$other instanceof SassColor) {
@@ -658,9 +656,7 @@ abstract class SassNumber extends Value
     public function minus(Value $other): Value
     {
         if ($other instanceof SassNumber) {
-            return $this->withValue($this->coerceUnits($other, function ($num1, $num2) {
-                return $num1 - $num2;
-            }));
+            return $this->withValue($this->coerceUnits($other, fn($num1, $num2) => $num1 - $num2));
         }
 
         if (!$other instanceof SassColor) {
@@ -739,9 +735,7 @@ abstract class SassNumber extends Value
      */
     private static function getCanonicalMultiplier(array $units): float
     {
-        return array_reduce($units, function ($multiplier, $unit) {
-            return $multiplier * self::getCanonicalMultiplierForUnit($unit);
-        }, 1.0);
+        return array_reduce($units, fn($multiplier, $unit) => $multiplier * self::getCanonicalMultiplierForUnit($unit), 1.0);
     }
 
     private static function getCanonicalMultiplierForUnit(string $unit): float
@@ -1022,8 +1016,8 @@ abstract class SassNumber extends Value
     public function unitSuggestion(string $name, ?string $unit = null): string
     {
         $result = "\$$name"
-            . implode(array_map(function ($unit) { return " * 1$unit"; }, $this->getDenominatorUnits()))
-            . implode(array_map(function ($unit) { return " / 1$unit"; }, $this->getNumeratorUnits()))
+            . implode(array_map(fn($unit) => " * 1$unit", $this->getDenominatorUnits()))
+            . implode(array_map(fn($unit) => " / 1$unit", $this->getNumeratorUnits()))
             . ($unit === null ? '' : " * 1$unit");
 
         return $this->getNumeratorUnits() === [] ? $result : "calc($result)";

--- a/src/Value/SassNumber.php
+++ b/src/Value/SassNumber.php
@@ -598,7 +598,7 @@ abstract class SassNumber extends Value
     public function greaterThan(Value $other): SassBoolean
     {
         if ($other instanceof SassNumber) {
-            return SassBoolean::create($this->coerceUnits($other, [NumberUtil::class, 'fuzzyGreaterThan']));
+            return SassBoolean::create($this->coerceUnits($other, NumberUtil::fuzzyGreaterThan(...)));
         }
 
         throw new SassScriptException("Undefined operation \"$this > $other\".");
@@ -607,7 +607,7 @@ abstract class SassNumber extends Value
     public function greaterThanOrEquals(Value $other): SassBoolean
     {
         if ($other instanceof SassNumber) {
-            return SassBoolean::create($this->coerceUnits($other, [NumberUtil::class, 'fuzzyGreaterThanOrEquals']));
+            return SassBoolean::create($this->coerceUnits($other, NumberUtil::fuzzyGreaterThanOrEquals(...)));
         }
 
         throw new SassScriptException("Undefined operation \"$this >= $other\".");
@@ -616,7 +616,7 @@ abstract class SassNumber extends Value
     public function lessThan(Value $other): SassBoolean
     {
         if ($other instanceof SassNumber) {
-            return SassBoolean::create($this->coerceUnits($other, [NumberUtil::class, 'fuzzyLessThan']));
+            return SassBoolean::create($this->coerceUnits($other, NumberUtil::fuzzyLessThan(...)));
         }
 
         throw new SassScriptException("Undefined operation \"$this < $other\".");
@@ -625,7 +625,7 @@ abstract class SassNumber extends Value
     public function lessThanOrEquals(Value $other): SassBoolean
     {
         if ($other instanceof SassNumber) {
-            return SassBoolean::create($this->coerceUnits($other, [NumberUtil::class, 'fuzzyLessThanOrEquals']));
+            return SassBoolean::create($this->coerceUnits($other, NumberUtil::fuzzyLessThanOrEquals(...)));
         }
 
         throw new SassScriptException("Undefined operation \"$this > $other\".");
@@ -634,7 +634,7 @@ abstract class SassNumber extends Value
     public function modulo(Value $other): SassNumber
     {
         if ($other instanceof SassNumber) {
-            return $this->withValue($this->coerceUnits($other, [NumberUtil::class, 'moduloLikeSass']));
+            return $this->withValue($this->coerceUnits($other, NumberUtil::moduloLikeSass(...)));
         }
 
         throw new SassScriptException("Undefined operation \"$this % $other\".");

--- a/src/Value/SassString.php
+++ b/src/Value/SassString.php
@@ -37,19 +37,13 @@ final class SassString extends Value
      * contain characters that aren't valid in identifiers, such as
      * `url(http://example.com)`. Unfortunately, it also means that we don't
      * consider `foo` and `f\6F\6F` the same string.
-     *
-     * @var string
-     * @readonly
      */
-    private $text;
+    private readonly string $text;
 
     /**
      * Whether this string has quotes.
-     *
-     * @var bool
-     * @readonly
      */
-    private $quotes;
+    private readonly bool $quotes;
 
     public function __construct(string $text, bool $quotes = true)
     {

--- a/src/Value/SingleUnitSassNumber.php
+++ b/src/Value/SingleUnitSassNumber.php
@@ -91,15 +91,9 @@ final class SingleUnitSassNumber extends SassNumber
         'dppx' => ['dpi', 'dpcm', 'dppx'],
     ];
 
-    /**
-     * @var string
-     * @readonly
-     */
-    private $unit;
+    private readonly string $unit;
 
     /**
-     * @param float                              $value
-     * @param string                             $unit
      * @param array{SassNumber, SassNumber}|null $asSlash
      */
     public function __construct(float $value, string $unit, array $asSlash = null)

--- a/src/Value/SpanColorFormat.php
+++ b/src/Value/SpanColorFormat.php
@@ -17,12 +17,9 @@ use ScssPhp\ScssPhp\SourceSpan\FileSpan;
 /**
  * @internal
  */
-final class SpanColorFormat
+final class SpanColorFormat implements ColorFormat
 {
-    /**
-     * @var FileSpan
-     */
-    private $span;
+    private readonly FileSpan $span;
 
     public function __construct(FileSpan $span)
     {

--- a/src/Value/UnitlessSassNumber.php
+++ b/src/Value/UnitlessSassNumber.php
@@ -22,7 +22,6 @@ use ScssPhp\ScssPhp\Util\NumberUtil;
 final class UnitlessSassNumber extends SassNumber
 {
     /**
-     * @param float                              $value
      * @param array{SassNumber, SassNumber}|null $asSlash
      */
     public function __construct(float $value, array $asSlash = null)
@@ -156,7 +155,7 @@ final class UnitlessSassNumber extends SassNumber
         return parent::lessThanOrEquals($other);
     }
 
-    public function modulo(Value $other): Value
+    public function modulo(Value $other): SassNumber
     {
         if ($other instanceof SassNumber) {
             return $other->withValue(NumberUtil::moduloLikeSass($this->getValue(), $other->getValue()));

--- a/src/Value/Value.php
+++ b/src/Value/Value.php
@@ -48,12 +48,8 @@ abstract class Value implements Equatable
      *
      * All SassScript values can be used as lists. Maps count as lists of pairs,
      * and all other values count as single-value lists.
-     *
-     * @return string
-     *
-     * @phpstan-return ListSeparator::*
      */
-    public function getSeparator(): string
+    public function getSeparator(): ListSeparator
     {
         return ListSeparator::UNDECIDED;
     }
@@ -504,14 +500,8 @@ WARNING
      * separator and brackets.
      *
      * @param list<Value> $contents
-     * @param string|null $separator
-     * @param bool|null   $brackets
-     *
-     * @return SassList
-     *
-     * @phpstan-param ListSeparator::*|null $separator
      */
-    public function withListContents(array $contents, ?string $separator = null, ?bool $brackets = null): SassList
+    public function withListContents(array $contents, ?ListSeparator $separator = null, ?bool $brackets = null): SassList
     {
         return new SassList($contents, $separator ?? $this->getSeparator(), $brackets ?? $this->hasBrackets());
     }

--- a/src/Value/Value.php
+++ b/src/Value/Value.php
@@ -12,6 +12,7 @@
 
 namespace ScssPhp\ScssPhp\Value;
 
+use JiriPudil\SealedClasses\Sealed;
 use ScssPhp\ScssPhp\Ast\Selector\ComplexSelector;
 use ScssPhp\ScssPhp\Ast\Selector\CompoundSelector;
 use ScssPhp\ScssPhp\Ast\Selector\SelectorList;
@@ -31,12 +32,11 @@ use ScssPhp\ScssPhp\Warn;
  * particular types using `assert*()` functions like {@see assertString}, which
  * throw user-friendly error messages if they fail.
  */
-abstract class Value implements Equatable
+#[Sealed(permits: [SassBoolean::class, SassCalculation::class, SassColor::class, SassFunction::class, SassList::class, SassMap::class, SassNull::class, SassNumber::class, SassString::class])]
+abstract class Value implements Equatable, \Stringable
 {
     /**
      * Whether the value counts as `true` in an `@if` statement and other contexts
-     *
-     * @return bool
      */
     public function isTruthy(): bool
     {
@@ -59,8 +59,6 @@ abstract class Value implements Equatable
      *
      * All SassScript values can be used as lists. Maps count as lists of pairs,
      * and all other values count as single-value lists.
-     *
-     * @return bool
      */
     public function hasBrackets(): bool
     {
@@ -157,10 +155,6 @@ WARNING
      * If this came from a function argument, $name is the argument name
      * (without the `$`). It's used for error reporting.
      *
-     * @param string|null $name
-     *
-     * @return SassBoolean
-     *
      * @throws SassScriptException
      */
     public function assertBoolean(?string $name = null): SassBoolean
@@ -173,10 +167,6 @@ WARNING
      *
      * If this came from a function argument, $name is the argument name
      * (without the `$`). It's used for error reporting.
-     *
-     * @param string|null $name
-     *
-     * @return SassCalculation
      *
      * @throws SassScriptException
      */
@@ -191,10 +181,6 @@ WARNING
      * If this came from a function argument, $name is the argument name
      * (without the `$`). It's used for error reporting.
      *
-     * @param string|null $name
-     *
-     * @return SassColor
-     *
      * @throws SassScriptException
      */
     public function assertColor(?string $name = null): SassColor
@@ -207,10 +193,6 @@ WARNING
      *
      * If this came from a function argument, $name is the argument name
      * (without the `$`). It's used for error reporting.
-     *
-     * @param string|null $name
-     *
-     * @return SassFunction
      *
      * @throws SassScriptException
      */
@@ -225,10 +207,6 @@ WARNING
      * If this came from a function argument, $name is the argument name
      * (without the `$`). It's used for error reporting.
      *
-     * @param string|null $name
-     *
-     * @return SassMap
-     *
      * @throws SassScriptException
      */
     public function assertMap(?string $name = null): SassMap
@@ -238,8 +216,6 @@ WARNING
 
     /**
      * Return $this as a SassMap if it is one (including empty lists) or null otherwise.
-     *
-     * @return SassMap|null
      */
     public function tryMap(): ?SassMap
     {
@@ -251,10 +227,6 @@ WARNING
      *
      * If this came from a function argument, $name is the argument name
      * (without the `$`). It's used for error reporting.
-     *
-     * @param string|null $name
-     *
-     * @return SassNumber
      *
      * @throws SassScriptException
      */
@@ -268,10 +240,6 @@ WARNING
      *
      * If this came from a function argument, $name is the argument name
      * (without the `$`). It's used for error reporting.
-     *
-     * @param string|null $name
-     *
-     * @return SassString
      *
      * @throws SassScriptException
      */
@@ -456,8 +424,6 @@ WARNING
     /**
      * Whether the value will be represented in CSS as the empty string.
      *
-     * @return bool
-     *
      * @internal
      */
     public function isBlank(): bool
@@ -471,8 +437,6 @@ WARNING
      * Functions that shadow plain CSS functions need to gracefully handle when
      * these arguments are passed in.
      *
-     * @return bool
-     *
      * @internal
      */
     public function isSpecialNumber(): bool
@@ -485,8 +449,6 @@ WARNING
      *
      * Functions that shadow plain CSS functions need to gracefully handle when
      * these arguments are passed in.
-     *
-     * @return bool
      *
      * @internal
      */
@@ -509,10 +471,6 @@ WARNING
     /**
      * The SassScript = operation
      *
-     * @param Value $other
-     *
-     * @return Value
-     *
      * @internal
      */
     public function singleEquals(Value $other): Value
@@ -522,10 +480,6 @@ WARNING
 
     /**
      * The SassScript `>` operation.
-     *
-     * @param Value $other
-     *
-     * @return SassBoolean
      *
      * @internal
      */
@@ -537,10 +491,6 @@ WARNING
     /**
      * The SassScript `>=` operation.
      *
-     * @param Value $other
-     *
-     * @return SassBoolean
-     *
      * @internal
      */
     public function greaterThanOrEquals(Value $other): SassBoolean
@@ -550,10 +500,6 @@ WARNING
 
     /**
      * The SassScript `<` operation.
-     *
-     * @param Value $other
-     *
-     * @return SassBoolean
      *
      * @internal
      */
@@ -565,10 +511,6 @@ WARNING
     /**
      * The SassScript `<=` operation.
      *
-     * @param Value $other
-     *
-     * @return SassBoolean
-     *
      * @internal
      */
     public function lessThanOrEquals(Value $other): SassBoolean
@@ -578,10 +520,6 @@ WARNING
 
     /**
      * The SassScript `*` operation.
-     *
-     * @param Value $other
-     *
-     * @return Value
      *
      * @internal
      */
@@ -593,10 +531,6 @@ WARNING
     /**
      * The SassScript `%` operation.
      *
-     * @param Value $other
-     *
-     * @return Value
-     *
      * @internal
      */
     public function modulo(Value $other): Value
@@ -606,10 +540,6 @@ WARNING
 
     /**
      * The SassScript `+` operation.
-     *
-     * @param Value $other
-     *
-     * @return Value
      *
      * @internal
      */
@@ -629,10 +559,6 @@ WARNING
     /**
      * The SassScript `-` operation.
      *
-     * @param Value $other
-     *
-     * @return Value
-     *
      * @internal
      */
     public function minus(Value $other): Value
@@ -647,10 +573,6 @@ WARNING
     /**
      * The SassScript `/` operation.
      *
-     * @param Value $other
-     *
-     * @return Value
-     *
      * @internal
      */
     public function dividedBy(Value $other): Value
@@ -660,8 +582,6 @@ WARNING
 
     /**
      * The SassScript unary `+` operation.
-     *
-     * @return Value
      *
      * @internal
      */
@@ -673,8 +593,6 @@ WARNING
     /**
      * The SassScript unary `-` operation.
      *
-     * @return Value
-     *
      * @internal
      */
     public function unaryMinus(): Value
@@ -685,8 +603,6 @@ WARNING
     /**
      * The SassScript unary `/` operation.
      *
-     * @return Value
-     *
      * @internal
      */
     public function unaryDivide(): Value
@@ -696,8 +612,6 @@ WARNING
 
     /**
      * The SassScript unary `not` operation.
-     *
-     * @return Value
      *
      * @internal
      */
@@ -710,8 +624,6 @@ WARNING
      * Returns a copy of $this without {@see SassNumber::$asSlash} set.
      *
      * If this isn't a SassNumber, return it as-is.
-     *
-     * @return Value
      *
      * @internal
      */

--- a/src/Visitor/AnySelectorVisitor.php
+++ b/src/Visitor/AnySelectorVisitor.php
@@ -15,14 +15,17 @@ namespace ScssPhp\ScssPhp\Visitor;
 use ScssPhp\ScssPhp\Ast\Selector\AttributeSelector;
 use ScssPhp\ScssPhp\Ast\Selector\ClassSelector;
 use ScssPhp\ScssPhp\Ast\Selector\ComplexSelector;
+use ScssPhp\ScssPhp\Ast\Selector\ComplexSelectorComponent;
 use ScssPhp\ScssPhp\Ast\Selector\CompoundSelector;
 use ScssPhp\ScssPhp\Ast\Selector\IDSelector;
 use ScssPhp\ScssPhp\Ast\Selector\ParentSelector;
 use ScssPhp\ScssPhp\Ast\Selector\PlaceholderSelector;
 use ScssPhp\ScssPhp\Ast\Selector\PseudoSelector;
 use ScssPhp\ScssPhp\Ast\Selector\SelectorList;
+use ScssPhp\ScssPhp\Ast\Selector\SimpleSelector;
 use ScssPhp\ScssPhp\Ast\Selector\TypeSelector;
 use ScssPhp\ScssPhp\Ast\Selector\UniversalSelector;
+use ScssPhp\ScssPhp\Util\ListUtil;
 
 /**
  * A visitor that visits each selector in a Sass selector AST and returns
@@ -37,24 +40,12 @@ abstract class AnySelectorVisitor implements SelectorVisitor
 {
     public function visitComplexSelector(ComplexSelector $complex): bool
     {
-        foreach ($complex->getComponents() as $component) {
-            if ($this->visitCompoundSelector($component->getSelector())) {
-                return true;
-            }
-        }
-
-        return false;
+        return ListUtil::any($complex->getComponents(), fn (ComplexSelectorComponent $component) => $this->visitCompoundSelector($component->getSelector()));
     }
 
     public function visitCompoundSelector(CompoundSelector $compound): bool
     {
-        foreach ($compound->getComponents() as $simple) {
-            if ($simple->accept($this)) {
-                return true;
-            }
-        }
-
-        return false;
+        return ListUtil::any($compound->getComponents(), fn (SimpleSelector $simple) => $simple->accept($this));
     }
 
     public function visitPseudoSelector(PseudoSelector $pseudo): bool
@@ -66,13 +57,7 @@ abstract class AnySelectorVisitor implements SelectorVisitor
 
     public function visitSelectorList(SelectorList $list): bool
     {
-        foreach ($list->getComponents() as $complex) {
-            if ($this->visitComplexSelector($complex)) {
-                return true;
-            }
-        }
-
-        return false;
+        return ListUtil::any($list->getComponents(), $this->visitComplexSelector(...));
     }
 
     public function visitAttributeSelector(AttributeSelector $attribute): bool

--- a/src/Visitor/CssVisitor.php
+++ b/src/Visitor/CssVisitor.php
@@ -33,66 +33,48 @@ use ScssPhp\ScssPhp\Ast\Css\CssSupportsRule;
 interface CssVisitor extends ModifiableCssVisitor
 {
     /**
-     * @param CssAtRule $node
-     *
      * @return T
      */
-    public function visitCssAtRule($node);
+    public function visitCssAtRule(CssAtRule $node);
 
     /**
-     * @param CssComment $node
-     *
      * @return T
      */
-    public function visitCssComment($node);
+    public function visitCssComment(CssComment $node);
 
     /**
-     * @param CssDeclaration $node
-     *
      * @return T
      */
-    public function visitCssDeclaration($node);
+    public function visitCssDeclaration(CssDeclaration $node);
 
     /**
-     * @param CssImport $node
-     *
      * @return T
      */
-    public function visitCssImport($node);
+    public function visitCssImport(CssImport $node);
 
     /**
-     * @param CssKeyframeBlock $node
-     *
      * @return T
      */
-    public function visitCssKeyframeBlock($node);
+    public function visitCssKeyframeBlock(CssKeyframeBlock $node);
 
     /**
-     * @param CssMediaRule $node
-     *
      * @return T
      */
-    public function visitCssMediaRule($node);
+    public function visitCssMediaRule(CssMediaRule $node);
 
     /**
-     * @param CssStyleRule $node
-     *
      * @return T
      */
-    public function visitCssStyleRule($node);
+    public function visitCssStyleRule(CssStyleRule $node);
 
     /**
-     * @param CssStylesheet $node
-     *
      * @return T
      */
-    public function visitCssStylesheet($node);
+    public function visitCssStylesheet(CssStylesheet $node);
 
     /**
-     * @param CssSupportsRule $node
-     *
      * @return T
      */
-    public function visitCssSupportsRule($node);
+    public function visitCssSupportsRule(CssSupportsRule $node);
 
 }

--- a/src/Visitor/EveryCssVisitor.php
+++ b/src/Visitor/EveryCssVisitor.php
@@ -12,6 +12,16 @@
 
 namespace ScssPhp\ScssPhp\Visitor;
 
+use ScssPhp\ScssPhp\Ast\Css\CssAtRule;
+use ScssPhp\ScssPhp\Ast\Css\CssComment;
+use ScssPhp\ScssPhp\Ast\Css\CssDeclaration;
+use ScssPhp\ScssPhp\Ast\Css\CssImport;
+use ScssPhp\ScssPhp\Ast\Css\CssKeyframeBlock;
+use ScssPhp\ScssPhp\Ast\Css\CssMediaRule;
+use ScssPhp\ScssPhp\Ast\Css\CssStyleRule;
+use ScssPhp\ScssPhp\Ast\Css\CssStylesheet;
+use ScssPhp\ScssPhp\Ast\Css\CssSupportsRule;
+
 /**
  * A visitor that visits each statements in a CSS AST and returns `true` if all
  * of the individual methods return `true`.
@@ -23,7 +33,7 @@ namespace ScssPhp\ScssPhp\Visitor;
  */
 abstract class EveryCssVisitor implements CssVisitor
 {
-    public function visitCssAtRule($node): bool
+    public function visitCssAtRule(CssAtRule $node): bool
     {
         foreach ($node->getChildren() as $child) {
             if (!$child->accept($this)) {
@@ -34,22 +44,22 @@ abstract class EveryCssVisitor implements CssVisitor
         return true;
     }
 
-    public function visitCssComment($node): bool
+    public function visitCssComment(CssComment $node): bool
     {
         return false;
     }
 
-    public function visitCssDeclaration($node): bool
+    public function visitCssDeclaration(CssDeclaration $node): bool
     {
         return false;
     }
 
-    public function visitCssImport($node): bool
+    public function visitCssImport(CssImport $node): bool
     {
         return false;
     }
 
-    public function visitCssKeyframeBlock($node): bool
+    public function visitCssKeyframeBlock(CssKeyframeBlock $node): bool
     {
         foreach ($node->getChildren() as $child) {
             if (!$child->accept($this)) {
@@ -60,7 +70,7 @@ abstract class EveryCssVisitor implements CssVisitor
         return true;
     }
 
-    public function visitCssMediaRule($node): bool
+    public function visitCssMediaRule(CssMediaRule $node): bool
     {
         foreach ($node->getChildren() as $child) {
             if (!$child->accept($this)) {
@@ -71,7 +81,7 @@ abstract class EveryCssVisitor implements CssVisitor
         return true;
     }
 
-    public function visitCssStyleRule($node): bool
+    public function visitCssStyleRule(CssStyleRule $node): bool
     {
         foreach ($node->getChildren() as $child) {
             if (!$child->accept($this)) {
@@ -82,7 +92,7 @@ abstract class EveryCssVisitor implements CssVisitor
         return true;
     }
 
-    public function visitCssStylesheet($node): bool
+    public function visitCssStylesheet(CssStylesheet $node): bool
     {
         foreach ($node->getChildren() as $child) {
             if (!$child->accept($this)) {
@@ -93,7 +103,7 @@ abstract class EveryCssVisitor implements CssVisitor
         return true;
     }
 
-    public function visitCssSupportsRule($node): bool
+    public function visitCssSupportsRule(CssSupportsRule $node): bool
     {
         foreach ($node->getChildren() as $child) {
             if (!$child->accept($this)) {

--- a/src/Visitor/EveryCssVisitor.php
+++ b/src/Visitor/EveryCssVisitor.php
@@ -18,12 +18,14 @@ use ScssPhp\ScssPhp\Ast\Css\CssDeclaration;
 use ScssPhp\ScssPhp\Ast\Css\CssImport;
 use ScssPhp\ScssPhp\Ast\Css\CssKeyframeBlock;
 use ScssPhp\ScssPhp\Ast\Css\CssMediaRule;
+use ScssPhp\ScssPhp\Ast\Css\CssNode;
 use ScssPhp\ScssPhp\Ast\Css\CssStyleRule;
 use ScssPhp\ScssPhp\Ast\Css\CssStylesheet;
 use ScssPhp\ScssPhp\Ast\Css\CssSupportsRule;
+use ScssPhp\ScssPhp\Util\ListUtil;
 
 /**
- * A visitor that visits each statements in a CSS AST and returns `true` if all
+ * A visitor that visits each statement in a CSS AST and returns `true` if all
  * of the individual methods return `true`.
  *
  * Each method returns `false` by default.
@@ -35,13 +37,7 @@ abstract class EveryCssVisitor implements CssVisitor
 {
     public function visitCssAtRule(CssAtRule $node): bool
     {
-        foreach ($node->getChildren() as $child) {
-            if (!$child->accept($this)) {
-                return false;
-            }
-        }
-
-        return true;
+        return ListUtil::every($node->getChildren(), fn (CssNode $child) => $child->accept($this));
     }
 
     public function visitCssComment(CssComment $node): bool
@@ -61,56 +57,26 @@ abstract class EveryCssVisitor implements CssVisitor
 
     public function visitCssKeyframeBlock(CssKeyframeBlock $node): bool
     {
-        foreach ($node->getChildren() as $child) {
-            if (!$child->accept($this)) {
-                return false;
-            }
-        }
-
-        return true;
+        return ListUtil::every($node->getChildren(), fn (CssNode $child) => $child->accept($this));
     }
 
     public function visitCssMediaRule(CssMediaRule $node): bool
     {
-        foreach ($node->getChildren() as $child) {
-            if (!$child->accept($this)) {
-                return false;
-            }
-        }
-
-        return true;
+        return ListUtil::every($node->getChildren(), fn (CssNode $child) => $child->accept($this));
     }
 
     public function visitCssStyleRule(CssStyleRule $node): bool
     {
-        foreach ($node->getChildren() as $child) {
-            if (!$child->accept($this)) {
-                return false;
-            }
-        }
-
-        return true;
+        return ListUtil::every($node->getChildren(), fn (CssNode $child) => $child->accept($this));
     }
 
     public function visitCssStylesheet(CssStylesheet $node): bool
     {
-        foreach ($node->getChildren() as $child) {
-            if (!$child->accept($this)) {
-                return false;
-            }
-        }
-
-        return true;
+        return ListUtil::every($node->getChildren(), fn (CssNode $child) => $child->accept($this));
     }
 
     public function visitCssSupportsRule(CssSupportsRule $node): bool
     {
-        foreach ($node->getChildren() as $child) {
-            if (!$child->accept($this)) {
-                return false;
-            }
-        }
-
-        return true;
+        return ListUtil::every($node->getChildren(), fn (CssNode $child) => $child->accept($this));
     }
 }

--- a/src/Visitor/ModifiableCssVisitor.php
+++ b/src/Visitor/ModifiableCssVisitor.php
@@ -32,65 +32,47 @@ use ScssPhp\ScssPhp\Ast\Css\ModifiableCssSupportsRule;
 interface ModifiableCssVisitor
 {
     /**
-     * @param ModifiableCssAtRule $node
-     *
      * @return T
      */
-    public function visitCssAtRule($node);
+    public function visitCssAtRule(ModifiableCssAtRule $node);
 
     /**
-     * @param ModifiableCssComment $node
-     *
      * @return T
      */
-    public function visitCssComment($node);
+    public function visitCssComment(ModifiableCssComment $node);
 
     /**
-     * @param ModifiableCssDeclaration $node
-     *
      * @return T
      */
-    public function visitCssDeclaration($node);
+    public function visitCssDeclaration(ModifiableCssDeclaration $node);
 
     /**
-     * @param ModifiableCssImport $node
-     *
      * @return T
      */
-    public function visitCssImport($node);
+    public function visitCssImport(ModifiableCssImport $node);
 
     /**
-     * @param ModifiableCssKeyframeBlock $node
-     *
      * @return T
      */
-    public function visitCssKeyframeBlock($node);
+    public function visitCssKeyframeBlock(ModifiableCssKeyframeBlock $node);
 
     /**
-     * @param ModifiableCssMediaRule $node
-     *
      * @return T
      */
-    public function visitCssMediaRule($node);
+    public function visitCssMediaRule(ModifiableCssMediaRule $node);
 
     /**
-     * @param ModifiableCssStyleRule $node
-     *
      * @return T
      */
-    public function visitCssStyleRule($node);
+    public function visitCssStyleRule(ModifiableCssStyleRule $node);
 
     /**
-     * @param ModifiableCssStylesheet $node
-     *
      * @return T
      */
-    public function visitCssStylesheet($node);
+    public function visitCssStylesheet(ModifiableCssStylesheet $node);
 
     /**
-     * @param ModifiableCssSupportsRule $node
-     *
      * @return T
      */
-    public function visitCssSupportsRule($node);
+    public function visitCssSupportsRule(ModifiableCssSupportsRule $node);
 }

--- a/src/Visitor/SelectorSearchVisitor.php
+++ b/src/Visitor/SelectorSearchVisitor.php
@@ -68,16 +68,12 @@ abstract class SelectorSearchVisitor implements SelectorVisitor
 
     public function visitComplexSelector(ComplexSelector $complex)
     {
-        return ListUtil::search($complex->getComponents(), function (ComplexSelectorComponent $component) {
-            return $this->visitCompoundSelector($component->getSelector());
-        });
+        return ListUtil::search($complex->getComponents(), fn(ComplexSelectorComponent $component) => $this->visitCompoundSelector($component->getSelector()));
     }
 
     public function visitCompoundSelector(CompoundSelector $compound)
     {
-        return ListUtil::search($compound->getComponents(), function (SimpleSelector $simple) {
-            return $simple->accept($this);
-        });
+        return ListUtil::search($compound->getComponents(), fn(SimpleSelector $simple) => $simple->accept($this));
     }
 
     public function visitPseudoSelector(PseudoSelector $pseudo)
@@ -91,8 +87,6 @@ abstract class SelectorSearchVisitor implements SelectorVisitor
 
     public function visitSelectorList(SelectorList $list)
     {
-        return ListUtil::search($list->getComponents(), function (ComplexSelector $component) {
-            return $this->visitComplexSelector($component);
-        });
+        return ListUtil::search($list->getComponents(), $this->visitComplexSelector(...));
     }
 }

--- a/src/Visitor/StatementSearchVisitor.php
+++ b/src/Visitor/StatementSearchVisitor.php
@@ -122,16 +122,10 @@ abstract class StatementSearchVisitor implements StatementVisitor
 
     public function visitIfRule(IfRule $node)
     {
-        $value = ListUtil::search($node->getClauses(), function (IfClause $clause) {
-            return ListUtil::search($clause->getChildren(), function (Statement $child) {
-                return $child->accept($this);
-            });
-        });
+        $value = ListUtil::search($node->getClauses(), fn(IfClause $clause) => ListUtil::search($clause->getChildren(), fn(Statement $child) => $child->accept($this)));
 
         if ($node->getLastClause() !== null) {
-            $value = $value ?? ListUtil::search($node->getLastClause()->getChildren(), function (Statement $child) {
-                return $child->accept($this);
-            });
+            $value ??= ListUtil::search($node->getLastClause()->getChildren(), fn(Statement $child) => $child->accept($this));
         }
 
         return $value;
@@ -231,14 +225,6 @@ abstract class StatementSearchVisitor implements StatementVisitor
      */
     protected function visitChildren(array $children)
     {
-        foreach ($children as $child) {
-            $result = $child->accept($this);
-
-            if ($result !== null) {
-                return $result;
-            }
-        }
-
-        return null;
+        return ListUtil::search($children, fn (Statement $child) => $child->accept($this));
     }
 }

--- a/tests/Ast/Css/CssMediaQueryTest.php
+++ b/tests/Ast/Css/CssMediaQueryTest.php
@@ -14,13 +14,15 @@ namespace ScssPhp\ScssPhp\Tests\Ast\Css;
 
 use ScssPhp\ScssPhp\Ast\Css\CssMediaQuery;
 use PHPUnit\Framework\TestCase;
+use ScssPhp\ScssPhp\Ast\Css\MediaQueryMergeResult;
+use ScssPhp\ScssPhp\Ast\Css\MediaQuerySingletonMergeResult;
 
 class CssMediaQueryTest extends TestCase
 {
     /**
      * @dataProvider provideMergedQueries
      */
-    public function testMerging($expected, string $first, string $other)
+    public function testMerging(MediaQueryMergeResult $expected, string $first, string $other)
     {
         $firstQuery = self::parseQuery($first);
         $otherQuery = self::parseQuery($other);
@@ -52,17 +54,17 @@ class CssMediaQueryTest extends TestCase
         // narrower `not screen and (color)`.
         yield [self::parseQuery('not screen and (color)'), 'not screen', 'not screen and (color)'];
         // The intersection of two different media types is empty, so they're eliminated.
-        yield [CssMediaQuery::MERGE_RESULT_EMPTY, 'screen', 'print'];
+        yield [MediaQuerySingletonMergeResult::empty, 'screen', 'print'];
         // The intersection of `not screen` and `screen` is empty.
-        yield [CssMediaQuery::MERGE_RESULT_EMPTY, 'screen', 'not screen'];
+        yield [MediaQuerySingletonMergeResult::empty, 'screen', 'not screen'];
         // That's true even if `screen` has features.
-        yield [CssMediaQuery::MERGE_RESULT_EMPTY, 'screen and (color)', 'not screen'];
+        yield [MediaQuerySingletonMergeResult::empty, 'screen and (color)', 'not screen'];
         // No way to represent those non-empty intersections
-        yield [CssMediaQuery::MERGE_RESULT_UNREPRESENTABLE, 'not screen', '(color)'];
-        yield [CssMediaQuery::MERGE_RESULT_UNREPRESENTABLE, 'not screen', 'all and (color)'];
-        yield [CssMediaQuery::MERGE_RESULT_UNREPRESENTABLE, 'not screen and (color)', 'screen'];
-        yield [CssMediaQuery::MERGE_RESULT_UNREPRESENTABLE, 'not screen and (color)', 'not screen and (grid)'];
-        yield [CssMediaQuery::MERGE_RESULT_UNREPRESENTABLE, 'not screen', 'not print'];
+        yield [MediaQuerySingletonMergeResult::unrepresentable, 'not screen', '(color)'];
+        yield [MediaQuerySingletonMergeResult::unrepresentable, 'not screen', 'all and (color)'];
+        yield [MediaQuerySingletonMergeResult::unrepresentable, 'not screen and (color)', 'screen'];
+        yield [MediaQuerySingletonMergeResult::unrepresentable, 'not screen and (color)', 'not screen and (grid)'];
+        yield [MediaQuerySingletonMergeResult::unrepresentable, 'not screen', 'not print'];
     }
 
     private static function parseQuery(string $query): CssMediaQuery

--- a/vendor-bin/phpstan/composer.json
+++ b/vendor-bin/phpstan/composer.json
@@ -4,6 +4,7 @@
     },
     "require": {
         "jiripudil/phpstan-sealed-classes": "^1.1",
-        "phpstan/phpstan": "1.10.35"
+        "phpstan/phpstan": "1.10.35",
+        "phpstan/phpstan-deprecation-rules": "^1.1"
     }
 }

--- a/vendor-bin/phpstan/composer.json
+++ b/vendor-bin/phpstan/composer.json
@@ -3,6 +3,7 @@
         "sort-packages": true
     },
     "require": {
+        "jiripudil/phpstan-sealed-classes": "^1.1",
         "phpstan/phpstan": "1.10.35"
     }
 }


### PR DESCRIPTION
This PR includes modernizing the 2.0 codebase (i.e. it only changes the code ported from dart-sass, not the 1.x parser and compiler) to use the new features that this unlocks, in particular enums to represent several things in the AST.

Closes #669 