### PR TITLE
Upgrade phpstan

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -121,11 +121,6 @@ parameters:
 			path: src/Cache.php
 
 		-
-			message: "#^Result of \\|\\| is always false\\.$#"
-			count: 3
-			path: src/Colors.php
-
-		-
 			message: "#^Argument of an invalid type array\\<int, string\\>\\|false supplied for foreach, only iterables are supported\\.$#"
 			count: 1
 			path: src/Compiler.php
@@ -1579,21 +1574,6 @@ parameters:
 			message: "#^Property ScssPhp\\\\ScssPhp\\\\Formatter\\\\OutputBlock\\:\\:\\$selectors type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Formatter/OutputBlock.php
-
-		-
-			message: "#^Offset 'denominator_units' on array\\<int, string\\> in isset\\(\\) does not exist\\.$#"
-			count: 1
-			path: src/Node/Number.php
-
-		-
-			message: "#^Offset 'numerator_units' on array\\<int, string\\> in isset\\(\\) does not exist\\.$#"
-			count: 1
-			path: src/Node/Number.php
-
-		-
-			message: "#^Call to function is_string\\(\\) with array will always evaluate to false\\.$#"
-			count: 1
-			path: src/Parser.php
 
 		-
 			message: "#^Left side of && is always true\\.$#"

--- a/phpstan-no-baseline.neon
+++ b/phpstan-no-baseline.neon
@@ -1,6 +1,7 @@
 parameters:
     level: 8
     inferPrivatePropertyTypeFromConstructor: true
+    treatPhpDocTypesAsCertain: false
     paths:
         - ./src/
     ignoreErrors:
@@ -36,3 +37,6 @@ parameters:
         -
             message: "#^Method ScssPhp\\\\ScssPhp\\\\Parser\\:\\:[^(]+\\(\\) has parameter \\$out with no value type specified in iterable type array\\.$#"
             path: src/Parser.php
+
+includes:
+    - vendor-bin/phpstan/vendor/phpstan/phpstan/conf/bleedingEdge.neon

--- a/src/Block/CallableBlock.php
+++ b/src/Block/CallableBlock.php
@@ -14,6 +14,7 @@ namespace ScssPhp\ScssPhp\Block;
 
 use ScssPhp\ScssPhp\Block;
 use ScssPhp\ScssPhp\Compiler\Environment;
+use ScssPhp\ScssPhp\Node\Number;
 
 /**
  * @internal
@@ -26,7 +27,7 @@ class CallableBlock extends Block
     public $name;
 
     /**
-     * @var array|null
+     * @var list<array{string, array|Number|null, bool}>|null
      */
     public $args;
 

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -571,7 +571,7 @@ class Compiler
 
             $sourceMap = null;
 
-            if (! empty($out) && $this->sourceMap && $this->sourceMap !== self::SOURCE_MAP_NONE) {
+            if (! empty($out) && $this->sourceMap !== self::SOURCE_MAP_NONE && $this->sourceMap) {
                 assert($sourceMapGenerator !== null);
                 $sourceMap = $sourceMapGenerator->generateJson($prefix);
                 $sourceMapUrl = null;
@@ -6561,7 +6561,7 @@ EOL;
      *
      * @return array
      *
-     * @phpstan-param non-empty-list<array{arguments: list<array{0: string, 1: string, 2: array|Number|null}>, rest_argument: string|null}> $prototypes
+     * @phpstan-param non-empty-array<array{arguments: list<array{0: string, 1: string, 2: array|Number|null}>, rest_argument: string|null}> $prototypes
      * @phpstan-return array{arguments: list<array{0: string, 1: string, 2: array|Number|null}>, rest_argument: string|null}
      */
     private function selectFunctionPrototype(array $prototypes, $positional, array $names)
@@ -7962,7 +7962,13 @@ EOL;
         $scale = $operation === 'scale';
         $change = $operation === 'change';
 
-        /** @phpstan-var callable(string, float|int, bool=, bool=): (float|int|null) $getParam */
+        /**
+         * @param string $name
+         * @param float|int $max
+         * @param bool $checkPercent
+         * @param bool $assertPercent
+         * @return float|int|null
+         */
         $getParam = function ($name, $max, $checkPercent = false, $assertPercent = false) use (&$kwargs, $scale, $change) {
             if (!isset($kwargs[$name])) {
                 return null;

--- a/src/Node/Number.php
+++ b/src/Node/Number.php
@@ -131,7 +131,7 @@ class Number extends Node implements \ArrayAccess
     }
 
     /**
-     * @return string[]
+     * @return list<string>
      */
     public function getNumeratorUnits()
     {
@@ -139,7 +139,7 @@ class Number extends Node implements \ArrayAccess
     }
 
     /**
-     * @return string[]
+     * @return list<string>
      */
     public function getDenominatorUnits()
     {

--- a/vendor-bin/phpstan/composer.json
+++ b/vendor-bin/phpstan/composer.json
@@ -3,6 +3,6 @@
         "sort-packages": true
     },
     "require": {
-        "phpstan/phpstan": "1.10.35"
+        "phpstan/phpstan": "1.10.42"
     }
 }


### PR DESCRIPTION
This also enables bleeding edge in the `1.x` branch, as done already in the `main`. This makes it easier to manage the baseline for the 1.x codebase during merges into the main branch if we have a similar config.
This backports some changes done in https://github.com/scssphp/scssphp/pull/680 to fix new baseline errors. However, the current PR does not remove some of the errors `... has no value type specified in iterable type array.` that were removed from the baseline in that PR because the phpstan bug that made them go undetected in bleeding-edge mode has been fixed in phpstan in the meantime. Those will be re-added in the baseline during the merge to main.