### PR TITLE
Separate list utilities from iterable utilities

### DIFF
--- a/src/Ast/Sass/Expression/IsCalculationSafeVisitor.php
+++ b/src/Ast/Sass/Expression/IsCalculationSafeVisitor.php
@@ -13,7 +13,7 @@
 namespace ScssPhp\ScssPhp\Ast\Sass\Expression;
 
 use ScssPhp\ScssPhp\Ast\Sass\Expression;
-use ScssPhp\ScssPhp\Util\ListUtil;
+use ScssPhp\ScssPhp\Util\IterableUtil;
 use ScssPhp\ScssPhp\Value\ListSeparator;
 use ScssPhp\ScssPhp\Visitor\ExpressionVisitor;
 
@@ -56,7 +56,7 @@ final class IsCalculationSafeVisitor implements ExpressionVisitor
 
     public function visitListExpression(ListExpression $node): bool
     {
-        return $node->getSeparator() === ListSeparator::SPACE && !$node->hasBrackets() && \count($node->getContents()) > 1 && ListUtil::every($node->getContents(), fn(Expression $expression) => $expression->accept($this));
+        return $node->getSeparator() === ListSeparator::SPACE && !$node->hasBrackets() && \count($node->getContents()) > 1 && IterableUtil::every($node->getContents(), fn(Expression $expression) => $expression->accept($this));
     }
 
     public function visitMapExpression(MapExpression $node): bool

--- a/src/Ast/Sass/Statement/IfRuleClause.php
+++ b/src/Ast/Sass/Statement/IfRuleClause.php
@@ -14,7 +14,7 @@ namespace ScssPhp\ScssPhp\Ast\Sass\Statement;
 
 use ScssPhp\ScssPhp\Ast\Sass\Import\DynamicImport;
 use ScssPhp\ScssPhp\Ast\Sass\Statement;
