### PR TITLE
Prepare the implementation of the new evaluation system

### DIFF
--- a/src/Ast/Sass/ArgumentDeclaration.php
+++ b/src/Ast/Sass/ArgumentDeclaration.php
@@ -17,6 +17,7 @@ use ScssPhp\ScssPhp\Exception\SassScriptException;
 use ScssPhp\ScssPhp\Logger\LoggerInterface;
 use ScssPhp\ScssPhp\Parser\ScssParser;
 use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+use ScssPhp\ScssPhp\Util\StringUtil;
 
 /**
  * An argument declaration, as for a function or mixin definition.
@@ -114,24 +115,23 @@ final class ArgumentDeclaration implements SassNode
 
         if ($positional > \count($this->arguments)) {
             $message = sprintf(
-                'Only %d %sargument%s allowed, but %d %s passed.',
+                'Only %d %s%s allowed, but %d %s passed.',
                 \count($this->arguments),
                 empty($names) ? '' : 'positional ',
-                \count($this->arguments) === 1 ? '' : 's',
+                StringUtil::pluralize('argument', \count($this->arguments)),
                 $positional,
-                $positional === 1 ? 'was' : 'were'
+                StringUtil::pluralize('was', $positional, 'were')
             );
             throw new SassScriptException($message);
         }
 
         if ($nameUsed < \count($names)) {
             $unknownNames = array_values(array_diff(array_keys($names), array_map(fn($argument) => $argument->getName(), $this->arguments)));
-            $lastName = array_pop($unknownNames);
+            \assert(\count($unknownNames) > 0);
             $message = sprintf(
-                'No argument%s named $%s%s.',
-                $unknownNames ? 's' : '',
-                $unknownNames ? implode(', $', $unknownNames) . ' or $' : '',
-                $lastName
+                'No %s named %s.',
+                StringUtil::pluralize('argument', \count($unknownNames)),
+                StringUtil::toSentence(array_map(fn ($name) => '$' . $name, $unknownNames), 'or')
             );
             throw new SassScriptException($message);
         }

--- a/src/Ast/Selector/PseudoSelector.php
+++ b/src/Ast/Selector/PseudoSelector.php
@@ -267,7 +267,7 @@ final class PseudoSelector extends SimpleSelector
             }
         }
 
-        if (EquatableUtil::listContains($compound, $this)) {
+        if (EquatableUtil::iterableContains($compound, $this)) {
             return $compound;
         }
 

--- a/src/Ast/Selector/SimpleSelector.php
+++ b/src/Ast/Selector/SimpleSelector.php
@@ -107,7 +107,7 @@ abstract class SimpleSelector extends Selector
             }
         }
 
-        if (EquatableUtil::listContains($compound, $this)) {
+        if (EquatableUtil::iterableContains($compound, $this)) {
             return $compound;
         }
 

--- a/src/Extend/ExtendUtil.php
+++ b/src/Extend/ExtendUtil.php
@@ -639,7 +639,7 @@ final class ExtendUtil
 
         foreach ($complex2 as $component) {
             foreach ($component->getSelector()->getComponents() as $simple) {
-                if (self::isUnique($simple) && EquatableUtil::listContains($uniqueSelectors, $simple)) {
+                if (self::isUnique($simple) && EquatableUtil::iterableContains($uniqueSelectors, $simple)) {
                     return true;
                 }
             }

--- a/src/Parser/InterpolationMap.php
+++ b/src/Parser/InterpolationMap.php
@@ -14,6 +14,7 @@ namespace ScssPhp\ScssPhp\Parser;
 
 use ScssPhp\ScssPhp\Ast\Sass\Expression;
 use ScssPhp\ScssPhp\Ast\Sass\Interpolation;
+use ScssPhp\ScssPhp\SourceSpan\FileLocation;
 use ScssPhp\ScssPhp\SourceSpan\FileSpan;
 use ScssPhp\ScssPhp\SourceSpan\SourceLocation;
 use ScssPhp\ScssPhp\Util\Character;
@@ -84,7 +85,7 @@ final class InterpolationMap
     }
 
     /**
-     * @return FileSpan|SourceLocation
+     * @return FileSpan|FileLocation
      */
     private function mapLocation(SourceLocation $target): object
     {
@@ -127,11 +128,8 @@ final class InterpolationMap
      * Note that this can be tricked by a `#{` that appears within a single-line
      * comment before the expression, but since it's only used for error
      * reporting that's probably fine.
-     *
-     * @param SourceLocation $start
-     * @return int
      */
-    private function expandInterpolationSpanLeft(SourceLocation $start): int
+    private function expandInterpolationSpanLeft(FileLocation $start): int
     {
         $source = $start->getFile()->getString();
         $i = $start->getOffset() - 1;
@@ -173,7 +171,7 @@ final class InterpolationMap
      * Given the end of a {@see FileSpan} covering an interpolated expression, returns
      * the offset of the interpolation's closing `}`.
      */
-    private function expandInterpolationSpanRight(SourceLocation $end): int
+    private function expandInterpolationSpanRight(FileLocation $end): int
     {
         $source = $end->getFile()->getString();
         $i = $end->getOffset();

--- a/src/Parser/Parser.php
+++ b/src/Parser/Parser.php
@@ -17,9 +17,9 @@ use ScssPhp\ScssPhp\Logger\AdaptingDeprecationAwareLogger;
 use ScssPhp\ScssPhp\Logger\DeprecationAwareLoggerInterface;
 use ScssPhp\ScssPhp\Logger\LoggerInterface;
 use ScssPhp\ScssPhp\Logger\QuietLogger;
+use ScssPhp\ScssPhp\SourceSpan\FileLocation;
 use ScssPhp\ScssPhp\SourceSpan\FileSpan;
 use ScssPhp\ScssPhp\SourceSpan\LazyFileSpan;
-use ScssPhp\ScssPhp\SourceSpan\SourceLocation;
 use ScssPhp\ScssPhp\Util;
 use ScssPhp\ScssPhp\Util\Character;
 use ScssPhp\ScssPhp\Util\ParserUtil;
@@ -976,7 +976,7 @@ class Parser
      * This helps avoid missing token errors pointing at the next closing bracket
      * rather than the line where the problem actually occurred.
      */
-    private function firstNewlineBefore(SourceLocation $location): SourceLocation
+    private function firstNewlineBefore(FileLocation $location): FileLocation
     {
         $text = $location->getFile()->getText(0, $location->getOffset());
         $index = $location->getOffset() - 1;

--- a/src/SassCallable/BuiltInCallable.php
+++ b/src/SassCallable/BuiltInCallable.php
@@ -1,0 +1,198 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\SassCallable;
+
+use ScssPhp\ScssPhp\Ast\Sass\ArgumentDeclaration;
+use ScssPhp\ScssPhp\Exception\SassFormatException;
+use ScssPhp\ScssPhp\Value\SassNull;
+use ScssPhp\ScssPhp\Value\Value;
+
+/**
+ * A callable defined in PHP code.
+ *
+ * Unlike user-defined callables, built-in callables support overloads. They
+ * may declare multiple different callbacks with multiple different sets of
+ * arguments. When the callable is invoked, the first callback with matching
+ * arguments is invoked.
+ *
+ * @internal
+ */
+class BuiltInCallable implements SassCallable
+{
+    private readonly string $name;
+
+    /**
+     * @var list<array{ArgumentDeclaration, callable(list<Value>): Value}>
+     */
+    private readonly array $overloads;
+
+    private readonly bool $acceptsContent;
+
+    /**
+     * Creates a function with a single $arguments declaration and a single
+     * $callback.
+     *
+     * The argument declaration is parsed from $arguments, which should not
+     * include parentheses. Throws a {@see SassFormatException} if parsing fails.
+     *
+     * If passed, $url is the URL of the module in which the function is
+     * defined.
+     *
+     * @param callable(list<Value>): Value $callback
+     *
+     * @throws SassFormatException
+     */
+    public static function function(string $name, string $arguments, callable $callback, ?string $url = null): BuiltInCallable
+    {
+        return self::parsed(
+            $name,
+            ArgumentDeclaration::parse("@function $name($arguments) {", url: $url),
+            $callback
+        );
+    }
+
+    /**
+     * Creates a mixin with a single $arguments declaration and a single
+     * $callback.
+     *
+     * The argument declaration is parsed from $arguments, which should not
+     * include parentheses. Throws a {@see SassFormatException} if parsing fails.
+     *
+     * If passed, $url is the URL of the module in which the mixin is
+     * defined.
+     *
+     * @param callable(list<Value>): void $callback
+     *
+     * @throws SassFormatException
+     */
+    public static function mixin(string $name, string $arguments, callable $callback, ?string $url = null, bool $acceptsContent = false): BuiltInCallable
+    {
+        return self::parsed(
+            $name,
+            ArgumentDeclaration::parse("@mixin $name($arguments) {", url: $url),
+            function ($arguments) use ($callback) {
+                $callback($arguments);
+
+                return SassNull::create();
+            },
+            $acceptsContent
+        );
+    }
+
+    /**
+     * Creates a function with multiple implementations.
+     *
+     * Each key/value pair in $overloads defines the argument declaration for
+     * the overload (which should not include parentheses), and the callback to
+     * execute if that argument declaration matches. Throws a
+     * {@see SassFormatException} if parsing fails.
+     *
+     * If passed, $url is the URL of the module in which the function is
+     * defined.
+     *
+     * @param array<string, callable(list<Value>): Value> $overloads
+     *
+     * @throws SassFormatException
+     */
+    public static function overloadedFunction(string $name, array $overloads, ?string $url = null): BuiltInCallable
+    {
+        $processedOverloads = [];
+
+        foreach ($overloads as $args => $callback) {
+            $overloads[] = [
+                ArgumentDeclaration::parse("@function $name($args) {", url: $url),
+                $callback
+            ];
+        }
+
+        return new BuiltInCallable($name, $processedOverloads, false);
+    }
+
+    /**
+     * Creates a callable with a single $arguments declaration and a single $callback.
+     *
+     * @param callable(list<Value>): Value $callback
+     */
+    private static function parsed(string $name, ArgumentDeclaration $arguments, callable $callback, bool $acceptsContent = false): BuiltInCallable
+    {
+        return new BuiltInCallable($name, [[$arguments, $callback]], $acceptsContent);
+    }
+
+    /**
+     * @param list<array{ArgumentDeclaration, callable(list<Value>): Value}> $overloads
+     */
+    private function __construct(string $name, array $overloads, bool $acceptsContent)
+    {
+        $this->name = $name;
+        $this->overloads = $overloads;
+        $this->acceptsContent = $acceptsContent;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function acceptsContent(): bool
+    {
+        return $this->acceptsContent;
+    }
+
+    /**
+     * Returns the argument declaration and PHP callback for the given
+     * positional and named arguments.
+     *
+     * If no exact match is found, finds the closest approximation. Note that this
+     * doesn't guarantee that $positional and $names are valid for the returned
+     * {@see ArgumentDeclaration}.
+     *
+     * @param array<string, mixed> $names Only the keys are relevant
+     *
+     * @return array{ArgumentDeclaration, callable(list<Value>): Value}
+     */
+    public function callbackFor(int $positional, array $names): array
+    {
+        $fuzzyMatch = null;
+        $minMismatchDistance = null;
+
+        foreach ($this->overloads as $overload) {
+            // Ideally, find an exact match.
+            if ($overload[0]->matches($positional, $names)) {
+                return $overload;
+            }
+
+            $mismatchDistance = \count($overload[0]->getArguments()) - $positional;
+
+            if ($minMismatchDistance !== null) {
+                if (abs($mismatchDistance) > $minMismatchDistance) {
+                    continue;
+                }
+
+                // If two overloads have the same mismatch distance, favor the overload
+                // that has more arguments.
+                if (abs($mismatchDistance) === abs($minMismatchDistance) && $mismatchDistance < 0) {
+                    continue;
+                }
+            }
+
+            $minMismatchDistance = $mismatchDistance;
+            $fuzzyMatch = $overload;
+        }
+
+        if ($fuzzyMatch !== null) {
+            return $fuzzyMatch;
+        }
+
+        throw new \LogicException("BuiltInCallable {$this->name} may not have empty overloads.");
+    }
+}

--- a/src/SassCallable/PlainCssCallable.php
+++ b/src/SassCallable/PlainCssCallable.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\SassCallable;
+
+use ScssPhp\ScssPhp\Util\Equatable;
+
+/**
+ * A callable that emits a plain CSS function.
+ *
+ * This can't be used for mixins.
+ *
+ * @internal
+ */
+final class PlainCssCallable implements SassCallable, Equatable
+{
+    private readonly string $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function equals(object $other): bool
+    {
+        return $other instanceof PlainCssCallable && $this->name === $other->name;
+    }
+}

--- a/src/SassCallable/SassCallable.php
+++ b/src/SassCallable/SassCallable.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\SassCallable;
+
+use ScssPhp\ScssPhp\Value\SassNumber;
+use ScssPhp\ScssPhp\Value\Value;
+
+/**
+ * An interface for functions and mixins that can be invoked from Sass by
+ * passing in arguments.
+ *
+ * When writing custom functions, it's important to make them as user-friendly
+ * and as close to the standards set by Sass's core functions as possible. Some
+ * good guidelines to follow include:
+ *
+ * * Use `Value.assert*` methods, like {@see Value::assertString}, to cast untyped
+ *   {@see Value} objects to more specific types. For values from the argument list,
+ *   pass in the argument name as well. This ensures that the user gets good
+ *   error messages when they pass in the wrong type to your function.
+ *
+ * * Individual classes may have more specific `assert*` methods, like
+ *   {@see SassNumber::assertInt}, which should be used when possible.
+ *
+ * * In Sass, every value counts as a list. Functions should avoid casting
+ *   values to the `SassList` type, and should use the {@see Value::asList} method
+ *   instead.
+ *
+ * * When manipulating values like lists, strings, and numbers that have
+ *   metadata (comma versus space separated, bracketed versus unbracketed,
+ *   quoted versus unquoted, units), the output metadata should match the input
+ *   metadata. For lists, the {@see Value::withListContents} method can be used to do
+ *   this automatically.
+ *
+ * * When in doubt, lists should default to comma-separated, strings should
+ *   default to quoted, and number should default to unitless.
+ *
+ * * In Sass, lists and strings use one-based indexing and use negative indices
+ *   to index from the end of value. Functions should follow these conventions.
+ *   The {@see Value::sassIndexToListIndex} and {@see SassString::sassIndexToStringIndex}
+ *   methods can be used to do this automatically.
+ *
+ * * String indexes in Sass refer to Unicode code points while PHP string
+ *   indices refer to bytes. For example, the character U+1F60A,
+ *   Smiling Face With Smiling Eyes, is a single Unicode code point but is
+ *   represented in UTF-8 as several bytes (`0xF0`, `0x9F`, `0x98` and `0x8A`). So in
+ *   PHP, `substr("a😊b", 1, 1)` returns `"\xF0"`, whereas in Sass
+ *   `str-slice("a😊b", 1, 1)` returns `"😊"`. Functions should follow this
+ *   convention. The {@see SassString::sassIndexToStringIndex} and
+ *   {@see SassString::sassIndexToCodePointIndex} methods can be used to do this
+ *   automatically, and the {@see SassString::getSassLength} getter can be used to
+ *   access a string's length in code points.
+ *
+ * @internal
+ */
+interface SassCallable
+{
+    /**
+     * The callable's name
+     */
+    public function getName(): string;
+}

--- a/src/Serializer/SerializeVisitor.php
+++ b/src/Serializer/SerializeVisitor.php
@@ -778,7 +778,7 @@ final class SerializeVisitor implements CssVisitor, ValueVisitor, SelectorVisito
         }
 
         $this->buffer->write('get-function(');
-        $this->visitQuotedString($value->getName());
+        $this->visitQuotedString($value->getCallable()->getName());
         $this->buffer->writeChar(')');
     }
 
@@ -789,7 +789,7 @@ final class SerializeVisitor implements CssVisitor, ValueVisitor, SelectorVisito
         }
 
         $this->buffer->write('get-mixin(');
-        $this->visitQuotedString($value->getName());
+        $this->visitQuotedString($value->getCallable()->getName());
         $this->buffer->writeChar(')');
     }
 

--- a/src/Serializer/SerializeVisitor.php
+++ b/src/Serializer/SerializeVisitor.php
@@ -350,7 +350,7 @@ final class SerializeVisitor implements CssVisitor, ValueVisitor, SelectorVisito
                 // TODO implement source map tracking
                 $node->getValue()->getValue()->accept($this);
             } catch (SassScriptException $error) {
-                throw new SassRuntimeException($error->getMessage(), $node->getValue()->getSpan(), $error);
+                throw new SassRuntimeException($error->getMessage(), $node->getValue()->getSpan(), null, $error);
             }
         }
     }

