### PR TITLE
Implement the deprecation handling logic

### DIFF
--- a/src/Ast/Selector/Selector.php
+++ b/src/Ast/Selector/Selector.php
@@ -13,6 +13,7 @@
 namespace ScssPhp\ScssPhp\Ast\Selector;
 
 use ScssPhp\ScssPhp\Ast\AstNode;
+use ScssPhp\ScssPhp\Deprecation;
 use ScssPhp\ScssPhp\Exception\SassException;
 use ScssPhp\ScssPhp\Serializer\Serializer;
 use ScssPhp\ScssPhp\SourceSpan\FileSpan;
@@ -103,7 +104,7 @@ abstract class Selector implements AstNode, Equatable
             return;
         }
 
-        Warn::deprecation(($name === null ? '' : "\$$name: ") . "$this is not valid CSS.\nThis will be an error in Dart Sass 2.0.0.\n\nMore info: https://sass-lang.com/d/bogus-combinators");
+        Warn::forDeprecation(($name === null ? '' : "\$$name: ") . "$this is not valid CSS.\nThis will be an error in Dart Sass 2.0.0.\n\nMore info: https://sass-lang.com/d/bogus-combinators", Deprecation::bogusCombinators);
     }
 
     /**

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -386,7 +386,7 @@ final class Compiler
             $this->rootEnv   = $this->pushEnv($tree);
 
             $warnCallback = function ($message, $deprecation) {
-                $this->logger->warn($message, $deprecation);
+                $this->logger->warn($message, $deprecation !== null);
             };
             $previousWarnCallback = Warn::setCallback($warnCallback);
 

--- a/src/Deprecation.php
+++ b/src/Deprecation.php
@@ -1,0 +1,133 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp;
+
+/**
+ * A deprecated feature in the language.
+ *
+ * Code consuming this enum outside Scssphp must not rely on exhaustiveness checks. New values will be added
+ * in this enum in minor versions of the package without considering that as a BC break.
+ */
+enum Deprecation: string
+{
+    /**
+     * Deprecation for passing a string to `call` instead of `get-function`.
+     */
+    case callString = 'call-string';
+
+    /**
+     * Deprecation for `@elseif`.
+     */
+    case elseif = 'elseif';
+
+    /**
+     * Deprecation for parsing `@-moz-document`.
+     */
+    case mozDocument = 'moz-document';
+
+    /**
+     * Deprecation for declaring new variables with `!global`.
+     */
+    case newGlobal = 'new-global';
+
+    /**
+     * Deprecation for treating `/` as division.
+     */
+    case slashDiv = 'slash-div';
+
+    /**
+     * Deprecation for leading, trailing, and repeated combinators.
+     */
+    case bogusCombinators = 'bogus-combinators';
+
+    /**
+     * Deprecation for ambiguous `+` and `-` operators.
+     */
+    case strictUnary = 'strict-unary';
+
+    /**
+     * Deprecation for passing invalid units to certain built-in functions.
+     */
+    case functionUnits = 'function-units';
+
+    /**
+     * Deprecation for passing percentages to the Sass abs() function.
+     */
+    case absPercent = 'abs-percent';
+
+    case duplicateVariableFlags = 'duplicate-var-flags';
+
+    /**
+     * Used for deprecations coming from user-authored code.
+     */
+    case userAuthored = 'user-authored';
+
+    public function getDescription(): ?string
+    {
+        return match ($this) {
+            self::callString => 'Passing a string directly to meta.call().',
+            self::elseif => '@elseif.',
+            self::mozDocument => '@-moz-document.',
+            self::newGlobal => 'Declaring new variables with !global.',
+            self::slashDiv => '/ operator for division.',
+            self::bogusCombinators => 'Leading, trailing, and repeated combinators.',
+            self::strictUnary => 'Ambiguous + and - operators.',
+            self::functionUnits => 'Passing invalid units to built-in functions.',
+            self::absPercent => 'Passing percentages to the Sass abs() function.',
+            self::duplicateVariableFlags => 'Using !default or !global multiple times for one variable.',
+            self::userAuthored => null,
+        };
+    }
+
+    /**
+     * The version in which this feature was first deprecated.
+     */
+    public function getDeprecatedIn(): ?string
+    {
+        return match ($this) {
+            self::callString => '1.2.0',
+            self::elseif => '2.0.0',
+            self::mozDocument => '2.0.0',
+            self::newGlobal => '2.0.0',
+            self::slashDiv => null,
+            self::bogusCombinators => '2.0.0',
+            self::strictUnary => '2.0.0',
+            self::functionUnits => '2.0.0',
+            self::absPercent => '2.0.0',
+            self::duplicateVariableFlags => '2.0.0',
+            self::userAuthored => null,
+        };
+    }
+
+    public function isFuture(): bool
+    {
+        if ($this === self::userAuthored) {
+            return false;
+        }
+
+        return $this->getDeprecatedIn() === null;
+    }
+
+    public function getStatus(): DeprecationStatus
+    {
+        if ($this === self::userAuthored) {
+            return DeprecationStatus::user;
+        }
+
+        if ($this->isFuture()) {
+            return DeprecationStatus::future;
+        }
+
+        return DeprecationStatus::active;
+    }
+}

