### PR TITLE
Implement the Importer layer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,9 @@
         "php": ">=8.1",
         "ext-ctype": "*",
         "ext-json": "*",
-        "league/uri": "^7.3",
-        "league/uri-interfaces": "^7.3"
+        "league/uri": "^7.4@dev",
+        "league/uri-interfaces": "^7.3",
+        "symfony/filesystem": "^5.4 || ^6.0 || ^7.0"
     },
     "suggest": {
         "ext-mbstring": "For best performance, mbstring should be installed as it is faster than ext-iconv",

--- a/src/Importer/CanonicalizeResult.php
+++ b/src/Importer/CanonicalizeResult.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Importer;
+
+use League\Uri\Contracts\UriInterface;
+
+/**
+ * @internal
+ */
+final class CanonicalizeResult
+{
+    public function __construct(
+        public readonly Importer $importer,
+        public readonly UriInterface $canonicalUrl,
+        public readonly UriInterface $originalUrl,
+    )
+    {
+    }
+}

--- a/src/Importer/FilesystemImporter.php
+++ b/src/Importer/FilesystemImporter.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Importer;
+
+use League\Uri\Contracts\UriInterface;
+use ScssPhp\ScssPhp\Syntax;
+use ScssPhp\ScssPhp\Util\Path;
+
+/**
+ * An importer that loads files from a load path on the filesystem.
+ */
+final class FilesystemImporter extends Importer
+{
+    /**
+     * The path relative to which this importer looks for files.
+     */
+    private readonly string $loadPath;
+
+    public function __construct(string $loadPath)
+    {
+        $this->loadPath = Path::absolute($loadPath);
+    }
+
+    public function canonicalize(UriInterface $url): ?UriInterface
+    {
+        if ($url->getScheme() !== 'file' && $url->getScheme() !== null) {
+            return null;
+        }
+
+        $path = ImportUtil::resolveImportPath(Path::join($this->loadPath, Path::fromUri($url)));
+
+        if ($path === null) {
+            return null;
+        }
+
+        return Path::toUri(Path::canonicalize($path));
+    }
+
+    public function load(UriInterface $url): ?ImporterResult
+    {
+        $path = Path::fromUri($url);
+        $content = file_get_contents($path);
+
+        if ($content === false) {
+            throw new \Exception("Could not read file $path");
+        }
+
+        return new ImporterResult($content, Syntax::forPath($path), $url);
+    }
+
+    public function couldCanonicalize(UriInterface $url, UriInterface $canonicalUrl): bool
+    {
+        if ($url->getScheme() !== 'file' && $url->getScheme() !== null) {
+            return false;
+        }
+
+        if ($canonicalUrl->getScheme() !== 'file') {
+            return false;
+        }
+
+        $basename = basename((string) $url);
+        $canonicalBasename = basename((string) $canonicalUrl);
+
+        if (!str_starts_with($basename, '_') && str_starts_with($canonicalBasename, '_')) {
+            $canonicalBasename = substr($canonicalBasename, 1);
+        }
+
+        return $basename === $canonicalBasename || $basename === Path::withoutExtension($canonicalBasename);
+    }
+
+    public function __toString(): string
+    {
+        return $this->loadPath;
+    }
+}

--- a/src/Importer/ImportCache.php
+++ b/src/Importer/ImportCache.php
@@ -1,0 +1,240 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Importer;
+
+use League\Uri\BaseUri;
+use League\Uri\Contracts\UriInterface;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\Stylesheet;
+use ScssPhp\ScssPhp\Logger\LocationAwareLoggerInterface;
+use ScssPhp\ScssPhp\Logger\QuietLogger;
+use ScssPhp\ScssPhp\Util\UriUtil;
+
+/**
+ * An in-memory cache of parsed stylesheets that have been imported by Sass.
+ *
+ * @internal
+ */
+final class ImportCache
+{
+    /**
+     * @var list<Importer>
+     */
+    private readonly array $importers;
+
+    private readonly LocationAwareLoggerInterface $logger;
+
+    /**
+     * The canonicalized URLs for each non-canonical URL.
+     *
+     * The `forImport` in each key is true when this canonicalization is for an
+     * `@import` rule. Otherwise, it's for a `@use` or `@forward` rule.
+     *
+     * This cache isn't used for relative imports, because they depend on the
+     * specific base importer. That's stored separately in
+     * {@see $relativeCanonicalizeCache}.
+     *
+     * @var array<string, array<0|1, CanonicalizeResult|SpecialCacheValue>>
+     */
+    private array $canonicalizeCache = [];
+
+    /**
+     * @var array<string, array<0|1, array<string, \SplObjectStorage<Importer, CanonicalizeResult|SpecialCacheValue>>>>
+     */
+    private array $relativeCanonicalizeCache = [];
+
+    /**
+     * The parsed stylesheets for each canonicalized import URL.
+     *
+     * @var array<string, Stylesheet|SpecialCacheValue>
+     */
+    private array $importCache = [];
+
+    /**
+     * The import results for each canonicalized import URL.
+     *
+     * @var array<string, ImporterResult>
+     */
+    private array $resultsCache = [];
+
+    /**
+     * @param list<Importer> $importers
+     */
+    public function __construct(array $importers, LocationAwareLoggerInterface $logger)
+    {
+        $this->importers = $importers;
+        $this->logger = $logger;
+    }
+
+    public function canonicalize(UriInterface $url, ?Importer $baseImporter = null, ?UriInterface $baseUrl = null, bool $forImport = false): ?CanonicalizeResult
+    {
+        $urlCacheKey = (string) $url;
+        $forImportCacheKey = (int) $forImport;
+
+        if ($baseImporter !== null && $url->getScheme() === null) {
+            $baseUrlCacheKey = (string) $baseUrl;
+
+            $this->relativeCanonicalizeCache[$urlCacheKey][$forImportCacheKey][$baseUrlCacheKey] ??= self::createStorage();
+
+            $relativeResult = $this->relativeCanonicalizeCache[$urlCacheKey][$forImportCacheKey][$baseUrlCacheKey][$baseImporter] ??= $this->doCanonicalize($baseImporter, self::resolveUri($baseUrl, $url,), $baseUrl, $forImport) ?? SpecialCacheValue::null;
+
+            if ($relativeResult !== SpecialCacheValue::null) {
+                return $relativeResult;
+            }
+        }
+
+        $cacheResult = $this->canonicalizeCache[$urlCacheKey][$forImportCacheKey] ??= $this->doCanonicalizeWithImporters($url, $baseUrl, $forImport) ?? SpecialCacheValue::null;
+
+        if ($cacheResult !== SpecialCacheValue::null) {
+            return $cacheResult;
+        }
+
+        return null;
+    }
+
+    private static function resolveUri(?UriInterface $baseUrl, UriInterface $url): UriInterface
+    {
+        if ($baseUrl === null) {
+            return $url;
+        }
+
+        return UriUtil::resolveUri($baseUrl, $url);
+    }
+
+    /**
+     * Creates a new storage for the importer-level cache
+     *
+     * This is in a dedicated method because phpstan cannot infer the generic types from the constructor.
+     *
+     * @return \SplObjectStorage<Importer, CanonicalizeResult|SpecialCacheValue>
+     */
+    private static function createStorage(): \SplObjectStorage
+    {
+        /** @var \SplObjectStorage<Importer, CanonicalizeResult|SpecialCacheValue> $storage */
+        $storage = new \SplObjectStorage();
+        return $storage;
+    }
+
+    private function doCanonicalizeWithImporters(UriInterface $url, ?UriInterface $baseUrl, bool $forImport): ?CanonicalizeResult
+    {
+        foreach ($this->importers as $importer) {
+            $result = $this->doCanonicalize($importer, $url, $baseUrl, $forImport);
+
+            if ($result !== null) {
+                return $result;
+            }
+        }
+
+        return null;
+    }
+
+    private function doCanonicalize(Importer $importer, UriInterface $url, ?UriInterface $baseUrl, bool $forImport): ?CanonicalizeResult
+    {
+        $canonicalize = $forImport
+            ? fn () => ImportContext::inImportRule(fn () => $importer->canonicalize($url))
+            : fn () => $importer->canonicalize($url);
+
+        $passContainingUrl = $baseUrl !== null && ($url->getScheme() === null || $importer->isNonCanonicalScheme($url->getScheme()));
+        $result = ImportContext::withContainingUrl($passContainingUrl ? $baseUrl : null, $canonicalize);
+
+        if ($result === null) {
+            return null;
+        }
+
+        if ($result->getScheme() === null) {
+            throw new \UnexpectedValueException("Importer $importer canonicalized $url to $result but canonical URLs must be absolute.");
+        }
+
+        if ($importer->isNonCanonicalScheme($result->getScheme())) {
+            throw new \UnexpectedValueException("Importer $importer canonicalized $url to $result, which uses a scheme declared as non-canonical.");
+
+        }
+
+        return new CanonicalizeResult($importer, $result, $url);
+    }
+
+    /**
+     * Tries to load the canonicalized $canonicalUrl using $importer.
+     *
+     * If $importer can import $canonicalUrl, returns the imported {@see Stylesheet}.
+     * Otherwise returns `null`.
+     *
+     * If passed, the $originalUrl represents the URL that was canonicalized
+     * into $canonicalUrl. It's used to resolve a relative canonical URL, which
+     * importers may return for legacy reasons.
+     *
+     * If $quiet is `true`, this will disable logging warnings when parsing the
+     * newly imported stylesheet.
+     *
+     * Caches the result of the import and uses cached results if possible.
+     */
+    public function importCanonical(Importer $importer, UriInterface $canonicalUrl, ?UriInterface $originalUrl = null, bool $quiet = false): ?Stylesheet
+    {
+        $result = $this->importCache[(string) $canonicalUrl] ??= $this->doImportCanonical($importer, $canonicalUrl, $originalUrl, $quiet) ?? SpecialCacheValue::null;
+
+        if ($result !== SpecialCacheValue::null) {
+            return $result;
+        }
+
+        return null;
+    }
+
+    private function doImportCanonical(Importer $importer, UriInterface $canonicalUrl, ?UriInterface $originalUrl = null, bool $quiet = false): ?Stylesheet
+    {
+        $result = $importer->load($canonicalUrl);
+
+        if ($result === null) {
+            return null;
+        }
+
+        $this->resultsCache[(string) $canonicalUrl] = $result;
+
+        return Stylesheet::parse($result->getContents(), $result->getSyntax(), $quiet ? new QuietLogger() : $this->logger, $originalUrl);
+    }
+
+    public function humanize(UriInterface $canonicalUrl): UriInterface
+    {
+        $shortestUrl = null;
+        $shortestLength = \PHP_INT_MAX;
+
+        foreach ($this->canonicalizeCache as $cacheValues) {
+            foreach ($cacheValues as $cacheValue) {
+                if ($cacheValue === SpecialCacheValue::null) {
+                    continue;
+                }
+
+                if ($cacheValue->canonicalUrl->toString() !== $canonicalUrl->toString()) {
+                    continue;
+                }
+
+                $originalUrlLength = \strlen($cacheValue->originalUrl->getPath());
+
+                if ($shortestUrl === null || $originalUrlLength < $shortestLength) {
+                    $shortestUrl = $cacheValue->originalUrl;
+                    $shortestLength = $originalUrlLength;
+                }
+            }
+        }
+
+        if ($shortestUrl !== null) {
+            // TODO check if basename is safe to use for the URL context
+            return UriUtil::resolve($shortestUrl, basename($canonicalUrl->getPath()));
+        }
+
+        return $canonicalUrl;
+    }
+
+    public function sourceMapUrl(UriInterface $canonicalUrl): UriInterface
+    {
+        return ($this->resultsCache[(string) $canonicalUrl] ?? null)?->getSourceMapUrl() ?? $canonicalUrl;
+    }
+}

--- a/src/Importer/ImportContext.php
+++ b/src/Importer/ImportContext.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Importer;
+
+use League\Uri\Contracts\UriInterface;
+
+/**
+ * @internal
+ */
+final class ImportContext
+{
+    private static bool $fromImport = false;
+
+    private static bool $hasContainingUrl = false;
+
+    private static ?UriInterface $containingUrl;
+
+    /**
+     * Whether the Sass compiler is currently evaluating an `@import` rule.
+     * ///
+     * /// When evaluating `@import` rules, URLs should canonicalize to an import-only
+     * /// file if one exists for the URL being canonicalized. Otherwise,
+     * /// canonicalization should be identical for `@import` and `@use` rules. It's
+     * /// admittedly hacky to set this globally, but `@import` will eventually be
+     * /// removed, at which point we can delete this and have one consistent behavior.
+     */
+    public static function isFromImport(): bool
+    {
+        return self::$fromImport;
+    }
+
+    /**
+     * @template T
+     *
+     * @param callable(): T $callback
+     * @return T
+     */
+    public static function inImportRule(callable $callback)
+    {
+        $oldFromImport = self::$fromImport;
+        self::$fromImport = true;
+
+        try {
+            return $callback();
+        } finally {
+            self::$fromImport = $oldFromImport;
+        }
+    }
+
+    public static function getContainingUrl(): ?UriInterface
+    {
+        if (!self::$hasContainingUrl) {
+            throw new \LogicException('containingUrl may only be accessed within a call to canonicalize().');
+        }
+
+        return self::$containingUrl;
+    }
+
+    /**
+     * @template T
+     *
+     * @param callable(): T $callback
+     * @return T
+     */
+    public static function withContainingUrl(?UriInterface $url, callable $callback)
+    {
+        $oldContainingUrl = self::$containingUrl;
+        $oldHasContainingUrl = self::$hasContainingUrl;
+
+        self::$containingUrl = $url;
+        self::$hasContainingUrl = true;
+
+        try {
+            return $callback();
+        } finally {
+            self::$containingUrl = $oldContainingUrl;
+            self::$hasContainingUrl = $oldHasContainingUrl;
+        }
+    }
+}

--- a/src/Importer/ImportUtil.php
+++ b/src/Importer/ImportUtil.php
@@ -1,0 +1,141 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Importer;
+
+use ScssPhp\ScssPhp\Util\Path;
+
+/**
+ * @internal
+ */
+final class ImportUtil
+{
+    /**
+     * Resolves an imported path using the same logic as the filesystem importer.
+     *
+     * This tries to fill in extensions and partial prefixes and check for a
+     * directory default. If no file can be found, it returns `null`.
+     */
+    public static function resolveImportPath(string $path): ?string
+    {
+        $extension = Path::extension($path);
+
+        if ($extension === '.sass' || $extension === '.scss' || $extension === '.css') {
+            return self::ifInImport(fn () => self::exactlyOne(self::tryPath(Path::withoutExtension($path) . '.import' . $extension)))
+                ?? self::exactlyOne(self::tryPath($path));
+        }
+
+        return self::ifInImport(fn () => self::exactlyOne(self::tryPathWithExtensions($path . '.import')))
+            ?? self::exactlyOne(self::tryPathWithExtensions($path))
+            ?? self::tryPathAsDirectory($path);
+    }
+
+    /**
+     * Like {@see tryPath}, but checks `.sass`, `.scss`, and `.css` extensions.
+     *
+     * @return list<string>
+     */
+    private static function tryPathWithExtensions(string $path): array
+    {
+        $result = array_merge(
+            self::tryPath($path . '.sass'),
+            self::tryPath($path . '.scss'),
+        );
+
+        if ($result !== []) {
+            return $result;
+        }
+
+        return self::tryPath($path . '.css');
+    }
+
+    /**
+     * Returns the $path and/or the partial with the same name, if either or both
+     * exists.
+     *
+     * If neither exists, returns an empty list.
+     *
+     * @return list<string>
+     */
+    private static function tryPath(string $path): array
+    {
+        $partial = Path::join(dirname($path), '_' . basename($path));
+        $candidates = [];
+
+        if (is_file($partial)) {
+            $candidates[] = $partial;
+        }
+
+        if (is_file($path)) {
+            $candidates[] = $path;
+        }
+
+        return $candidates;
+    }
+
+    /**
+     * Returns the resolved index file for $path if $path is a directory and the
+     * index file exists.
+     *
+     * Otherwise, returns `null`.
+     */
+    private static function tryPathAsDirectory(String $path): ?string
+    {
+        if (!is_dir($path)) {
+            return null;
+        }
+
+        return self::ifInImport(fn () => self::exactlyOne(self::tryPathWithExtensions(Path::join($path, 'index.import'))))
+            ?? self::exactlyOne(self::tryPathWithExtensions(Path::join($path, 'index')));
+    }
+
+    /**
+     * @param list<string> $paths
+     */
+    private static function exactlyOne(array $paths): ?string
+    {
+        if (\count($paths) === 0) {
+            return null;
+        }
+
+        if (\count($paths) === 1) {
+            return $paths[0];
+        }
+
+        $formattedPrettyPaths = [];
+
+        foreach ($paths as $path) {
+            $formattedPrettyPaths[] = '  ' . Path::prettyUri($path);
+        }
+
+        throw new \Exception("It's not clear which file to import. Found:\n" . implode("\n", $formattedPrettyPaths));
+    }
+
+    /**
+     * If {@see ImportContext::isFromImport} is `true`, invokes callback and returns the result.
+     *
+     * Otherwise, returns `null`.
+     *
+     * @template T
+     *
+     * @param callable(): T $callback
+     * @return T|null
+     */
+    private static function ifInImport(callable $callback)
+    {
+        if (ImportContext::isFromImport()) {
+            return $callback();
+        }
+
+        return null;
+    }
+}

--- a/src/Importer/Importer.php
+++ b/src/Importer/Importer.php
@@ -1,0 +1,170 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Importer;
+
+use League\Uri\Contracts\UriInterface;
+
+/**
+ * A base class for importers that resolves URLs in `@import`s to the contents
+ * of Sass files.
+ *
+ * Importers should implement {@see __toString} to provide a human-readable description
+ * of the importer. For example, the default filesystem importer returns its
+ * load path.
+ */
+abstract class Importer implements \Stringable
+{
+    /**
+     * If $url is recognized by this importer, returns its canonical format.
+     *
+     * Note that canonical URLs *must* be absolute, including a scheme. Returning
+     * `file:` URLs is encouraged if the imported stylesheet comes from a file on
+     * disk.
+     *
+     * If Sass has already loaded a stylesheet with the returned canonical URL,
+     * it re-uses the existing parse tree. This means that importers **must
+     * ensure** that the same canonical URL always refers to the same stylesheet,
+     * *even across different importers*.
+     *
+     * This may return `null` if $url isn't recognized by this importer.
+     *
+     * If this importer's URL format supports file extensions, it should
+     * canonicalize them the same way as the default filesystem importer:
+     *
+     * * The importer should look for stylesheets by adding the prefix `_` to the
+     *   URL's basename, and by adding the extensions `.sass` and `.scss` if the
+     *   URL doesn't already have one of those extensions. For example, if the
+     *   URL was `foo/bar/baz`, the importer would look for:
+     *   * `foo/bar/baz.sass`
+     *   * `foo/bar/baz.scss`
+     *   * `foo/bar/_baz.sass`
+     *   * `foo/bar/_baz.scss`
+     *
+     *   If the URL was `foo/bar/baz.scss`, the importer would just look for:
+     *   * `foo/bar/baz.scss`
+     *   * `foo/bar/_baz.scss`
+     *
+     *   If the importer finds a stylesheet at more than one of these URLs, it
+     *   should throw an exception indicating that the import is ambiguous. Note
+     *   that if the extension is explicitly specified, a stylesheet with the
+     *   opposite extension may exist.
+     *
+     * * If none of the possible paths is valid, the importer should perform the
+     *   same resolution on the URL followed by `/index`. In the example above,
+     *   it would look for:
+     *   * `foo/bar/baz/_index.sass`
+     *   * `foo/bar/baz/index.sass`
+     *   * `foo/bar/baz/_index.scss`
+     *   * `foo/bar/baz/index.scss`
+     *
+     *   As above, if the importer finds a stylesheet at more than one of these
+     *   URLs, it should throw an exception indicating that the import is
+     *   ambiguous.
+     *
+     * If no stylesheets are found, the importer should return `null`.
+     *
+     * Calling {@see canonicalize} multiple times with the same URL must return the
+     * same result. Calling {@see canonicalize} with a URL returned by {@see canonicalize}
+     * must return that URL. Calling {@see canonicalize} with a URL relative to one
+     * returned by {@see canonicalize} must return a meaningful result.
+     */
+    abstract public function canonicalize(UriInterface $url): ?UriInterface;
+
+    /**
+     * Loads the Sass text for the given $url, or returns `null` if
+     * this importer can't find the stylesheet it refers to.
+     *
+     * The $url comes from a call to {@see canonicalize} for this importer.
+     *
+     * When Sass encounters an `@import` rule in a stylesheet, it first calls
+     * {@see canonicalize} and {@see load} on the importer that first loaded that
+     * stylesheet with the imported URL resolved relative to the stylesheet's
+     * original URL. If either of those returns `null`, it then calls
+     * {@see canonicalize} and {@see load} on each importer in order with the URL as it
+     * appears in the `@import` rule.
+     *
+     * If the importer finds a stylesheet at $url but it fails to load for some
+     * reason, or if $url is uniquely associated with this importer but doesn't
+     * refer to a real stylesheet, the importer may throw an exception that will
+     * be wrapped by Sass.
+     */
+    abstract public function load(UriInterface $url): ?ImporterResult;
+
+    /**
+     * Without accessing the filesystem, returns whether passing $url to
+     * {@see canonicalize} could possibly return $canonicalUrl.
+     *
+     * This is expected to be very efficient, and subclasses are allowed to
+     * return false positives if it would be inefficient to determine whether
+     * $url would actually resolve to $canonicalUrl. Subclasses are not allowed
+     * to return false negatives.
+     */
+    public function couldCanonicalize(UriInterface $url, UriInterface $canonicalUrl): bool
+    {
+        return true;
+    }
+
+    /**
+     * Returns whether the given URL scheme (without `:`) should be considered
+     * "non-canonical" for this importer.
+     *
+     * An importer may not return a URL with a non-canonical scheme from
+     * {@see canonicalize}. In exchange, {@see getContainingUrl} is available within
+     * {@see canonicalize} for absolute URLs with non-canonical schemes so that the
+     * importer can resolve those URLs differently based on where they're loaded.
+     *
+     * This must always return the same value for the same $scheme. It is
+     * expected to be very efficient.
+     */
+    public function isNonCanonicalScheme(string $scheme): bool
+    {
+        return false;
+    }
+
+    /**
+     * Whether the current {@see canonicalize} invocation comes from an `@import`
+     * rule.
+     *
+     * When evaluating `@import` rules, URLs should canonicalize to an
+     * [import-only file] if one exists for the URL being canonicalized.
+     * Otherwise, canonicalization should be identical for `@import` and `@use`
+     * rules.
+     *
+     * [import-only file]: https://sass-lang.com/documentation/at-rules/import#import-only-files
+     *
+     * Subclasses should only access this from within calls to {@see canonicalize}.
+     * Outside of that context, its value is undefined and subject to change.
+     */
+    final protected function isFromImport(): bool
+    {
+        return ImportContext::isFromImport();
+    }
+
+    /**
+     * The canonical URL of the stylesheet that caused the current {@see canonicalize}
+     * invocation.
+     *
+     * This is only set when the containing stylesheet has a canonical URL, and
+     * when the URL being canonicalized is either relative or has a scheme for
+     * which {@see isNonCanonicalScheme} returns `true`. This restriction ensures that
+     * canonical URLs are always interpreted the same way regardless of their
+     * context.
+     *
+     * Subclasses should only access this from within calls to {@see canonicalize}.
+     * Outside of that context, its value is undefined and subject to change.
+     */
+    final protected function getContainingUrl(): ?UriInterface
+    {
+        return ImportContext::getContainingUrl();
+    }
+}

--- a/src/Importer/ImporterResult.php
+++ b/src/Importer/ImporterResult.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Importer;
+
+use League\Uri\Contracts\UriInterface;
+use League\Uri\Uri;
+use ScssPhp\ScssPhp\Syntax;
+
+final class ImporterResult
+{
+    private readonly string $contents;
+
+    private readonly ?UriInterface $sourceMapUrl;
+
+    private readonly Syntax $syntax;
+
+    public function __construct(string $contents, Syntax $syntax, ?UriInterface $sourceMapUrl = null)
+    {
+        $this->contents = $contents;
+        $this->syntax = $syntax;
+        $this->sourceMapUrl = $sourceMapUrl;
+    }
+
+    public function getContents(): string
+    {
+        return $this->contents;
+    }
+
+    /**
+     * An absolute, browser-accessible URL indicating the resolved location of
+     * the imported stylesheet.
+     *
+     * This should be a `file:` URL if one is available, but an `http:` URL is
+     * acceptable as well. If no URL is supplied, a `data:` URL is generated
+     * automatically from {@see contents}.
+     */
+    public function getSourceMapUrl(): UriInterface
+    {
+        return $this->sourceMapUrl ?? Uri::fromData($this->contents, '', 'charset=utf-8');
+    }
+
+    /**
+     * The syntax to use to parse the stylesheet.
+     */
+    public function getSyntax(): Syntax
+    {
+        return $this->syntax;
+    }
+}

--- a/src/Importer/NoOpImporter.php
+++ b/src/Importer/NoOpImporter.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Importer;
+
+use League\Uri\Contracts\UriInterface;
+
+/**
+ * An importer that never imports any stylesheets.
+ *
+ * This is used for stylesheets which don't support relative imports, such as
+ * those created from PHP code with plain strings.
+ */
+final class NoOpImporter extends Importer
+{
+    public function canonicalize(UriInterface $url): ?UriInterface
+    {
+        return null;
+    }
+
+    public function load(UriInterface $url): ?ImporterResult
+    {
+        return null;
+    }
+
+    public function couldCanonicalize(UriInterface $url, UriInterface $canonicalUrl): bool
+    {
+        return false;
+    }
+
+    public function __toString(): string
+    {
+        return '(unknown)';
+    }
+}

--- a/src/Importer/SpecialCacheValue.php
+++ b/src/Importer/SpecialCacheValue.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Importer;
+
+/**
+ * @internal
+ */
+enum SpecialCacheValue
+{
+    case null;
+}

--- a/src/Util/UriUtil.php
+++ b/src/Util/UriUtil.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Util;
+
+use League\Uri\BaseUri;
+use League\Uri\Contracts\UriInterface;
+
+/**
+ * @internal
+ */
+final class UriUtil
+{
+    public static function resolve(UriInterface $baseUrl, string $reference): UriInterface
+    {
+        $resolvedUri = BaseUri::from($baseUrl)->resolve($reference)->getUri();
+
+        \assert($resolvedUri instanceof UriInterface);
+
+        return $resolvedUri;
+    }
+
+    public static function resolveUri(UriInterface $baseUrl, UriInterface $url): UriInterface
+    {
+        $resolvedUri = BaseUri::from($baseUrl)->resolve($url)->getUri();
+
+        \assert($resolvedUri instanceof UriInterface);
+
+        return $resolvedUri;
+    }
+}

--- a/tests/Util/PathTest.php
+++ b/tests/Util/PathTest.php
@@ -2,6 +2,7 @@
 
 namespace ScssPhp\ScssPhp\Tests\Util;
 
+use League\Uri\Uri;
 use ScssPhp\ScssPhp\Util\Path;
 use PHPUnit\Framework\TestCase;
 
@@ -22,6 +23,7 @@ class PathTest extends TestCase
     {
         $this->assertFalse(Path::isAbsolute($path));
     }
+
     /**
      * @dataProvider provideWindowsOnlyAbsolutePath
      */
@@ -100,5 +102,41 @@ class PathTest extends TestCase
         yield ['/foo/', 'bar', '/foo/bar'];
         yield ['/foo/', '/bar', '/bar'];
         yield ['foo', '/bar', '/bar'];
+    }
+
+    /**
+     * @dataProvider provideExtensionCases
+     */
+    public function testExtension(string $path, string $expected): void
+    {
+        self::assertEquals($expected, Path::extension($path));
+    }
+
+    public static function provideExtensionCases(): iterable
+    {
+        yield ['path/to/foo.dart', '.dart'];
+        yield ['path/to/foo', ''];
+        yield ['path.to/foo', ''];
+        yield ['path/to/foo.dart.js', '.js'];
+        yield ['~/.bashrc', ''];
+        yield ['~/.notes.txt', '.txt'];
+    }
+
+    /**
+     * @dataProvider provideWithoutExtensionCases
+     */
+    public function testWithoutExtension(string $path, string $expected): void
+    {
+        self::assertEquals($expected, Path::withoutExtension($path));
+    }
+
+    public static function provideWithoutExtensionCases(): iterable
+    {
+        yield ['path/to/foo.dart', 'path/to/foo'];
+        yield ['path/to/foo', 'path/to/foo'];
+        yield ['path.to/foo', 'path.to/foo'];
+        yield ['path/to/foo.dart.js', 'path/to/foo.dart'];
+        yield ['~/.bashrc', '~/.bashrc'];
+        yield ['~/.notes.txt', '~/.notes'];
     }
 }


### PR DESCRIPTION
This implements the importer system ported from dart-sass.

`ImportCache` is the main (internal) entrypoint of that system, turning a requested `UriInterface` into its canonical URL (which identifies uniquely what needs to be loaded) and importing a canonical url as a parsed `Stylesheet` object.
The `Importer` abstract class is the public extension point of that system, allowing to customize the loading of files. The FilesystemImporter is the core implementation that implements the official behavior for filesystem imports.


The FilesystemImporter is intentionally limited to `file:` URLs to match the behavior of dart-sass and keep the same optimizations than dart-sass for `couldCanonicalize`. Support for stream wrappers as discussed in https://github.com/scssphp/scssphp/issues/256 will have to be implemented with a separate importer. We don't want to make the FilesysteImporter slower for people _not_ using stream wrapper (which will be the common case). For now, the path-based `ImportUtil` and the `Path` utility class (which ports some APIs of `dart:path`) are also incompatible with stream wrappers (as those actually rely on URIs rather than OS paths, which don't have the same format).
I haven't yet decided what the best way would be to integrate with stream wrappers yet (one option is to _not_ directly use stream wrappers but to have an importer supporting the custom scheme, which would be more consistent with the behavior of dart-sass and is already possible with the current state of the API). This was not the goal of this PR.