--- a/src/SourceSpan/ConcreteFileSpan.php
+++ b/src/SourceSpan/ConcreteFileSpan.php
@@ -52,14 +52,14 @@ final class ConcreteFileSpan implements FileSpan
         return $this->end - $this->start;
     }
 
-    public function getStart(): SourceLocation
+    public function getStart(): FileLocation
     {
-        return new SourceLocation($this->file, $this->start);
+        return new FileLocation($this->file, $this->start);
     }
 
-    public function getEnd(): SourceLocation
+    public function getEnd(): FileLocation
     {
-        return new SourceLocation($this->file, $this->end);
+        return new FileLocation($this->file, $this->end);
     }
 
     public function getText(): string

--- a/src/SourceSpan/FileLocation.php
+++ b/src/SourceSpan/FileLocation.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\SourceSpan;
+
+/**
+ * @internal
+ */
+final class FileLocation implements SourceLocation
+{
+    private readonly SourceFile $file;
+
+    private readonly int $offset;
+
+    public function __construct(SourceFile $file, int $offset)
+    {
+        $this->file = $file;
+        $this->offset = $offset;
+    }
+
+    public function getFile(): SourceFile
+    {
+        return $this->file;
+    }
+
+    public function getOffset(): int
+    {
+        return $this->offset;
+    }
+
+    public function getLine(): int
+    {
+        return $this->file->getLine($this->offset);
+    }
+
+    public function getColumn(): int
+    {
+        return $this->file->getColumn($this->offset);
+    }
+
+    public function getSourceUrl(): ?string
+    {
+        return $this->file->getSourceUrl();
+    }
+
+    public function pointSpan(): FileSpan
+    {
+        return new ConcreteFileSpan($this->file, $this->offset, $this->offset);
+    }
+}

