### PR TITLE
Enable bleeding edge rules for phpstan

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -31,11 +31,6 @@ parameters:
 			path: src/Block/AtRootBlock.php
 
 		-
-			message: "#^Property ScssPhp\\\\ScssPhp\\\\Block\\\\CallableBlock\\:\\:\\$args type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Block/CallableBlock.php
-
-		-
 			message: "#^Property ScssPhp\\\\ScssPhp\\\\Block\\\\ContentBlock\\:\\:\\$child type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Block/ContentBlock.php
@@ -156,11 +151,6 @@ parameters:
 			path: src/Compiler.php
 
 		-
-			message: "#^Method ScssPhp\\\\ScssPhp\\\\Compiler\\:\\:applyArguments\\(\\) has parameter \\$argDef with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Compiler.php
-
-		-
 			message: "#^Method ScssPhp\\\\ScssPhp\\\\Compiler\\:\\:applyArguments\\(\\) has parameter \\$argValues with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Compiler.php
@@ -177,11 +167,6 @@ parameters:
 
 		-
 			message: "#^Method ScssPhp\\\\ScssPhp\\\\Compiler\\:\\:applyArgumentsToDeclaration\\(\\) has parameter \\$positionalArgs with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Compiler.php
-
-		-
-			message: "#^Method ScssPhp\\\\ScssPhp\\\\Compiler\\:\\:applyArgumentsToDeclaration\\(\\) has parameter \\$prototype with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Compiler.php
 
@@ -272,11 +257,6 @@ parameters:
 
 		-
 			message: "#^Method ScssPhp\\\\ScssPhp\\\\Compiler\\:\\:checkCompatibleTags\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Compiler.php
-
-		-
-			message: "#^Method ScssPhp\\\\ScssPhp\\\\Compiler\\:\\:checkPrototypeMatches\\(\\) has parameter \\$prototype with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Compiler.php
 
@@ -517,7 +497,7 @@ parameters:
 
 		-
 			message: "#^Method ScssPhp\\\\ScssPhp\\\\Compiler\\:\\:evaluateArguments\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 2
+			count: 1
 			path: src/Compiler.php
 
 		-
@@ -1166,11 +1146,6 @@ parameters:
 			path: src/Compiler.php
 
 		-
-			message: "#^Method ScssPhp\\\\ScssPhp\\\\Compiler\\:\\:parseFunctionPrototype\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Compiler.php
-
-		-
 			message: "#^Method ScssPhp\\\\ScssPhp\\\\Compiler\\:\\:prependSelectors\\(\\) has parameter \\$parts with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Compiler.php
@@ -1222,11 +1197,6 @@ parameters:
 
 		-
 			message: "#^Method ScssPhp\\\\ScssPhp\\\\Compiler\\:\\:replaceSelfSelector\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Compiler.php
-
-		-
-			message: "#^Method ScssPhp\\\\ScssPhp\\\\Compiler\\:\\:selectFunctionPrototype\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Compiler.php
 
@@ -1317,11 +1287,6 @@ parameters:
 
 		-
 			message: "#^Method ScssPhp\\\\ScssPhp\\\\Compiler\\:\\:unifyCompoundSelectors\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Compiler.php
-
-		-
-			message: "#^Method ScssPhp\\\\ScssPhp\\\\Compiler\\:\\:verifyPrototype\\(\\) has parameter \\$prototype with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Compiler.php
 

--- a/phpstan-no-baseline.neon
+++ b/phpstan-no-baseline.neon
@@ -5,6 +5,10 @@ parameters:
     paths:
         - ./src/
     ignoreErrors:
+        # This variable is modified by reference in some Closure and may be assigned null later. Without this type, phpstan does not detect it properly.
+        -
+            message: '#^PHPDoc tag @var with type ScssPhp\\ScssPhp\\Ast\\Sass\\Expression\|null is not subtype of native type ScssPhp\\ScssPhp\\Ast\\Sass\\Expression\.$#'
+            path: src/Parser/StylesheetParser.php
         # Ignore errors about not having typehints for definitions of builtin functions. These won't be typed until they are extracted.
         -
             message: "#^Property ScssPhp\\\\ScssPhp\\\\Compiler\\:\\:\\$lib[\\w]+ has no type specified\\.$#"
@@ -39,5 +43,6 @@ parameters:
             path: src/Parser.php
 
 includes:
