### PR TITLE
Fix the compilation cache key when using numbers in variables

### DIFF
--- a/src/Node/Number.php
+++ b/src/Node/Number.php
@@ -33,7 +33,7 @@ use ScssPhp\ScssPhp\Util;
  *
  * @template-implements \ArrayAccess<int, mixed>
  */
-class Number extends Node implements \ArrayAccess
+class Number extends Node implements \ArrayAccess, \JsonSerializable
 {
     const PRECISION = 10;
 
@@ -144,6 +144,16 @@ class Number extends Node implements \ArrayAccess
     public function getDenominatorUnits()
     {
         return $this->denominatorUnits;
+    }
+
+    /**
+     * @return mixed
+     */
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
+    {
+        // Passing a compiler instance makes the method output a Sass representation instead of a CSS one, supporting full units.
+        return $this->output(new Compiler());
     }
 
     /**


### PR DESCRIPTION
Variables gets encoded as JSON as part of the cache key. For most types, this is fine as they are represented as arrays. But numbers are represented as an object with private properties so all numbers were encoded the same, breaking the cache invalidation when replacing them with a different number.

Closes #699