--- a/src/SourceSpan/FileSpan.php
+++ b/src/SourceSpan/FileSpan.php
@@ -23,9 +23,9 @@ interface FileSpan
 
     public function getLength(): int;
 
-    public function getStart(): SourceLocation;
+    public function getStart(): FileLocation;
 
-    public function getEnd(): SourceLocation;
+    public function getEnd(): FileLocation;
 
     public function getText(): string;
 

--- a/src/SourceSpan/LazyFileSpan.php
+++ b/src/SourceSpan/LazyFileSpan.php
@@ -65,12 +65,12 @@ class LazyFileSpan implements FileSpan
         return $this->getSpan()->getLength();
     }
 
-    public function getStart(): SourceLocation
+    public function getStart(): FileLocation
     {
         return $this->getSpan()->getStart();
     }
 
-    public function getEnd(): SourceLocation
+    public function getEnd(): FileLocation
     {
         return $this->getSpan()->getEnd();
     }

--- a/src/SourceSpan/SourceFile.php
+++ b/src/SourceSpan/SourceFile.php
@@ -76,7 +76,7 @@ final class SourceFile
         return new ConcreteFileSpan($this, $start, $end);
     }
 
-    public function location(int $offset): SourceLocation
+    public function location(int $offset): FileLocation
     {
         if ($offset < 0) {
             throw new \RangeException("Offset may not be negative, was $offset.");
@@ -88,7 +88,7 @@ final class SourceFile
             throw new \RangeException("Offset $offset must not be greater than the number of characters in the file, $fileLength.");
         }
 
-        return new SourceLocation($this, $offset);
+        return new FileLocation($this, $offset);
     }
 
     public function getSourceUrl(): ?string

