### PR TITLE
Deprecate passing trailing data in value parsing

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -328,6 +328,13 @@ class Parser
 
         $list = $this->valueList($out);
 
+        if ($this->count !== \strlen($this->buffer)) {
+            $error = $this->parseError('Expected end of value');
+            $message = 'Passing trailing content after the expression when parsing a value is deprecated since Scssphp 1.12.0 and will be an error in 2.0. ' . $error->getMessage();
+
+            @trigger_error($message, E_USER_DEPRECATED);
+        }
+
         $this->restoreEncoding();
 
         return $list;


### PR DESCRIPTION
The logic was not ensuring that all the input has been consumed by the parsing, ignoring silently the remaining content. This behavior is now deprecated, ensuring only a valid value is passed.

While looking at https://github.com/scssphp/scssphp/issues/689, I figured out that our value parsing silently ignores extra content that  comes after the expression instead of enforcing that the value corresponds to the whole input. This triggers a deprecation warning in that case, allowing to turn that into an error in 2.0 (where the new way to parse values won't allow extra content anyway)