-use ScssPhp\ScssPhp\Util\ListUtil;
+use ScssPhp\ScssPhp\Util\IterableUtil;
 
 /**
  * The superclass of `@if` and `@else` clauses.
@@ -36,13 +36,13 @@ abstract class IfRuleClause
     public function __construct(array $children)
     {
         $this->children = $children;
-        $this->declarations = ListUtil::any($children, function (Statement $child) {
+        $this->declarations = IterableUtil::any($children, function (Statement $child) {
             if ($child instanceof VariableDeclaration || $child instanceof FunctionRule || $child instanceof MixinRule) {
                 return true;
             }
 
             if ($child instanceof ImportRule) {
-                return ListUtil::any($child->getImports(), fn ($import) => $import instanceof DynamicImport);
+                return IterableUtil::any($child->getImports(), fn ($import) => $import instanceof DynamicImport);
             }
 
             return false;

--- a/src/Util/IterableUtil.php
+++ b/src/Util/IterableUtil.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2018-2020 Anthon Pang
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Util;
+
+/**
+ * @internal
+ */
+final class IterableUtil
+{
+    /**
+     * @template T
+     *
+     * @param iterable<T>       $list
+     * @param callable(T): bool $callback
+     */
+    public static function any(iterable $list, callable $callback): bool
+    {
+        foreach ($list as $item) {
+            if ($callback($item)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @template T
+     *
+     * @param iterable<T>       $list
+     * @param callable(T): bool $callback
+     */
+    public static function every(iterable $list, callable $callback): bool
+    {
+        foreach ($list as $item) {
+            if (!$callback($item)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Returns the first `T` returned by $callback for an element of $iterable,
+     * or `null` if it returns `null` for every element.
+     *
+     * @template T
+     * @template E
+     * @param iterable<E> $iterable
+     * @param callable(E): (T|null) $callback
+     *
+     * @return T|null
+     */
+    public static function search(iterable $iterable, callable $callback)
+    {
+        foreach ($iterable as $element) {
+            $value = $callback($element);
+
+            if ($value !== null) {
+                return $value;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Util/ListUtil.php
+++ b/src/Util/ListUtil.php
@@ -18,40 +18,6 @@ namespace ScssPhp\ScssPhp\Util;
 final class ListUtil
 {
     /**
-     * @template T
-     *
-     * @param T[]               $list
-     * @param callable(T): bool $callback
-     */
-    public static function any(array $list, callable $callback): bool
-    {
-        foreach ($list as $item) {
-            if ($callback($item)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * @template T
-     *
-     * @param T[]               $list
-     * @param callable(T): bool $callback
-     */
-    public static function every(array $list, callable $callback): bool
-    {
-        foreach ($list as $item) {
-            if (!$callback($item)) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    /**
      * Flattens the first level of nested arrays in $queues.
      *
      * The return value is ordered first by index in the nested iterable, then by
@@ -182,29 +148,5 @@ final class ListUtil
         }
 
         return array_slice($list, 0, $count - 1);
-    }
-
-    /**
-     * Returns the first `T` returned by $callback for an element of $iterable,
-     * or `null` if it returns `null` for every element.
-     *
-     * @template T
-     * @template E
-     * @param iterable<E> $iterable
-     * @param callable(E): (T|null) $callback
-     *
-     * @return T|null
-     */
-    public static function search(iterable $iterable, callable $callback)
-    {
-        foreach ($iterable as $element) {
-            $value = $callback($element);
-
-            if ($value !== null) {
-                return $value;
-            }
-        }
-
-        return null;
     }
 }

--- a/src/Visitor/AnySelectorVisitor.php
+++ b/src/Visitor/AnySelectorVisitor.php
@@ -25,7 +25,7 @@ use ScssPhp\ScssPhp\Ast\Selector\SelectorList;
 use ScssPhp\ScssPhp\Ast\Selector\SimpleSelector;
 use ScssPhp\ScssPhp\Ast\Selector\TypeSelector;
 use ScssPhp\ScssPhp\Ast\Selector\UniversalSelector;
-use ScssPhp\ScssPhp\Util\ListUtil;
+use ScssPhp\ScssPhp\Util\IterableUtil;
 
 /**
  * A visitor that visits each selector in a Sass selector AST and returns
@@ -40,12 +40,12 @@ abstract class AnySelectorVisitor implements SelectorVisitor
 {
     public function visitComplexSelector(ComplexSelector $complex): bool
     {
-        return ListUtil::any($complex->getComponents(), fn (ComplexSelectorComponent $component) => $this->visitCompoundSelector($component->getSelector()));
+        return IterableUtil::any($complex->getComponents(), fn (ComplexSelectorComponent $component) => $this->visitCompoundSelector($component->getSelector()));
     }
 
     public function visitCompoundSelector(CompoundSelector $compound): bool
     {
-        return ListUtil::any($compound->getComponents(), fn (SimpleSelector $simple) => $simple->accept($this));
+        return IterableUtil::any($compound->getComponents(), fn (SimpleSelector $simple) => $simple->accept($this));
     }
 
     public function visitPseudoSelector(PseudoSelector $pseudo): bool
@@ -57,7 +57,7 @@ abstract class AnySelectorVisitor implements SelectorVisitor
 
     public function visitSelectorList(SelectorList $list): bool
     {
-        return ListUtil::any($list->getComponents(), $this->visitComplexSelector(...));
+        return IterableUtil::any($list->getComponents(), $this->visitComplexSelector(...));
     }
 
     public function visitAttributeSelector(AttributeSelector $attribute): bool

--- a/src/Visitor/EveryCssVisitor.php
+++ b/src/Visitor/EveryCssVisitor.php
@@ -22,7 +22,7 @@ use ScssPhp\ScssPhp\Ast\Css\CssNode;
 use ScssPhp\ScssPhp\Ast\Css\CssStyleRule;
 use ScssPhp\ScssPhp\Ast\Css\CssStylesheet;
 use ScssPhp\ScssPhp\Ast\Css\CssSupportsRule;
-use ScssPhp\ScssPhp\Util\ListUtil;
+use ScssPhp\ScssPhp\Util\IterableUtil;
 
 /**
  * A visitor that visits each statement in a CSS AST and returns `true` if all
@@ -37,7 +37,7 @@ abstract class EveryCssVisitor implements CssVisitor
 {
     public function visitCssAtRule(CssAtRule $node): bool
     {
-        return ListUtil::every($node->getChildren(), fn (CssNode $child) => $child->accept($this));
+        return IterableUtil::every($node->getChildren(), fn (CssNode $child) => $child->accept($this));
     }
 
     public function visitCssComment(CssComment $node): bool
@@ -57,26 +57,26 @@ abstract class EveryCssVisitor implements CssVisitor
 
     public function visitCssKeyframeBlock(CssKeyframeBlock $node): bool
     {
-        return ListUtil::every($node->getChildren(), fn (CssNode $child) => $child->accept($this));
+        return IterableUtil::every($node->getChildren(), fn (CssNode $child) => $child->accept($this));
     }
 
     public function visitCssMediaRule(CssMediaRule $node): bool
     {
-        return ListUtil::every($node->getChildren(), fn (CssNode $child) => $child->accept($this));
+        return IterableUtil::every($node->getChildren(), fn (CssNode $child) => $child->accept($this));
     }
 
     public function visitCssStyleRule(CssStyleRule $node): bool
     {
-        return ListUtil::every($node->getChildren(), fn (CssNode $child) => $child->accept($this));
+        return IterableUtil::every($node->getChildren(), fn (CssNode $child) => $child->accept($this));
     }
 
     public function visitCssStylesheet(CssStylesheet $node): bool
     {
-        return ListUtil::every($node->getChildren(), fn (CssNode $child) => $child->accept($this));
+        return IterableUtil::every($node->getChildren(), fn (CssNode $child) => $child->accept($this));
     }
 
     public function visitCssSupportsRule(CssSupportsRule $node): bool
     {
-        return ListUtil::every($node->getChildren(), fn (CssNode $child) => $child->accept($this));
+        return IterableUtil::every($node->getChildren(), fn (CssNode $child) => $child->accept($this));
     }
 }

--- a/src/Visitor/SelectorSearchVisitor.php
+++ b/src/Visitor/SelectorSearchVisitor.php
@@ -15,7 +15,7 @@ use ScssPhp\ScssPhp\Ast\Selector\SelectorList;
 use ScssPhp\ScssPhp\Ast\Selector\SimpleSelector;
 use ScssPhp\ScssPhp\Ast\Selector\TypeSelector;
 use ScssPhp\ScssPhp\Ast\Selector\UniversalSelector;
-use ScssPhp\ScssPhp\Util\ListUtil;
+use ScssPhp\ScssPhp\Util\IterableUtil;
 
 /**
  * A {@see SelectorVisitor} whose `visit*` methods default to returning `null`, but
@@ -68,12 +68,12 @@ abstract class SelectorSearchVisitor implements SelectorVisitor
 
     public function visitComplexSelector(ComplexSelector $complex)
     {
-        return ListUtil::search($complex->getComponents(), fn(ComplexSelectorComponent $component) => $this->visitCompoundSelector($component->getSelector()));
+        return IterableUtil::search($complex->getComponents(), fn(ComplexSelectorComponent $component) => $this->visitCompoundSelector($component->getSelector()));
     }
 
     public function visitCompoundSelector(CompoundSelector $compound)
     {
-        return ListUtil::search($compound->getComponents(), fn(SimpleSelector $simple) => $simple->accept($this));
+        return IterableUtil::search($compound->getComponents(), fn(SimpleSelector $simple) => $simple->accept($this));
     }
 
     public function visitPseudoSelector(PseudoSelector $pseudo)
@@ -87,6 +87,6 @@ abstract class SelectorSearchVisitor implements SelectorVisitor
 
     public function visitSelectorList(SelectorList $list)
     {
-        return ListUtil::search($list->getComponents(), $this->visitComplexSelector(...));
+        return IterableUtil::search($list->getComponents(), $this->visitComplexSelector(...));
     }
 }

--- a/src/Visitor/StatementSearchVisitor.php
+++ b/src/Visitor/StatementSearchVisitor.php
@@ -41,7 +41,7 @@ use ScssPhp\ScssPhp\Ast\Sass\Statement\SupportsRule;
 use ScssPhp\ScssPhp\Ast\Sass\Statement\VariableDeclaration;
 use ScssPhp\ScssPhp\Ast\Sass\Statement\WarnRule;
 use ScssPhp\ScssPhp\Ast\Sass\Statement\WhileRule;
-use ScssPhp\ScssPhp\Util\ListUtil;
+use ScssPhp\ScssPhp\Util\IterableUtil;
 
 /**
  * A StatementVisitor whose `visit*` methods default to returning `null`, but
@@ -122,10 +122,10 @@ abstract class StatementSearchVisitor implements StatementVisitor
 
     public function visitIfRule(IfRule $node)
     {
-        $value = ListUtil::search($node->getClauses(), fn(IfClause $clause) => ListUtil::search($clause->getChildren(), fn(Statement $child) => $child->accept($this)));
+        $value = IterableUtil::search($node->getClauses(), fn(IfClause $clause) => IterableUtil::search($clause->getChildren(), fn(Statement $child) => $child->accept($this)));
 
         if ($node->getLastClause() !== null) {
-            $value ??= ListUtil::search($node->getLastClause()->getChildren(), fn(Statement $child) => $child->accept($this));
+            $value ??= IterableUtil::search($node->getLastClause()->getChildren(), fn(Statement $child) => $child->accept($this));
         }
 
         return $value;
@@ -225,6 +225,6 @@ abstract class StatementSearchVisitor implements StatementVisitor
      */
     protected function visitChildren(array $children)
     {
-        return ListUtil::search($children, fn (Statement $child) => $child->accept($this));
+        return IterableUtil::search($children, fn (Statement $child) => $child->accept($this));
     }
 }


### PR DESCRIPTION
The `every` and `any` method work for any iterable, not just for lists. And `search` was already typed using `iterable`.
This will let me reuse them in more places in future PRs porting code.