--- a/src/SourceSpan/SourceLocation.php
+++ b/src/SourceSpan/SourceLocation.php
@@ -15,54 +15,19 @@ namespace ScssPhp\ScssPhp\SourceSpan;
 /**
  * @internal
  */
-final class SourceLocation
+interface SourceLocation
 {
-    private readonly SourceFile $file;
-
-    private readonly int $offset;
-
-    public function __construct(SourceFile $file, int $offset)
-    {
-        $this->file = $file;
-        $this->offset = $offset;
-    }
-
-    public function getFile(): SourceFile
-    {
-        return $this->file;
-    }
-
-    public function getOffset(): int
-    {
-        return $this->offset;
-    }
+    public function getOffset(): int;
 
     /**
      * The 0-based line of that location
      */
-    public function getLine(): int
-    {
-        return $this->file->getLine($this->offset);
-    }
+    public function getLine(): int;
 
     /**
      * The 0-based column of that location
      */
-    public function getColumn(): int
-    {
-        return $this->file->getColumn($this->offset);
-    }
+    public function getColumn(): int;
 
-    public function getSourceUrl(): ?string
-    {
-        return $this->file->getSourceUrl();
-    }
-
-    /**
-     * Returns a span that covers only a single point: this location.
-     */
-    public function pointSpan(): FileSpan
-    {
-        return new ConcreteFileSpan($this->file, $this->offset, $this->offset);
-    }
+    public function getSourceUrl(): ?string;
 }

