### PR TITLE
Update the extension store to match the decision taken in dart-sass

### DIFF
--- a/src/Extend/ConcreteExtensionStore.php
+++ b/src/Extend/ConcreteExtensionStore.php
@@ -435,13 +435,6 @@ class ConcreteExtensionStore implements ExtensionStore
                     }
                 }
             }
-
-            // If $selectors doesn't contain $extension->extender, for example if it
-            // was replaced due to :not() expansion, we must get rid of the old
-            // version.
-            if (!$containsExtension) {
-                $sources->detach($extension->extender->selector);
-            }
         }
 
         return $additionalExtensions;


### PR DESCRIPTION
When porting the extension store from dart-sass, phpstan detected an issue about the way an extender was removed from a map using selectors as keys. In #682, I wrote the code by removing the selector of that extender instead. However, the decision taken in https://github.com/sass/dart-sass/pull/2129 ended up being the alternative choice of removing the no-op deletion. This synchronizes the code with that decision.