--- a/src/DeprecationStatus.php
+++ b/src/DeprecationStatus.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace ScssPhp\ScssPhp;
+
+enum DeprecationStatus
+{
+    case active;
+    case user;
+    case future;
+    case obsolete;
+}

--- a/src/Importer/ImportCache.php
+++ b/src/Importer/ImportCache.php
@@ -12,10 +12,9 @@
 
 namespace ScssPhp\ScssPhp\Importer;
 
-use League\Uri\BaseUri;
 use League\Uri\Contracts\UriInterface;
 use ScssPhp\ScssPhp\Ast\Sass\Statement\Stylesheet;
-use ScssPhp\ScssPhp\Logger\LocationAwareLoggerInterface;
+use ScssPhp\ScssPhp\Logger\DeprecationAwareLoggerInterface;
 use ScssPhp\ScssPhp\Logger\QuietLogger;
 use ScssPhp\ScssPhp\Util\UriUtil;
 
@@ -31,7 +30,7 @@ final class ImportCache
      */
     private readonly array $importers;
 
-    private readonly LocationAwareLoggerInterface $logger;
+    private readonly DeprecationAwareLoggerInterface $logger;
 
     /**
      * The canonicalized URLs for each non-canonical URL.
@@ -69,7 +68,7 @@ final class ImportCache
     /**
      * @param list<Importer> $importers
      */