--- a/src/SourceSpan/StringSourceLocation.php
+++ b/src/SourceSpan/StringSourceLocation.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\SourceSpan;
+
+/**
+ * @internal
+ */
+final class StringSourceLocation implements SourceLocation
+{
+    /**
+     * @var int
+     * @readonly
+     */
+    private $offset;
+
+    /**
+     * @var string|null
+     * @readonly
+     */
+    private $sourceUrl;
+
+    public function __construct(int $offset, ?string $sourceUrl = null)
+    {
+        $this->offset = $offset;
+        $this->sourceUrl = $sourceUrl;
+    }
+
+    public function getOffset(): int
+    {
+        return $this->offset;
+    }
+
+    public function getLine(): int
+    {
+        return 0;
+    }
+
+    public function getColumn(): int
+    {
+        return $this->offset;
+    }
+
+    public function getSourceUrl(): ?string
+    {
+        return $this->sourceUrl;
+    }
+}

--- a/src/Util.php
+++ b/src/Util.php
@@ -16,6 +16,7 @@ use ScssPhp\ScssPhp\Base\Range;
 use ScssPhp\ScssPhp\Exception\RangeException;
 use ScssPhp\ScssPhp\Node\Number;
 use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+use ScssPhp\ScssPhp\StackTrace\Frame;
 use ScssPhp\ScssPhp\Util\StringUtil;
 
 /**
@@ -82,6 +83,16 @@ final class Util
         $revert = ['%21' => '!', '%2A' => '*', '%27' => "'", '%28' => '(', '%29' => ')'];
 
         return strtr(rawurlencode($string), $revert);
+    }
+
+    public static function frameForSpan(FileSpan $span, string $member, ?string $url = null): Frame
+    {
+        return new Frame(
+            $url ?? $span->getSourceUrl() ?? '-',
+            $span->getStart()->getLine() + 1,
+            $span->getStart()->getColumn() + 1,
+            $member
+        );
     }
 
     /**

--- a/src/Util/EquatableUtil.php
+++ b/src/Util/EquatableUtil.php
@@ -18,9 +18,9 @@ namespace ScssPhp\ScssPhp\Util;
 final class EquatableUtil
 {
     /**
-     * @param list<mixed> $list
+     * @param iterable<mixed> $list
      */