+    - vendor-bin/phpstan/vendor/phpstan/phpstan/conf/bleedingEdge.neon
     - vendor-bin/phpstan/vendor/phpstan/phpstan-deprecation-rules/rules.neon
     - vendor-bin/phpstan/vendor/jiripudil/phpstan-sealed-classes/extension.neon

--- a/src/Ast/Selector/SelectorList.php
+++ b/src/Ast/Selector/SelectorList.php
@@ -177,9 +177,7 @@ final class SelectorList extends Selector
                     if (\count($newComplexes) === 0) {
                         $newComplexes[] = new ComplexSelector($complex->getLeadingCombinators(), [$component], $complex->getSpan(), false);
                     } else {
-                        foreach ($newComplexes as $i => $newComplex) {
-                            $newComplexes[$i] = $newComplex->withAdditionalComponent($component, $complex->getSpan());
-                        }
+                        $newComplexes = array_map(fn ($newComplex) => $newComplex->withAdditionalComponent($component, $complex->getSpan()), $newComplexes);
                     }
                 } elseif (\count($newComplexes) === 0) {
                     $newComplexes = $resolved;

--- a/src/Block/CallableBlock.php
+++ b/src/Block/CallableBlock.php
@@ -14,6 +14,7 @@ namespace ScssPhp\ScssPhp\Block;
 
 use ScssPhp\ScssPhp\Block;
 use ScssPhp\ScssPhp\Compiler\Environment;
+use ScssPhp\ScssPhp\Node\Number;
 
 /**
  * @internal
@@ -26,7 +27,7 @@ final class CallableBlock extends Block
     public $name;
 
     /**
-     * @var array|null
+     * @var list<array{string, array|Number|null, bool}>|null
      */
     public $args;
 

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -5945,7 +5945,7 @@ EOL;
      *
      * @return array
      *
-     * @phpstan-param non-empty-list<array{arguments: list<array{0: string, 1: string, 2: array|Number|null}>, rest_argument: string|null}> $prototypes
+     * @phpstan-param non-empty-array<array{arguments: list<array{0: string, 1: string, 2: array|Number|null}>, rest_argument: string|null}> $prototypes
      * @phpstan-return array{arguments: list<array{0: string, 1: string, 2: array|Number|null}>, rest_argument: string|null}
      */
     private function selectFunctionPrototype(array $prototypes, int $positional, array $names): array
@@ -7301,7 +7301,13 @@ EOL;
         $scale = $operation === 'scale';
         $change = $operation === 'change';
 
-        /** @phpstan-var callable(string, float|int, bool=, bool=): (float|int|null) $getParam */
+        /**
+         * @param string $name
+         * @param float|int $max
+         * @param bool $checkPercent
+         * @param bool $assertPercent
+         * @return float|int|null
+         */
         $getParam = function ($name, $max, $checkPercent = false, $assertPercent = false) use (&$kwargs, $scale, $change) {
             if (!isset($kwargs[$name])) {
                 return null;

--- a/src/Node/Number.php
+++ b/src/Node/Number.php
@@ -125,7 +125,7 @@ final class Number extends Node implements \ArrayAccess
     }
 
     /**
-     * @return string[]
+     * @return list<string>
      */
     public function getNumeratorUnits()
     {
@@ -133,7 +133,7 @@ final class Number extends Node implements \ArrayAccess
     }
 
     /**
-     * @return string[]
+     * @return list<string>
      */
     public function getDenominatorUnits()
     {

--- a/src/Parser/StylesheetParser.php
+++ b/src/Parser/StylesheetParser.php
@@ -1785,11 +1785,11 @@ abstract class StylesheetParser extends Parser
         $start = $this->scanner->getPosition();
         $wasInParentheses = $this->inParentheses;
         /**
-         * @var Expression[]|null $commaExpressions
+         * @var list<Expression>|null $commaExpressions
          */
         $commaExpressions = null;
         /**
-         * @var Expression[]|null $spaceExpressions
+         * @var list<Expression>|null $spaceExpressions
          */
         $spaceExpressions = null;
         /**
@@ -1798,7 +1798,7 @@ abstract class StylesheetParser extends Parser
          * parsing to finish for all preceding higher-precedence $operators, this is
          * naturally ordered from lowest to highest precedence.
          *
-         * @phpstan-var list<BinaryOperator>|null $operators
+         * @var list<BinaryOperator>|null $operators
          */
         $operators = null;
         /**

--- a/src/SourceSpan/SourceFile.php
+++ b/src/SourceSpan/SourceFile.php
@@ -23,9 +23,8 @@ final class SourceFile
 
     /**
      * @var int[]
-     * @readonly
      */
-    private array $lineStarts;
+    private readonly array $lineStarts;
 
     /**
      * The 0-based last line that was returned by {@see getLine}
@@ -45,24 +44,27 @@ final class SourceFile
         $this->sourceUrl = $sourceUrl;
 
         // Extract line starts
-        $this->lineStarts = [0];
+        $lineStarts = [0];
 
         if ($content === '') {
+            $this->lineStarts = $lineStarts;
             return;
         }
 
         $prev = 0;
 
         while (($pos = strpos($content, "\n", $prev)) !== false) {
-            $this->lineStarts[] = $pos;
+            $lineStarts[] = $pos;
             $prev = $pos + 1;
         }
 
-        $this->lineStarts[] = \strlen($content);
+        $lineStarts[] = \strlen($content);
 
         if (!str_ends_with($content, "\n")) {
-            $this->lineStarts[] = \strlen($content) + 1;
+            $lineStarts[] = \strlen($content) + 1;
         }
+
+        $this->lineStarts = $lineStarts;
     }
 
     public function span(int $start, ?int $end = null): FileSpan

--- a/src/Util/ListUtil.php
+++ b/src/Util/ListUtil.php
@@ -92,7 +92,12 @@ final class ListUtil
             }
         }
 
-        $backtrack = function (int $i, int $j) use ($selections, $lengths, &$backtrack): array {
+        /**
+         * @param int $i
+         * @param int $j
+         * @return list<T>
+         */
+        $backtrack = function (int $i, int $j) use ($selections, $lengths, &$backtrack) {
             if ($i === -1 || $j === -1) {
                 return [];
             }

--- a/src/Value/SassCalculation.php
+++ b/src/Value/SassCalculation.php
@@ -454,7 +454,7 @@ WARNING;
             return $value;
         }
 
-        $args = array_filter([$min, $value, $max]);
+        $args = array_values(array_filter([$min, $value, $max]));
         self::verifyCompatibleNumbers($args);
         self::verifyLength($args, 3);
 
@@ -708,13 +708,12 @@ WARNING;
             case $step === null:
                 return new SassCalculation('round', [$strategyOrNumber, $numberOrStep]);
 
-            case $strategyOrNumber instanceof SassString && (\in_array($strategyOrNumber->getText(), ['nearest', 'up', 'down', 'to-zero'], true) || $strategyOrNumber->isVar()) && $numberOrStep !== null && $step !== null:
+            case $strategyOrNumber instanceof SassString && (\in_array($strategyOrNumber->getText(), ['nearest', 'up', 'down', 'to-zero'], true) || $strategyOrNumber->isVar()) && $numberOrStep !== null:
                 return new SassCalculation('round', [$strategyOrNumber, $numberOrStep, $step]);
 
-            case $numberOrStep !== null && $step !== null:
+            case $numberOrStep !== null:
                 throw new SassScriptException("$strategyOrNumber must be either nearest, up, down or to-zero.");
 
-            case $numberOrStep === null:
             default:
                 throw new SassScriptException('Invalid parameters.');
         }

--- a/src/Value/SingleUnitSassNumber.php
+++ b/src/Value/SingleUnitSassNumber.php
@@ -296,13 +296,11 @@ final class SingleUnitSassNumber extends SassNumber
             break;
         }
 
-        if ($removed) {
-            $otherDenominators = array_values($otherDenominators);
-        } else {
+        if (!$removed) {
             array_unshift($newNumerators, $this->unit);
         }
 
-        return SassNumber::withUnits($value, $newNumerators, $otherDenominators);
+        return SassNumber::withUnits($value, $newNumerators, array_values($otherDenominators));
     }
 
     private function tryCoerceToUnit(string $unit): ?SassNumber


### PR DESCRIPTION
As the new code works a lot with the list type, we should make phpstan enforce it, which is the case only in bleeding edge for now. As phpstan is pinned to an exact version, the fact that bleeding edge can enable new rules in any release (and so change the result of the analysis) is not an issue.