-    public function __construct(array $importers, LocationAwareLoggerInterface $logger)
+    public function __construct(array $importers, DeprecationAwareLoggerInterface $logger)
     {
         $this->importers = $importers;
         $this->logger = $logger;

--- a/src/Logger/AdaptingDeprecationAwareLogger.php
+++ b/src/Logger/AdaptingDeprecationAwareLogger.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Logger;
+
+use ScssPhp\ScssPhp\Deprecation;
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+use ScssPhp\ScssPhp\StackTrace\Trace;
+
+/**
+ * @internal
+ */
+final class AdaptingDeprecationAwareLogger implements DeprecationAwareLoggerInterface
+{
+    private function __construct(private readonly LocationAwareLoggerInterface $logger)
+    {
+    }
+
+    public static function adaptLogger(LoggerInterface $logger): DeprecationAwareLoggerInterface
+    {
+        if ($logger instanceof DeprecationAwareLoggerInterface) {
+            return $logger;
+        }
+
+        return new self(AdaptingLogger::adaptLogger($logger));
+    }
+
+    public function warnForDeprecation(Deprecation $deprecation, string $message, ?FileSpan $span = null, ?Trace $trace = null): void
+    {
+        if ($deprecation->isFuture()) {
+            return;
+        }
+
+        $this->logger->warn($message, true, $span, $trace);
+    }
+
+    public function warn(string $message, bool $deprecation = false, ?FileSpan $span = null, ?Trace $trace = null): void
+    {
+        $this->logger->warn($message, $deprecation, $span, $trace);
+    }
+
+    public function debug(string $message, FileSpan $span = null): void
+    {
+        $this->logger->debug($message, $span);
+    }
+}

--- a/src/Logger/DeprecationAwareLoggerInterface.php
+++ b/src/Logger/DeprecationAwareLoggerInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Logger;
+
+use ScssPhp\ScssPhp\Deprecation;
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+use ScssPhp\ScssPhp\StackTrace\Trace;
+
+/**
+ * @internal
+ */
+interface DeprecationAwareLoggerInterface extends LocationAwareLoggerInterface
+{
+    public function warnForDeprecation(Deprecation $deprecation, string $message, ?FileSpan $span = null, ?Trace $trace = null): void;
+}

--- a/src/Logger/DeprecationHandlingLogger.php
+++ b/src/Logger/DeprecationHandlingLogger.php
@@ -1,0 +1,118 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Logger;
+
+use ScssPhp\ScssPhp\Deprecation;
+use ScssPhp\ScssPhp\Exception\SassRuntimeException;
+use ScssPhp\ScssPhp\Exception\SassScriptException;
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+use ScssPhp\ScssPhp\StackTrace\Trace;
+
+/**
+ * A logger that wraps an inner logger to have special handling for
+ * deprecation warnings.
+ *
+ * @internal
+ */
+final class DeprecationHandlingLogger implements DeprecationAwareLoggerInterface
+{
+    private const MAX_REPETITIONS = 5;
+
+    /**
+     * @var array<value-of<Deprecation>, int>
+     */
+    private array $warningCounts = [];
+
+    /**
+     * @param Deprecation[] $fatalDeprecations
+     * @param Deprecation[] $futureDeprecations
+     */
+    public function __construct(
+        private readonly LocationAwareLoggerInterface $inner,
+        private readonly array $fatalDeprecations,
+        private readonly array $futureDeprecations,
+        private readonly bool $limitRepetition = true
+    ) {
+    }
+
+    public function warn(string $message, bool $deprecation = false, ?FileSpan $span = null, ?Trace $trace = null): void
+    {
+        $this->inner->warn($message, $deprecation, $span, $trace);
+    }
+
+    /**
+     * Processes a deprecation warning.
+     *
+     * If $deprecation is in {@see $fatalDeprecations}, this shows an error.
+     *
+     * If it's a future deprecation that hasn't been opted into or it's a
+     * deprecation that's already been warned for {@see self::MAX_REPETITIONS} times and
+     * {@see limitRepetitions} is true, the warning is dropped.
+     *
+     * Otherwise, this is passed on to {@see warn}.
+     */
+    public function warnForDeprecation(Deprecation $deprecation, string $message, ?FileSpan $span = null, ?Trace $trace = null): void
+    {
+        if (\in_array($deprecation, $this->fatalDeprecations, true)) {
+            $message .= "\n\nThis is only an error because you've set the {$deprecation->value} deprecation to be fatal.\nRemove this setting if you need to keep using this feature.";
+
+            if ($span !== null && $trace !== null) {
+                throw new SassRuntimeException($message, $span); // TODO add trace
+            }
+
+            if ($span !== null) {
+                throw new SassRuntimeException($message, $span); // TODO use the right exception type
+            }
+
+            throw new SassScriptException($message);
+        }
+
+        if ($deprecation->isFuture() && !\in_array($deprecation, $this->futureDeprecations, true)) {
+            return;
+        }
+
+        if ($this->limitRepetition) {
+            $count = $this->warningCounts[$deprecation->value] = ($this->warningCounts[$deprecation->value] ?? 0) + 1;
+
+            if ($count > self::MAX_REPETITIONS) {
+                return;
+            }
+        }
+
+        $this->warn($message, true, $span, $trace);
+    }
+
+    public function debug(string $message, ?FileSpan $span = null): void
+    {
+        $this->inner->debug($message, $span);
+    }
+
+    /**
+     * Prints a warning indicating the number of deprecation warnings that were
+     * omitted due to repetition.
+     */
+    public function summarize(): void
+    {
+        $total = 0;
+
+        foreach ($this->warningCounts as $count) {
+            if ($count > self::MAX_REPETITIONS) {
+                $total += $count - self::MAX_REPETITIONS;
+            }
+        }
+
+        if ($total > 0) {
+            $this->inner->warn("$total repetitive deprecation warnings omitted.\nRun in verbose mode to see all warnings.");
+        }
+    }
+}

--- a/src/Logger/LocationAwareLoggerInterface.php
+++ b/src/Logger/LocationAwareLoggerInterface.php
@@ -45,5 +45,5 @@ interface LocationAwareLoggerInterface extends LoggerInterface
      *
      * @return void
      */
-    public function debug(string $message, FileSpan $span = null);
+    public function debug(string $message, ?FileSpan $span = null);
 }