-    public static function listContains(array $list, Equatable $item): bool
+    public static function iterableContains(iterable $list, Equatable $item): bool
     {
         foreach ($list as $listItem) {
             if (!\is_object($listItem)) {

--- a/src/Util/StringUtil.php
+++ b/src/Util/StringUtil.php
@@ -17,6 +17,39 @@ namespace ScssPhp\ScssPhp\Util;
  */
 final class StringUtil
 {
+    /**
+     * @phpstan-param non-empty-array<string> $iter
+     */
+    public static function toSentence(array $iter, string $conjunction = 'and'): string
+    {
+        if (\count($iter) === 1) {
+            return $iter[array_key_first($iter)];
+        }
+
+        $last = array_pop($iter);
+
+        return implode(', ', $iter) . ' ' . $conjunction . ' ' . $last;
+    }
+
+    /**
+     * Returns $name if $number is 1, or the plural of $name otherwise.
+     *
+     * By default, this just adds "s" to the end of $name to get the plural. If
+     * $plural is passed, that's used instead.
+     */
+    public static function pluralize(string $name, int $number, ?string $plural = null): string
+    {
+        if ($number === 1) {
+            return $name;
+        }
+
+        if ($plural !== null) {
+            return $plural;
+        }
+
+        return $name . 's';
+    }
+
     public static function trimAsciiRight(string $string, bool $excludeEscape = false): string
     {
         $end = self::lastNonWhitespace($string, $excludeEscape);

--- a/src/Value/SassCalculation.php
+++ b/src/Value/SassCalculation.php
@@ -17,6 +17,7 @@ use ScssPhp\ScssPhp\Exception\SassScriptException;
 use ScssPhp\ScssPhp\Util\Character;
 use ScssPhp\ScssPhp\Util\Equatable;
 use ScssPhp\ScssPhp\Util\NumberUtil;
+use ScssPhp\ScssPhp\Util\StringUtil;
 use ScssPhp\ScssPhp\Visitor\ValueVisitor;
 use ScssPhp\ScssPhp\Warn;
 
@@ -1125,7 +1126,7 @@ WARNING;
         }
 
         $length = \count($args);
-        $verb = $length === 1 ? 'was' : 'were';
+        $verb = StringUtil::pluralize('was', $length, 'were');
 
         throw new SassScriptException("$expectedLength arguments required, but only $length $verb passed.");
     }

--- a/src/Value/SassCalculation.php
+++ b/src/Value/SassCalculation.php
@@ -745,6 +745,8 @@ WARNING;
      *
      * If $simplify is `false`, no simplification will be done.
      *
+     * @return SassNumber|CalculationOperation|SassString|SassCalculation|Value
+     *
      * @throws SassScriptException
      *
      * @internal

--- a/src/Value/SassFunction.php
+++ b/src/Value/SassFunction.php
@@ -12,6 +12,8 @@
 
 namespace ScssPhp\ScssPhp\Value;
 
+use ScssPhp\ScssPhp\SassCallable\SassCallable;
+use ScssPhp\ScssPhp\Util\EquatableUtil;
 use ScssPhp\ScssPhp\Visitor\ValueVisitor;
 
 /**
@@ -22,23 +24,22 @@ use ScssPhp\ScssPhp\Visitor\ValueVisitor;
  */
 final class SassFunction extends Value
 {
-    // TODO find a better representation of functions, as names won't be unique anymore once modules enter in the equation.
-    private $name;
+    private readonly SassCallable $callable;
 
     /**
      * @internal
      */
-    public function __construct(string $name)
+    public function __construct(SassCallable $callable)
     {
-        $this->name = $name;
+        $this->callable = $callable;
     }
 
     /**
      * @internal
      */
-    public function getName(): string
+    public function getCallable(): SassCallable
     {
-        return $this->name;
+        return $this->callable;
     }
 
     public function accept(ValueVisitor $visitor)
@@ -53,6 +54,6 @@ final class SassFunction extends Value
 
     public function equals(object $other): bool
     {
-        return $other instanceof SassFunction && $this->name === $other->name;
+        return $other instanceof SassFunction && EquatableUtil::equals($this->callable, $other->callable);
     }
 }

--- a/src/Value/SassMixin.php
+++ b/src/Value/SassMixin.php
@@ -12,6 +12,8 @@
 
 namespace ScssPhp\ScssPhp\Value;
 
+use ScssPhp\ScssPhp\SassCallable\SassCallable;
+use ScssPhp\ScssPhp\Util\EquatableUtil;
 use ScssPhp\ScssPhp\Visitor\ValueVisitor;
 
 /**
@@ -22,23 +24,22 @@ use ScssPhp\ScssPhp\Visitor\ValueVisitor;
  */
 final class SassMixin extends Value
 {
-    // TODO find a better representation of mixins, as names won't be unique anymore once modules enter in the equation.
-    private $name;
+    private readonly SassCallable $callable;
 
     /**
      * @internal
      */
-    public function __construct(string $name)
+    public function __construct(SassCallable $callable)
     {
-        $this->name = $name;
+        $this->callable = $callable;
     }
 
     /**
      * @internal
      */
-    public function getName(): string
+    public function getCallable(): SassCallable
     {
-        return $this->name;
+        return $this->callable;
     }
 
     /**
@@ -56,6 +57,6 @@ final class SassMixin extends Value
 
     public function equals(object $other): bool
     {
-        return $other instanceof SassMixin && $this->name === $other->name;
+        return $other instanceof SassMixin && EquatableUtil::equals($this->callable, $other->callable);
     }
 }

--- a/src/Value/SassNull.php
+++ b/src/Value/SassNull.php
@@ -40,6 +40,11 @@ final class SassNull extends Value
         return true;
     }
 
+    public function realNull(): ?Value
+    {
+        return null;
+    }
+
     public function accept(ValueVisitor $visitor)
     {
         return $visitor->visitNull();

--- a/src/Value/SassNumber.php
+++ b/src/Value/SassNumber.php
@@ -15,6 +15,7 @@ namespace ScssPhp\ScssPhp\Value;
 use JiriPudil\SealedClasses\Sealed;
 use ScssPhp\ScssPhp\Exception\SassScriptException;
 use ScssPhp\ScssPhp\Util\NumberUtil;
+use ScssPhp\ScssPhp\Util\StringUtil;
 use ScssPhp\ScssPhp\Visitor\ValueVisitor;
 
 /**
@@ -917,7 +918,7 @@ abstract class SassNumber extends Value
             return SassScriptException::forArgument("Expected $this to have $article $type unit ($supportedUnits).", $name);
         }
 
-        return SassScriptException::forArgument(sprintf('Expected %s to have unit%s %s.', $this, \count($newNumeratorUnits) + \count($newDenominatorUnits) !== 1 ? 's' : '', self::buildUnitString($newNumeratorUnits, $newDenominatorUnits)), $name);
+        return SassScriptException::forArgument(sprintf('Expected %s to have %s %s.', $this, StringUtil::pluralize('unit', \count($newNumeratorUnits) + \count($newDenominatorUnits)), self::buildUnitString($newNumeratorUnits, $newDenominatorUnits)), $name);
     }
 
     /**

--- a/src/Value/Value.php
+++ b/src/Value/Value.php
@@ -471,6 +471,14 @@ WARNING;
     }
 
     /**
+     * Returns PHP's `null` value if this is Sass null, and returns `$this` otherwise
+     */
+    public function realNull(): ?Value
+    {
+        return $this;
+    }
+
+    /**
      * Returns a new list containing $contents that defaults to this value's
      * separator and brackets.
      *

--- a/tests/Value/ValueTestCase.php
+++ b/tests/Value/ValueTestCase.php
@@ -14,6 +14,7 @@ namespace ScssPhp\ScssPhp\Tests\Value;
 
 use PHPUnit\Framework\TestCase;
 use ScssPhp\ScssPhp\Collection\Map;
+use ScssPhp\ScssPhp\SassCallable\PlainCssCallable;
 use ScssPhp\ScssPhp\Value\ListSeparator;
 use ScssPhp\ScssPhp\Value\SassBoolean;
 use ScssPhp\ScssPhp\Value\SassColor;
@@ -60,7 +61,7 @@ abstract class ValueTestCase extends TestCase
             case 'grey':
                 return SassColor::rgb(0x80, 0x80, 0x80);
             case "get-function('red')":
-                return new SassFunction('red');
+                return new SassFunction(new PlainCssCallable('red'));
             case 'foobar':
                 return new SassString('foobar', false);
             case 'a👭b👬c':


### PR DESCRIPTION
This is some work extracted from #709 to make the diff smaller.

Here are the important bits:

- it implements the representation of Sass callables. This PR does not include the `UserDefinedCallable` class which depends on the evaluation system (and will be added in #709 instead).
- it separates `SourceLocation` and `FileLocation` to allow implementing a `StringSourceLocation` which is relevant when processing interpolation with sourcemap tracking