### PR TITLE
Fix the usage of comments when parsing values

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -1683,9 +1683,9 @@ class Parser
      */
     protected function appendComment($comment)
     {
-        assert($this->env !== null);
-
         if (! $this->discardComments) {
+            assert($this->env !== null);
+
             $this->env->comments[] = $comment;
         }
     }

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -322,6 +322,14 @@ class ApiTest extends TestCase
                     'color' => 'blue',
                 ],
             ],
+            // Comment in value
+            [
+                "a {\n  b: d, e;\n}",
+                'a { b: $c; }',
+                [
+                    'c' => 'd, /* comment */ e'
+                ]
+            ],
         ];
     }
 


### PR DESCRIPTION
When parsing only a value, the parser runs without an env being set. Inside values, comments are always discarded. So moving our assertion inside the condition that actually needs it is enough and fixes the issue.

Closes #689