--- a/src/Logger/QuietLogger.php
+++ b/src/Logger/QuietLogger.php
@@ -12,15 +12,23 @@
 
 namespace ScssPhp\ScssPhp\Logger;
 
+use ScssPhp\ScssPhp\Deprecation;
 use ScssPhp\ScssPhp\SourceSpan\FileSpan;
 use ScssPhp\ScssPhp\StackTrace\Trace;
 
 /**
  * A logger that silently ignores all messages.
  */
-final class QuietLogger implements LocationAwareLoggerInterface
+final class QuietLogger implements LocationAwareLoggerInterface, DeprecationAwareLoggerInterface
 {
     public function warn(string $message, bool $deprecation = false, ?FileSpan $span = null, ?Trace $trace = null): void
+    {
+    }
+
+    /**
+     * @internal
+     */
+    public function warnForDeprecation(Deprecation $deprecation, string $message, ?FileSpan $span = null, ?Trace $trace = null): void
     {
     }
 

--- a/src/Parser/Parser.php
+++ b/src/Parser/Parser.php
@@ -13,8 +13,8 @@
 namespace ScssPhp\ScssPhp\Parser;
 
 use ScssPhp\ScssPhp\Exception\SassFormatException;
-use ScssPhp\ScssPhp\Logger\AdaptingLogger;
-use ScssPhp\ScssPhp\Logger\LocationAwareLoggerInterface;
+use ScssPhp\ScssPhp\Logger\AdaptingDeprecationAwareLogger;
+use ScssPhp\ScssPhp\Logger\DeprecationAwareLoggerInterface;
 use ScssPhp\ScssPhp\Logger\LoggerInterface;
 use ScssPhp\ScssPhp\Logger\QuietLogger;
 use ScssPhp\ScssPhp\SourceSpan\FileSpan;
@@ -31,7 +31,7 @@ class Parser
 {
     protected readonly StringScanner $scanner;
 
-    protected readonly LocationAwareLoggerInterface $logger;
+    protected readonly DeprecationAwareLoggerInterface $logger;
 
     /**
      * A map used to map source spans in the text being parsed back to their
@@ -69,7 +69,7 @@ class Parser
     public function __construct(string $contents, ?LoggerInterface $logger = null, ?string $sourceUrl = null, ?InterpolationMap $interpolationMap = null)
     {
         $this->scanner = new StringScanner($contents);
-        $this->logger = AdaptingLogger::adaptLogger($logger ?? new QuietLogger());
+        $this->logger = AdaptingDeprecationAwareLogger::adaptLogger($logger ?? new QuietLogger());
         $this->sourceUrl = $sourceUrl;
         $this->interpolationMap = $interpolationMap;
     }

--- a/src/Parser/ScssParser.php
+++ b/src/Parser/ScssParser.php
@@ -15,6 +15,7 @@ namespace ScssPhp\ScssPhp\Parser;
 use ScssPhp\ScssPhp\Ast\Sass\Interpolation;
 use ScssPhp\ScssPhp\Ast\Sass\Statement\LoudComment;
 use ScssPhp\ScssPhp\Ast\Sass\Statement\SilentComment;
+use ScssPhp\ScssPhp\Deprecation;
 use ScssPhp\ScssPhp\Util\Character;
 
 /**
@@ -80,7 +81,7 @@ class ScssParser extends StylesheetParser
             }
 
             if ($this->scanIdentifier('elseif', true)) {
-                $this->logger->warn("@elseif is deprecated and will not be supported in future Sass versions.\n\nRecommendation: @else if", true, $this->scanner->spanFrom($beforeAt));
+                $this->logger->warnForDeprecation(Deprecation::elseif, "@elseif is deprecated and will not be supported in future Sass versions.\n\nRecommendation: @else if", $this->scanner->spanFrom($beforeAt));
 
                 $this->scanner->setPosition($this->scanner->getPosition() - 2);
 

--- a/src/Parser/StylesheetParser.php
+++ b/src/Parser/StylesheetParser.php
@@ -75,6 +75,7 @@ use ScssPhp\ScssPhp\Ast\Sass\SupportsCondition\SupportsInterpolation;
 use ScssPhp\ScssPhp\Ast\Sass\SupportsCondition\SupportsNegation;
 use ScssPhp\ScssPhp\Ast\Sass\SupportsCondition\SupportsOperation;
 use ScssPhp\ScssPhp\Colors;
+use ScssPhp\ScssPhp\Deprecation;
 use ScssPhp\ScssPhp\Exception\SassFormatException;
 use ScssPhp\ScssPhp\Logger\LoggerInterface;
 use ScssPhp\ScssPhp\SourceSpan\FileSpan;
@@ -1530,7 +1531,7 @@ abstract class StylesheetParser extends Parser
 
         return $this->withChildren($this->statement(...), $start, function (array $children, FileSpan $span) use ($name, $value, $needsDeprecationWarning) {
             if ($needsDeprecationWarning) {
-                $this->logger->warn("@-moz-document is deprecated and support will be removed in Dart Sass 2.0.0.\n\nFor details, see https://sass-lang.com/d/moz-document.", true, $span);
+                $this->logger->warnForDeprecation(Deprecation::mozDocument, "@-moz-document is deprecated and support will be removed in Dart Sass 2.0.0.\n\nFor details, see https://sass-lang.com/d/moz-document.", $span);
             }
 
             return new AtRule($name, $span, $value, $children);
@@ -1884,7 +1885,7 @@ versions of Sass.
 More info and automated migrator: https://sass-lang.com/d/strict-unary
 WARNING;
 
-                        $this->logger->warn($message, true, $singleExpression->getSpan());
+                        $this->logger->warnForDeprecation(Deprecation::strictUnary, $message, $singleExpression->getSpan());
                     }
                 }
             }

--- a/src/Value/SassCalculation.php
+++ b/src/Value/SassCalculation.php
@@ -12,6 +12,7 @@
 
 namespace ScssPhp\ScssPhp\Value;
 
+use ScssPhp\ScssPhp\Deprecation;
 use ScssPhp\ScssPhp\Exception\SassScriptException;
 use ScssPhp\ScssPhp\Util\Character;
 use ScssPhp\ScssPhp\Util\Equatable;
@@ -343,16 +344,16 @@ final class SassCalculation extends Value
         }
 
         if ($argument->hasUnit('%')) {
-            Warn::deprecation(
-                <<<WARNING
+            $message = <<<WARNING
 Passing percentage units to the global abs() function is deprecated.
 In the future, this will emit a CSS abs() function to be resolved by the browser.
 To preserve current behavior: math.abs($argument)
 
 To emit a CSS abs() now: abs(#\{$argument})
 More info: https://sass-lang.com/d/abs-percent
-WARNING
-            );
+WARNING;
+
+            Warn::forDeprecation($message, Deprecation::absPercent);
         }
 
         return NumberUtil::abs($argument);

--- a/src/Value/Value.php
+++ b/src/Value/Value.php
@@ -17,6 +17,7 @@ use ScssPhp\ScssPhp\Ast\Selector\ComplexSelector;
 use ScssPhp\ScssPhp\Ast\Selector\CompoundSelector;
 use ScssPhp\ScssPhp\Ast\Selector\SelectorList;
 use ScssPhp\ScssPhp\Ast\Selector\SimpleSelector;
+use ScssPhp\ScssPhp\Deprecation;
 use ScssPhp\ScssPhp\Exception\SassFormatException;
 use ScssPhp\ScssPhp\Exception\SassScriptException;
 use ScssPhp\ScssPhp\Serializer\Serializer;
@@ -119,15 +120,15 @@ abstract class Value implements Equatable, \Stringable
         $indexValue = $sassIndex->assertNumber($name);
 
         if ($indexValue->hasUnits()) {
-            Warn::deprecation(
-                <<<WARNING
+            $message = <<<WARNING
 \$$name: Passing a number with unit {$indexValue->getUnitString()} is deprecated.
 
 To preserve current behavior: {$indexValue->unitSuggestion($name ?? 'index')}
 
 More info: https://sass-lang.com/d/function-units
-WARNING
-            );
+WARNING;
+
+            Warn::forDeprecation($message, Deprecation::functionUnits);
         }
 
         $index = $indexValue->assertInt($name);

--- a/src/Warn.php
+++ b/src/Warn.php
@@ -16,7 +16,7 @@ final class Warn
 {
     /**
      * @var callable|null
-     * @phpstan-var (callable(string, bool): void)|null
+     * @phpstan-var (callable(string, ?Deprecation): void)|null
      */
     private static $callback;
 
@@ -31,7 +31,7 @@ final class Warn
      */
     public static function warning(string $message): void
     {
-        self::reportWarning($message, false);
+        self::reportWarning($message, null);
     }
 
     /**
@@ -45,7 +45,12 @@ final class Warn
      */
     public static function deprecation(string $message): void
     {
-        self::reportWarning($message, true);
+        self::reportWarning($message, Deprecation::userAuthored);
+    }
+
+    public static function forDeprecation(string $message, Deprecation $deprecation): void
+    {
+        self::reportWarning($message, $deprecation);
     }
 
     /**
@@ -53,9 +58,9 @@ final class Warn
      *
      * @return callable|null The previous warn callback
      *
-     * @phpstan-param (callable(string, bool): void)|null $callback
+     * @phpstan-param (callable(string, ?Deprecation): void)|null $callback
      *
-     * @phpstan-return (callable(string, bool): void)|null
+     * @phpstan-return (callable(string, ?Deprecation): void)|null
      *
      * @internal
      */
@@ -67,13 +72,7 @@ final class Warn
         return $previousCallback;
     }
 
-    /**
-     * @param string $message
-     * @param bool   $deprecation
-     *
-     * @return void
-     */
-    private static function reportWarning(string $message, bool $deprecation): void
+    private static function reportWarning(string $message, ?Deprecation $deprecation): void
     {
         if (self::$callback === null) {
             throw new \BadMethodCallException('The warning Reporter may only be called within a custom function or importer callback.');


### PR DESCRIPTION
This implements the deprecation handling logic of dart-sass.

The various configuration settings supported by the DeprecationHandlingLogger will be configured in the Compiler class once it is rewritten, exposing new configuration settings.
Note all values of the Deprecation enum have been ported yet. Deprecations that only make sense for an implementation supporting modules are not there yet. However, I added the deprecations that are expected to be implemented in our 2.0 release even though they are not all implemented yet (because they are triggered in code that is not ported yet).
Values that are specific to dart-sass and won't ever be implemented are not ported either:
- `nullAlpha` because our SassColor API already forbids passing `null` entirely as it is new and so we don't have any BC reasons to allow passing `null`
- `calcInterp` because it was added in dart-sass by mistake (forgetting to revert that change when changing the proposal to not deprecate this thing)
- `relativeCanonical` because our new Importer API forbids returning relative canonical URLs entirely from the start