### PR TITLE
Implement global functions for the new evaluation system

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1521,6 +1521,16 @@ parameters:
 			path: src/Formatter/OutputBlock.php
 
 		-
+			message: "#^Parameter \\#2 \\$overloads of static method ScssPhp\\\\ScssPhp\\\\SassCallable\\\\BuiltInCallable\\:\\:overloadedFunction\\(\\) expects array\\<string, callable\\(list\\<ScssPhp\\\\ScssPhp\\\\Value\\\\Value\\>\\)\\: ScssPhp\\\\ScssPhp\\\\Value\\\\Value\\>, 'sass\\:color'\\|'sass\\:list'\\|'sass\\:map'\\|'sass\\:math'\\|'sass\\:meta'\\|'sass\\:selector'\\|'sass\\:string'\\|non\\-empty\\-array\\<literal\\-string, array\\{'ScssPhp\\\\\\\\ScssPhp\\\\\\\\Function\\\\\\\\ColorFunctions', 'adjust'\\|'adjustHue'\\|'alpha'\\|'alphaMicrosoft'\\|'blue'\\|'change'\\|'complement'\\|'darken'\\|'desaturate'\\|'grayscale'\\|'green'\\|'hsl'\\|'hsla'\\|'hslaOneArgs'\\|'hslaTwoArgs'\\|'hslOneArgs'\\|'hslTwoArgs'\\|'hue'\\|'ieHexStr'\\|'invert'\\|'lighten'\\|'lightness'\\|'mix'\\|'opacify'\\|'opacity'\\|'red'\\|'rgb'\\|'rgba'\\|'rgbaOneArgs'\\|'rgbaTwoArgs'\\|'rgbOneArgs'\\|'rgbTwoArgs'\\|'saturate'\\|'saturateCss'\\|'saturation'\\|'scale'\\|'transparentize'\\}\\|array\\{'ScssPhp\\\\\\\\ScssPhp\\\\\\\\Function\\\\\\\\ListFunctions'\\|'ScssPhp\\\\\\\\ScssPhp\\\\\\\\Function\\\\\\\\SelectorFunctions'\\|'ScssPhp\\\\\\\\ScssPhp\\\\\\\\Function\\\\\\\\StringFunctions', 'append'\\|'extend'\\|'index'\\|'insert'\\|'isBracketed'\\|'isSuperselector'\\|'join'\\|'length'\\|'nest'\\|'nth'\\|'parse'\\|'quote'\\|'replace'\\|'separator'\\|'setNth'\\|'simpleSelectors'\\|'slice'\\|'toLowerCase'\\|'toUpperCase'\\|'unify'\\|'uniqueId'\\|'unquote'\\|'zip'\\}\\|array\\{'ScssPhp\\\\\\\\ScssPhp\\\\\\\\Function\\\\\\\\MapFunctions', 'get'\\|'hasKey'\\|'keys'\\|'mergeTwoArgs'\\|'mergeVariadic'\\|'remove'\\|'removeNoKeys'\\|'values'\\}\\|array\\{'ScssPhp\\\\\\\\ScssPhp\\\\\\\\Function\\\\\\\\MathFunctions', 'abs'\\|'ceil'\\|'compatible'\\|'floor'\\|'isUnitless'\\|'max'\\|'min'\\|'percentage'\\|'random'\\|'round'\\|'unit'\\}\\|array\\{'ScssPhp\\\\\\\\ScssPhp\\\\\\\\Function\\\\\\\\MetaFunctions', 'featureExists'\\|'inspect'\\|'typeof'\\}\\> given\\.$#"
+			count: 1
+			path: src/Function/FunctionRegistry.php
+
+		-
+			message: "#^Parameter \\#3 \\$url of static method ScssPhp\\\\ScssPhp\\\\SassCallable\\\\BuiltInCallable\\:\\:overloadedFunction\\(\\) expects string\\|null, array\\<string, array\\<int, string\\>\\>\\|string given\\.$#"
+			count: 1
+			path: src/Function/FunctionRegistry.php
+
+		-
 			message: "#^Method ScssPhp\\\\ScssPhp\\\\Importer\\\\FilesystemImporter\\:\\:load\\(\\) never returns null so it can be removed from the return type\\.$#"
 			count: 1
 			path: src/Importer/FilesystemImporter.php

--- a/src/Collection/Map.php
+++ b/src/Collection/Map.php
@@ -102,6 +102,11 @@ final class Map implements \Countable, \IteratorAggregate
         return null;
     }
 
+    public function containsKey(Value $key): bool
+    {
+        return $this->get($key) !== null;
+    }
+
     /**
      * Associates the key with the given value.
      *
@@ -149,6 +154,34 @@ final class Map implements \Countable, \IteratorAggregate
         }
 
         return null;
+    }
+
+    /**
+     * @return list<Value>
+     */
+    public function keys(): array
+    {
+        $keys = [];
+
+        foreach ($this->pairs as $pair) {
+            $keys[] = $pair[0];
+        }
+
+        return $keys;
+    }
+
+    /**
+     * @return list<T>
+     */
+    public function values(): array
+    {
+        $values = [];
+
+        foreach ($this->pairs as $pair) {
+            $values[] = $pair[1];
+        }
+
+        return $values;
     }
 
     private function assertModifiable(): void

--- a/src/Evaluation/EvaluationContext.php
+++ b/src/Evaluation/EvaluationContext.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Evaluation;
+
+use ScssPhp\ScssPhp\Deprecation;
+use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+
+/**
+ * @internal
+ */
+abstract class EvaluationContext
+{
+    private static ?EvaluationContext $evaluationContext = null;
+
+    /**
+     * The current evaluation context.
+     *
+     * @throws \LogicException if there isn't a Sass stylesheet currently being
+     * evaluated.
+     */
+    public static function getCurrent(): EvaluationContext
+    {
+        if (self::$evaluationContext !== null) {
+            return self::$evaluationContext;
+        }
+
+        throw new \LogicException('No Sass stylesheet is currently being evaluated.');
+    }
+
+    /**
+     * Runs $callback with $context as {@see EvaluationContext::getCurrent()}.
+     *
+     * @template T
+     *
+     * @param callable(): T $callback
+     *
+     * @return T
+     */
+    public static function withEvaluationContext(EvaluationContext $context, callable $callback)
+    {
+        $oldContext = self::$evaluationContext;
+        self::$evaluationContext = $context;
+
+        try {
+            return $callback();
+        } finally {
+            self::$evaluationContext = $oldContext;
+        }
+    }
+
+    /**
+     * Returns the span for the currently executing callable.
+     *
+     * For normal exception reporting, this should be avoided in favor of
+     * throwing {@see SassScriptException}s. It should only be used when calling APIs
+     * that require spans.
+     *
+     * @throws \LogicException if there isn't a callable being invoked.
+     */
+    abstract public function getCurrentCallableSpan(): FileSpan;
+
+    /**
+     * Prints a warning message associated with the current `@import` or function
+     * call.
+     *
+     * If $deprecation is non-null`, the warning is emitted as a deprecation
+     * warning of that type.
+     */
+    abstract public function warn(string $message, ?Deprecation $deprecation = null): void;
+}

--- a/src/Function/ColorFunctions.php
+++ b/src/Function/ColorFunctions.php
@@ -1,0 +1,883 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Function;
+
+use ScssPhp\ScssPhp\Deprecation;
+use ScssPhp\ScssPhp\Exception\SassScriptException;
+use ScssPhp\ScssPhp\Util\IterableUtil;
+use ScssPhp\ScssPhp\Util\NumberUtil;
+use ScssPhp\ScssPhp\Util\StringUtil;
+use ScssPhp\ScssPhp\Value\ColorFormatEnum;
+use ScssPhp\ScssPhp\Value\ListSeparator;
+use ScssPhp\ScssPhp\Value\SassArgumentList;
+use ScssPhp\ScssPhp\Value\SassColor;
+use ScssPhp\ScssPhp\Value\SassNumber;
+use ScssPhp\ScssPhp\Value\SassString;
+use ScssPhp\ScssPhp\Value\Value;
+use ScssPhp\ScssPhp\Warn;
+
+/**
+ * @internal
+ */
+class ColorFunctions
+{
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function rgb(array $arguments): Value
+    {
+        return self::rgbImpl('rgb', $arguments);
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function rgbTwoArgs(array $arguments): Value
+    {
+        return self::rgbTwoArgsImpl('rgb', $arguments);
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function rgbOneArgs(array $arguments): Value
+    {
+        $parsed = self::parseChannels('rgb', ['$red', '$green', '$blue'], $arguments[0]);
+
+        return $parsed instanceof SassString ? $parsed : self::rgbImpl('rgb', $parsed);
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function rgba(array $arguments): Value
+    {
+        return self::rgbImpl('rgba', $arguments);
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function rgbaTwoArgs(array $arguments): Value
+    {
+        return self::rgbTwoArgsImpl('rgba', $arguments);
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function rgbaOneArgs(array $arguments): Value
+    {
+        $parsed = self::parseChannels('rgba', ['$red', '$green', '$blue'], $arguments[0]);
+
+        return $parsed instanceof SassString ? $parsed : self::rgbImpl('rgba', $parsed);
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function invert(array $arguments): Value
+    {
+        $weight = $arguments[1]->assertNumber('weight');
+        if ($arguments[0] instanceof SassNumber || $arguments[0]->isSpecialNumber()) {
+            if ($weight->getValue() !== 100.0 || !$weight->hasUnit('%')) {
+                throw new SassScriptException('Only one argument may be passed to the plain-CSS invert() function.');
+            }
+
+            // Use the native CSS `invert` filter function.
+            return self::functionString('invert', $arguments);
+        }
+
+        $color = $arguments[0]->assertColor('color');
+        $inverse = $color->changeRgb(255 - $color->getRed(), 255 - $color->getGreen(), 255 - $color->getBlue());
+
+        return self::mixColors($inverse, $color, $weight);
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function hsl(array $arguments): Value
+    {
+        return self::hslImpl('hsl', $arguments);
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function hslTwoArgs(array $arguments): Value
+    {
+        // hsl(123, var(--foo)) is valid CSS because --foo might be `10%, 20%` and
+        // functions are parsed after variable substitution.
+        if ($arguments[0]->isVar() || $arguments[1]->isVar()) {
+            return self::functionString('hsl', $arguments);
+        }
+
+        throw new SassScriptException('Missing argument $lightness.');
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function hslOneArgs(array $arguments): Value
+    {
+        $parsed = self::parseChannels('hsl', ['$hue', '$saturation', '$lightness'], $arguments[0]);
+
+        return $parsed instanceof SassString ? $parsed : self::hslImpl('hsl', $parsed);
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function hsla(array $arguments): Value
+    {
+        return self::hslImpl('hsla', $arguments);
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function hslaTwoArgs(array $arguments): Value
+    {
+        // hsl(123, var(--foo)) is valid CSS because --foo might be `10%, 20%` and
+        // functions are parsed after variable substitution.
+        if ($arguments[0]->isVar() || $arguments[1]->isVar()) {
+            return self::functionString('hsla', $arguments);
+        }
+
+        throw new SassScriptException('Missing argument $lightness.');
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function hslaOneArgs(array $arguments): Value
+    {
+        $parsed = self::parseChannels('hsla', ['$hue', '$saturation', '$lightness'], $arguments[0]);
+
+        return $parsed instanceof SassString ? $parsed : self::hslImpl('hsla', $parsed);
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function grayscale(array $arguments): Value
+    {
+        if ($arguments[0] instanceof SassNumber || $arguments[0]->isSpecialNumber()) {
+            // Use the native CSS `grayscale` filter function.
+            return self::functionString('grayscale', $arguments);
+        }
+
+        $color = $arguments[0]->assertColor('color');
+
+        return $color->changeHsl(saturation: 0);
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function adjustHue(array $arguments): Value
+    {
+        $color = $arguments[0]->assertColor('color');
+        $degrees = self::angleValue($arguments[1], 'degrees');
+
+        return $color->changeHsl(hue: $color->getHue() + $degrees);
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function lighten(array $arguments): Value
+    {
+        $color = $arguments[0]->assertColor('color');
+        $amount = $arguments[1]->assertNumber('amount');
+
+        return $color->changeHsl(lightness: NumberUtil::clamp($color->getLightness() + $amount->valueInRange(0, 100, 'amount'), 0, 100));
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function darken(array $arguments): Value
+    {
+        $color = $arguments[0]->assertColor('color');
+        $amount = $arguments[1]->assertNumber('amount');
+
+        return $color->changeHsl(lightness: NumberUtil::clamp($color->getLightness() - $amount->valueInRange(0, 100, 'amount'), 0, 100));
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function saturateCss(array $arguments): Value
+    {
+        if ($arguments[0] instanceof SassNumber || $arguments[0]->isSpecialNumber()) {
+            // Use the native CSS `saturate` filter function.
+            return self::functionString('saturate', $arguments);
+        }
+
+        $number = $arguments[0]->assertNumber('amount');
+
+        return new SassString('saturate(' . $number->toCssString() . ')', false);
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function saturate(array $arguments): Value
+    {
+        $color = $arguments[0]->assertColor('color');
+        $amount = $arguments[1]->assertNumber('amount');
+
+        return $color->changeHsl(saturation: NumberUtil::clamp($color->getSaturation() + $amount->valueInRange(0, 100, 'amount'), 0, 100));
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function desaturate(array $arguments): Value
+    {
+        $color = $arguments[0]->assertColor('color');
+        $amount = $arguments[1]->assertNumber('amount');
+
+        return $color->changeHsl(saturation: NumberUtil::clamp($color->getSaturation() - $amount->valueInRange(0, 100, 'amount'), 0, 100));
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function alpha(array $arguments): Value
+    {
+        $argument = $arguments[0];
+        if ($argument instanceof SassString && !$argument->hasQuotes() && preg_match('/^[a-zA-Z]+\s*=/', $argument->getText())) {
+            // Support the proprietary Microsoft alpha() function.
+            return self::functionString('alpha', $arguments);
+        }
+
+        $color = $arguments[0]->assertColor('color');
+
+        return SassNumber::create($color->getAlpha());
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function alphaMicrosoft(array $arguments): Value
+    {
+        $argList = $arguments[0]->asList();
+        $argumentCount = \count($argList);
+
+        if ($argumentCount > 0 && IterableUtil::every($argList, fn($argument) => $argument instanceof SassString && !$argument->hasQuotes() && preg_match('/^[a-zA-Z]+\s*=/', $argument->getText()))) {
+            // Support the proprietary Microsoft alpha() function.
+            return self::functionString('alpha', $arguments);
+        }
+
+        \assert($argumentCount !== 1);
+
+        if ($argumentCount === 0) {
+            throw new SassScriptException('Missing argument $color.');
+        }
+
+        throw new SassScriptException("Only 1 argument allowed, but $argumentCount were passed.");
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function opacity(array $arguments): Value
+    {
+        if ($arguments[0] instanceof SassNumber || $arguments[0]->isSpecialNumber()) {
+            // Use the native CSS `opacity` filter function.
+            return self::functionString('opacity', $arguments);
+        }
+
+        $color = $arguments[0]->assertColor('color');
+
+        return SassNumber::create($color->getAlpha());
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function red(array $arguments): Value
+    {
+        return SassNumber::create($arguments[0]->assertColor('color')->getRed());
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function green(array $arguments): Value
+    {
+        return SassNumber::create($arguments[0]->assertColor('color')->getGreen());
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function blue(array $arguments): Value
+    {
+        return SassNumber::create($arguments[0]->assertColor('color')->getBlue());
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function mix(array $arguments): Value
+    {
+        $color1 = $arguments[0]->assertColor('color1');
+        $color2 = $arguments[1]->assertColor('color2');
+        $weight = $arguments[2]->assertNumber('weight');
+
+        return self::mixColors($color1, $color2, $weight);
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function hue(array $arguments): Value
+    {
+        return SassNumber::create($arguments[0]->assertColor('color')->getHue(), 'deg');
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function saturation(array $arguments): Value
+    {
+        return SassNumber::create($arguments[0]->assertColor('color')->getSaturation(), '%');
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function lightness(array $arguments): Value
+    {
+        return SassNumber::create($arguments[0]->assertColor('color')->getLightness(), '%');
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function complement(array $arguments): Value
+    {
+        $color = $arguments[0]->assertColor('color');
+
+        return $color->changeHsl(hue: $color->getHue() + 180);
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function adjust(array $arguments): Value
+    {
+        return self::updateComponents($arguments, adjust: true);
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function scale(array $arguments): Value
+    {
+        return self::updateComponents($arguments, scale: true);
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function change(array $arguments): Value
+    {
+        return self::updateComponents($arguments, change: true);
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function ieHexStr(array $arguments): Value
+    {
+        $color = $arguments[0]->assertColor('color');
+        return new SassString('#' . self::hexString(NumberUtil::fuzzyRound($color->getAlpha() * 255)) . self::hexString($color->getRed()) . self::hexString($color->getGreen()) . self::hexString($color->getBlue()), false);
+    }
+
+    private static function hexString(int $component): string
+    {
+        return strtoupper(str_pad(dechex($component), 2, '0', STR_PAD_LEFT));
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    private static function updateComponents(array $arguments, bool $change = false, bool $adjust = false, bool $scale = false): SassColor
+    {
+        \assert(\count(array_filter([$change, $adjust, $scale])) === 1);
+
+        $color = $arguments[0]->assertColor('color');
+        $argumentList = $arguments[1];
+        \assert($argumentList instanceof SassArgumentList);
+
+        if (\count($argumentList->asList()) > 0) {
+            throw new SassScriptException('Only one positional argument is allowed. All other arguments must be passed by name.');
+        }
+
+        $keywords = $argumentList->getKeywords();
+
+        $getParam = function (string $name, float $max, bool $checkPercent = false, bool $assertPercent = false, bool $checkUnitless = false) use (&$keywords, $change, $scale): ?float {
+            $number = ($keywords[$name] ?? null)?->assertNumber($name);
+            unset($keywords[$name]);
+
+            if ($number === null) {
+                return null;
+            }
+
+            if (!$scale && $checkUnitless) {
+                if ($number->hasUnits()) {
+                    Warn::forDeprecation(
+                        <<<TXT
+\$$name: Passing a number with unit {$number->getUnitString()} is deprecated.
+
+To preserve current behavior: {$number->unitSuggestion($name)}
+
+More info: https://sass-lang.com/d/function-units
+TXT,
+                        Deprecation::functionUnits
+                    );
+                }
+            }
+            if (!$scale && $checkPercent) {
+                self::checkPercent($number, $name);
+            }
+            if ($scale || $assertPercent) {
+                $number->assertUnit('%', $name);
+            }
+            if ($scale) {
+                $max = 100;
+            }
+
+            return $scale || $assertPercent
+                ? $number->valueInRange($change ? 0 : -$max, $max, $name)
+                : $number->valueInRangeWithUnit($change ? 0 : -$max, $max, $name, $checkPercent ? '%' : '');
+        };
+
+        $alpha = $getParam('alpha', 1, checkUnitless: true);
+        $red = $getParam('red', 255);
+        $green = $getParam('green', 255);
+        $blue = $getParam('blue', 255);
+
+        if ($scale) {
+            $hue = null;
+        } else {
+            $hueValue = $keywords['hue'] ?? null;
+            unset($keywords['hue']);
+            $hue = $hueValue === null ? null : self::angleValue($hueValue, 'hue');
+        }
+
+        $saturation = $getParam('saturation', 100, checkPercent: true);
+        $lightness = $getParam('lightness', 100, checkPercent: true);
+        $whiteness = $getParam('whiteness', 100, assertPercent: true);
+        $blackness = $getParam('blackness', 100, assertPercent: true);
+
+        if (\count($keywords) > 0) {
+            throw new SassScriptException(sprintf(
+                'No %s named %s.',
+                StringUtil::pluralize('argument', \count($keywords)),
+                StringUtil::toSentence(array_map(fn($name) => "\$$name", array_keys($keywords)), 'or')
+            ));
+        }
+
+        $hasRgb = $red !== null || $green !== null || $blue !== null;
+        $hasSL = $saturation !== null || $lightness !== null;
+        $hasWB = $whiteness !== null || $blackness !== null;
+
+        if ($hasRgb && ($hasSL || $hasWB || $hue !== null)) {
+            $format = $hasWB ? 'HWB' : 'HSL';
+            throw new SassScriptException("RGB parameters may not be passed along with $format parameters.");
+        }
+
+        if ($hasSL && $hasWB) {
+            throw new SassScriptException('HSL parameters may not be passed along with HWB parameters.');
+        }
+
+        $updateValue = function (float $current, ?float $param, float $max) use ($change, $adjust): float {
+            if ($param === null) {
+                return $current;
+            }
+
+            if ($change) {
+                return $param;
+            }
+
+            if ($adjust) {
+                return NumberUtil::clamp($current + $param, 0, $max);
+            }
+
+            return $current + ($param > 0 ? $max - $current : $current) * $param / 100;
+        };
+
+        $updateRgb = function (int $current, ?float $param) use ($updateValue): int {
+            return NumberUtil::fuzzyRound($updateValue($current, $param, 255));
+        };
+
+        if ($hasRgb) {
+            return $color->changeRgb(
+                $updateRgb($color->getRed(), $red),
+                $updateRgb($color->getGreen(), $green),
+                $updateRgb($color->getBlue(), $blue),
+                $updateValue($color->getAlpha(), $alpha, 1)
+            );
+        }
+
+        if ($hasWB) {
+            return $color->changeHwb(
+                $change ? $hue : $color->getHue() + ($hue ?? 0),
+                $updateValue($color->getWhiteness(), $whiteness, 100),
+                $updateValue($color->getBlackness(), $blackness, 100),
+                $updateValue($color->getAlpha(), $alpha, 1)
+            );
+        }
+
+        if ($hue !== null || $hasSL) {
+            return $color->changeHsl(
+                $change ? $hue : $color->getHue() + ($hue ?? 0),
+                $updateValue($color->getSaturation(), $saturation, 100),
+                $updateValue($color->getLightness(), $lightness, 100),
+                $updateValue($color->getAlpha(), $alpha, 1)
+            );
+        }
+
+        if ($alpha !== null) {
+            return $color->changeAlpha($updateValue($color->getAlpha(), $alpha, 1));
+        }
+
+        return $color;
+    }
+
+    /**
+     * Returns a string representation of $name called with $arguments, as though
+     * it were a plain CSS function.
+     *
+     * @param Value[] $arguments
+     */
+    private static function functionString(string $name, array $arguments): SassString
+    {
+        return new SassString($name . '(' . implode(', ', array_map(fn(Value $argument) => $argument->toCssString(), $arguments)) . ')', false);
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    private static function rgbImpl(string $name, array $arguments): Value
+    {
+        $alpha = $arguments[3] ?? null;
+
+        if ($arguments[0]->isSpecialNumber() || $arguments[1]->isSpecialNumber() || $arguments[2]->isSpecialNumber() || ($alpha?->isSpecialNumber() ?? false)) {
+            return self::functionString($name, $arguments);
+        }
+
+        $red = $arguments[0]->assertNumber('red');
+        $green = $arguments[1]->assertNumber('green');
+        $blue = $arguments[2]->assertNumber('blue');
+
+        return SassColor::rgbInternal(
+            NumberUtil::fuzzyRound(self::percentageOrUnitless($red, 255, 'red')),
+            NumberUtil::fuzzyRound(self::percentageOrUnitless($green, 255, 'green')),
+            NumberUtil::fuzzyRound(self::percentageOrUnitless($blue, 255, 'blue')),
+            $alpha !== null ? self::percentageOrUnitless($alpha->assertNumber('alpha'), 1, 'alpha') : 1,
+            ColorFormatEnum::rgbFunction
+        );
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    private static function rgbTwoArgsImpl(string $name, array $arguments): Value
+    {
+        // rgba(var(--foo), 0.5) is valid CSS because --foo might be `123, 456, 789`
+        // and functions are parsed after variable substitution.
+        if ($arguments[0]->isVar() || (!$arguments[0] instanceof SassColor && $arguments[1]->isVar())) {
+            return self::functionString($name, $arguments);
+        }
+
+        if ($arguments[1]->isSpecialNumber()) {
+            $color = $arguments[0]->assertColor('color');
+
+            return new SassString("$name({$color->getRed()}, {$color->getGreen()}, {$color->getBlue()}, {$arguments[1]->toCssString()})", false);
+        }
+
+        $color = $arguments[0]->assertColor('color');
+        $alpha = $arguments[1]->assertNumber('alpha');
+
+        return $color->changeAlpha(self::percentageOrUnitless($alpha, 1, 'alpha'));
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    private static function hslImpl(string $name, array $arguments): Value
+    {
+        $alpha = $arguments[3] ?? null;
+
+        if ($arguments[0]->isSpecialNumber() || $arguments[1]->isSpecialNumber() || $arguments[2]->isSpecialNumber() || ($alpha?->isSpecialNumber() ?? false)) {
+            return self::functionString($name, $arguments);
+        }
+
+        $hue = self::angleValue($arguments[0], 'hue');
+        $saturation = $arguments[1]->assertNumber('saturation');
+        $lightness = $arguments[2]->assertNumber('lightness');
+
+        return SassColor::hslInternal(
+            $hue,
+            NumberUtil::clamp($saturation->getValue(), 0, 100),
+            NumberUtil::clamp($lightness->getValue(), 0, 100),
+            $alpha !== null ? self::percentageOrUnitless($alpha->assertNumber('alpha'), 1, 'alpha') : 1,
+            ColorFormatEnum::hslFunction
+        );
+    }
+
+    /**
+     * Asserts that $angle is a number and returns its value in degrees.
+     *
+     * Prints a deprecation warning if $angle has a non-angle unit.
+     */
+    private static function angleValue(Value $angleValue, string $name): float
+    {
+        $angle = $angleValue->assertNumber($name);
+
+        if ($angle->compatibleWithUnit('deg')) {
+            return $angle->coerceValueToUnit('deg');
+        }
+
+        Warn::forDeprecation(
+            <<<TXT
+\$$name: Passing a unit other than deg ($angle) is deprecated.
+
+To preserve current behavior: {$angle->unitSuggestion($name)}
+
+See https://sass-lang.com/d/function-units
+TXT,
+            Deprecation::functionUnits
+        );
+
+        return $angle->getValue();
+    }
+
+    private static function checkPercent(SassNumber $number, string $name): void
+    {
+        if ($number->hasUnit('%')) {
+            return;
+        }
+
+        Warn::forDeprecation(
+            <<<TXT
+\$$name: Passing a number without unit % ($number) is deprecated.
+
+To preserve current behavior: {$number->unitSuggestion($name, '%')}
+
+More info: https://sass-lang.com/d/function-units
+TXT,
+            Deprecation::functionUnits
+        );
+    }
+
+    /**
+     * @param list<string> $argumentNames
+     *
+     * @return SassString|list<Value>
+     */
+    private static function parseChannels(string $name, array $argumentNames, Value $channels): SassString|array
+    {
+        if ($channels->isVar()) {
+            return self::functionString($name, [$channels]);
+        }
+
+        $originalChannels = $channels;
+        $alphaFromSlashList = null;
+
+        if ($channels->getSeparator() === ListSeparator::SLASH) {
+            $list = $channels->asList();
+
+            if (\count($list) !== 2) {
+                throw new SassScriptException(sprintf(
+                    'Only 2 slash-separated elements allowed, but %s %s passed.',
+                    \count($list),
+                    StringUtil::pluralize('was', \count($list), 'were')
+                ));
+            }
+
+            $channels = $list[0];
+            $alphaFromSlashList = $list[1];
+
+            if (!$alphaFromSlashList->isSpecialNumber()) {
+                $alphaFromSlashList->assertNumber('alpha');
+            }
+
+            if ($list[0]->isVar()) {
+                return self::functionString($name, [$originalChannels]);
+            }
+        }
+
+        $isCommaSeparated = $channels->getSeparator() === ListSeparator::COMMA;
+        $isBracketed = $channels->hasBrackets();
+
+        if ($isCommaSeparated || $isBracketed) {
+            $buffer = '$channels must be';
+            if ($isBracketed) {
+                $buffer .= ' an unbracketed';
+            }
+            if ($isCommaSeparated) {
+                $buffer .= $isBracketed ? ',' : ' a';
+                $buffer .= ' space-separated';
+            }
+
+            $buffer .= ' list.';
+
+            throw new SassScriptException($buffer);
+        }
+
+        $list = $channels->asList();
+
+        if (\count($list) >= 2 && $list[0] instanceof SassString && !$list[0]->hasQuotes() && StringUtil::equalsIgnoreCase($list[0]->getText(), 'from')) {
+            return self::functionString($name, [$originalChannels]);
+        }
+
+        if (\count($list) > 3) {
+            throw new SassScriptException(sprintf(
+                'Only 3 elements allowed, but %s were passed',
+                \count($list)
+            ));
+        }
+
+        if (\count($list) < 3) {
+            if (IterableUtil::any($list, fn (Value $value) => $value->isVar()) || (\count($list) > 0 && self::isVarSlash($list[0]))) {
+                return self::functionString($name, [$originalChannels]);
+            }
+
+            $argument = $argumentNames[\count($list)];
+
+            throw new SassScriptException("Missing element $argument.");
+        }
+
+        if ($alphaFromSlashList !== null) {
+            return [...$list, $alphaFromSlashList];
+        }
+
+        if ($list[2] instanceof SassNumber && $list[2]->getAsSlash() !== null) {
+            [$channel3, $alpha] = $list[2]->getAsSlash();
+
+            return [$list[0], $list[1], $channel3, $alpha];
+        }
+
+        if ($list[2] instanceof SassString && !$list[2]->hasQuotes() && str_contains($list[2]->getText(), '/')) {
+            return self::functionString($name, [$channels]);
+        }
+
+        return $list;
+    }
+
+    /**
+     * Returns whether $value is an unquoted string that start with `var(` and
+     * contains `/`.
+     */
+    private static function isVarSlash(Value $value): bool
+    {
+        return $value instanceof SassString && $value->hasQuotes() && StringUtil::startsWithIgnoreCase($value->getText(), 'var(') && str_contains($value->getText(), '/');
+    }
+
+    /**
+     * Asserts that $number is a percentage or has no units, and normalizes the
+     * value.
+     *
+     * If $number has no units, its value is clamped to be greater than `0` or
+     * less than $max and returned. If $number is a percentage, it's scaled to be
+     * within `0` and $max. Otherwise, this throws a {@see SassScriptException}.
+     *
+     * $name is used to identify the argument in the error message.
+     */
+    private static function percentageOrUnitless(SassNumber $number, float $max, string $name): float
+    {
+        if (!$number->hasUnits()) {
+            $value = $number->getValue();
+        } elseif ($number->hasUnit('%')) {
+            $value = $max * $number->getValue() / 100;
+        } else {
+            throw new SassScriptException("\$$name: Expected $number to have unit \"%\" or no units.");
+        }
+
+        return NumberUtil::clamp($value, 0, $max);
+    }
+
+    private static function mixColors(SassColor $color1, SassColor $color2, SassNumber $weight): SassColor
+    {
+        self::checkPercent($weight, 'weight');
+
+        // This algorithm factors in both the user-provided weight (w) and the
+        // difference between the alpha values of the two colors (a) to decide how
+        // to perform the weighted average of the two RGB values.
+        //
+        // It works by first normalizing both parameters to be within [-1, 1], where
+        // 1 indicates "only use color1", -1 indicates "only use color2", and all
+        // values in between indicated a proportionately weighted average.
+        //
+        // Once we have the normalized variables w and a, we apply the formula
+        // (w + a)/(1 + w*a) to get the combined weight (in [-1, 1]) of color1. This
+        // formula has two especially nice properties:
+        //
+        //   * When either w or a are -1 or 1, the combined weight is also that
+        //     number (cases where w * a == -1 are undefined, and handled as a
+        //     special case).
+        //
+        //   * When a is 0, the combined weight is w, and vice versa.
+        //
+        // Finally, the weight of color1 is renormalized to be within [0, 1] and the
+        // weight of color2 is given by 1 minus the weight of color1.
+
+        $weightScale = $weight->valueInRange(0, 100, 'weight') / 100;
+        $normalizedWeight = $weightScale * 2 - 1;
+        $alphaDistance = $color1->getAlpha() - $color2->getAlpha();
+
+        $combinedWeight1 = $normalizedWeight * $alphaDistance == -1
+            ? $normalizedWeight
+            : ($normalizedWeight + $alphaDistance) / (1 + $normalizedWeight * $alphaDistance);
+
+        $weight1 = ($combinedWeight1 + 1) / 2;
+        $weight2 = 1 - $weight1;
+
+        return SassColor::rgb(
+            NumberUtil::fuzzyRound($color1->getRed() * $weight1 + $color2->getRed() * $weight2),
+            NumberUtil::fuzzyRound($color1->getGreen() * $weight1 + $color2->getGreen() * $weight2),
+            NumberUtil::fuzzyRound($color1->getBlue() * $weight1 + $color2->getBlue() * $weight2),
+            $color1->getAlpha() * $weightScale + $color2->getAlpha() * (1 -  $weightScale)
+        );
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function opacify(array $arguments): SassColor
+    {
+        $color = $arguments[0]->assertColor('color');
+        $amount = $arguments[1]->assertNumber('amount');
+
+        return $color->changeAlpha(NumberUtil::clamp($color->getAlpha() + $amount->valueInRangeWithUnit(0, 1, 'amount', ''), 0, 1));
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function transparentize(array $arguments): SassColor
+    {
+        $color = $arguments[0]->assertColor('color');
+        $amount = $arguments[1]->assertNumber('amount');
+
+        return $color->changeAlpha(NumberUtil::clamp($color->getAlpha() - $amount->valueInRangeWithUnit(0, 1, 'amount', ''), 0, 1));
+    }
+}

--- a/src/Function/FunctionRegistry.php
+++ b/src/Function/FunctionRegistry.php
@@ -24,6 +24,16 @@ class FunctionRegistry
      * @var array<string, array{overloads: array<string, callable(list<Value>): Value>, url: string}>
      */
     private const BUILTIN_FUNCTIONS = [
+        // sass:list
+        'length' => ['overloads' => ['$list' => [ListFunctions::class, 'length']], 'url' => 'sass:list'],
+        'nth' => ['overloads' => ['$list, $n' => [ListFunctions::class, 'nth']], 'url' => 'sass:list'],
+        'set-nth' => ['overloads' => ['$list, $n, $value' => [ListFunctions::class, 'setNth']], 'url' => 'sass:list'],
+        'join' => ['overloads' => ['$list1, $list2, $separator: auto, $bracketed: auto' => [ListFunctions::class, 'join']], 'url' => 'sass:list'],
+        'append' => ['overloads' => ['$list, $val, $separator: auto' => [ListFunctions::class, 'append']], 'url' => 'sass:list'],
+        'zip' => ['overloads' => ['$lists...' => [ListFunctions::class, 'zip']], 'url' => 'sass:list'],
+        'index' => ['overloads' => ['$list, $value' => [ListFunctions::class, 'index']], 'url' => 'sass:list'],
+        'is-bracketed' => ['overloads' => ['$list' => [ListFunctions::class, 'isBracketed']], 'url' => 'sass:list'],
+        'list-separator' => ['overloads' => ['$list' => [ListFunctions::class, 'separator']], 'url' => 'sass:list'],
         // sass:map
         'map-get' => ['overloads' => ['$map, $key, $keys...' => [MapFunctions::class, 'get']], 'url' => 'sass:map'],
         'map-merge' => ['overloads' => [

--- a/src/Function/FunctionRegistry.php
+++ b/src/Function/FunctionRegistry.php
@@ -24,6 +24,24 @@ class FunctionRegistry
      * @var array<string, array{overloads: array<string, callable(list<Value>): Value>, url: string}>
      */
     private const BUILTIN_FUNCTIONS = [
+        // sass:map
+        'map-get' => ['overloads' => ['$map, $key, $keys...' => [MapFunctions::class, 'get']], 'url' => 'sass:map'],
+        'map-merge' => ['overloads' => [
+            '$map1, $map2' => [MapFunctions::class, 'mergeTwoArgs'],
+            '$map1, $args...' => [MapFunctions::class, 'mergeVariadic'],
+        ], 'url' => 'sass:map'],
+        'map-remove' => ['overloads' => [
+            // Because the signature below has an explicit `$key` argument, it doesn't
+            // allow zero keys to be passed. We want to allow that case, so we add an
+            // explicit overload for it.
+            '$map' => [MapFunctions::class, 'removeNoKeys'],
+            // The first argument has special handling so that the $key parameter can be
+            // passed by name.
+            '$map, $key, $keys...' => [MapFunctions::class, 'remove'],
+        ], 'url' => 'sass:map'],
+        'map-keys' => ['overloads' => ['$map' => [MapFunctions::class, 'keys']], 'url' => 'sass:map'],
+        'map-values' => ['overloads' => ['$map' => [MapFunctions::class, 'values']], 'url' => 'sass:map'],
+        'map-has-key' => ['overloads' => ['map, $key, $keys...' => [MapFunctions::class, 'hasKey']], 'url' => 'sass:map'],
         // sass:math
         'abs' => ['overloads' => ['$number' => [MathFunctions::class, 'abs']], 'url' => 'sass:math'],
         'ceil' => ['overloads' => ['$number' => [MathFunctions::class, 'ceil']], 'url' => 'sass:math'],

--- a/src/Function/FunctionRegistry.php
+++ b/src/Function/FunctionRegistry.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Function;
+
+use ScssPhp\ScssPhp\SassCallable\BuiltInCallable;
+use ScssPhp\ScssPhp\Value\Value;
+
+/**
+ * @internal
+ */
+class FunctionRegistry
+{
+    /**
+     * @var array<string, array{overloads: array<string, callable(list<Value>): Value>, url: string}>
+     */
+    private const BUILTIN_FUNCTIONS = [
+        // sass:meta
+        'feature-exists' => ['overloads' => ['$feature' => [MetaFunctions::class, 'featureExists']], 'url' => 'sass:meta'],
+        'inspect' => ['overloads' => ['$value' => [MetaFunctions::class, 'inspect']], 'url' => 'sass:meta'],
+        'type-of' => ['overloads' => ['$value' => [MetaFunctions::class, 'typeof']], 'url' => 'sass:meta'],
+    ];
+
+    public static function has(string $name): bool
+    {
+        return isset(self::BUILTIN_FUNCTIONS[$name]);
+    }
+
+    public static function get(string $name): BuiltInCallable
+    {
+        if (!isset(self::BUILTIN_FUNCTIONS[$name])) {
+            throw new \InvalidArgumentException("There is no builtin function named $name.");
+        }
+
+        return BuiltInCallable::overloadedFunction($name, self::BUILTIN_FUNCTIONS[$name]['overloads'], self::BUILTIN_FUNCTIONS[$name]['url']);
+    }
+}

--- a/src/Function/FunctionRegistry.php
+++ b/src/Function/FunctionRegistry.php
@@ -28,6 +28,16 @@ class FunctionRegistry
         'feature-exists' => ['overloads' => ['$feature' => [MetaFunctions::class, 'featureExists']], 'url' => 'sass:meta'],
         'inspect' => ['overloads' => ['$value' => [MetaFunctions::class, 'inspect']], 'url' => 'sass:meta'],
         'type-of' => ['overloads' => ['$value' => [MetaFunctions::class, 'typeof']], 'url' => 'sass:meta'],
+        // sass:string
+        'unquote' => ['overloads' => ['$string' => [StringFunctions::class, 'unquote']], 'url' => 'sass:string'],
+        'quote' => ['overloads' => ['$string' => [StringFunctions::class, 'quote']], 'url' => 'sass:string'],
+        'to-upper-case' => ['overloads' => ['$string' => [StringFunctions::class, 'toUpperCase']], 'url' => 'sass:string'],
+        'to-lower-case' => ['overloads' => ['$string' => [StringFunctions::class, 'toLowerCase']], 'url' => 'sass:string'],
+        'uniqueId' => ['overloads' => ['' => [StringFunctions::class, 'uniqueId']], 'url' => 'sass:string'],
+        'str-length' => ['overloads' => ['$string' => [StringFunctions::class, 'length']], 'url' => 'sass:string'],
+        'str-insert' => ['overloads' => ['$string, $insert, $index' => [StringFunctions::class, 'insert']], 'url' => 'sass:string'],
+        'str-index' => ['overloads' => ['$string, $substring' => [StringFunctions::class, 'index']], 'url' => 'sass:string'],
+        'str-slice' => ['overloads' => ['$string, $start-at, $end-at: -1' => [StringFunctions::class, 'slice']], 'url' => 'sass:string'],
     ];
 
     public static function has(string $name): bool

--- a/src/Function/FunctionRegistry.php
+++ b/src/Function/FunctionRegistry.php
@@ -28,6 +28,15 @@ class FunctionRegistry
         'feature-exists' => ['overloads' => ['$feature' => [MetaFunctions::class, 'featureExists']], 'url' => 'sass:meta'],
         'inspect' => ['overloads' => ['$value' => [MetaFunctions::class, 'inspect']], 'url' => 'sass:meta'],
         'type-of' => ['overloads' => ['$value' => [MetaFunctions::class, 'typeof']], 'url' => 'sass:meta'],
+        // sass:selector
+        'is-superselector' => ['overloads' => ['$super, $sub' => [SelectorFunctions::class, 'isSuperselector']], 'url' => 'sass:selector'],
+        'simple-selectors' => ['overloads' => ['$selector' => [SelectorFunctions::class, 'simpleSelectors']], 'url' => 'sass:selector'],
+        'selector-parse' => ['overloads' => ['$selector' => [SelectorFunctions::class, 'parse']], 'url' => 'sass:selector'],
+        'selector-nest' => ['overloads' => ['$selectors...' => [SelectorFunctions::class, 'nest']], 'url' => 'sass:selector'],
+        'selector-append' => ['overloads' => ['$selectors...' => [SelectorFunctions::class, 'append']], 'url' => 'sass:selector'],
+        'selector-extend' => ['overloads' => ['$selector, $extendee, $extender' => [SelectorFunctions::class, 'extend']], 'url' => 'sass:selector'],
+        'selector-replace' => ['overloads' => ['$selector, $original, $replacement' => [SelectorFunctions::class, 'replace']], 'url' => 'sass:selector'],
+        'selector-unify' => ['overloads' => ['$selector1, $selector2' => [SelectorFunctions::class, 'unify']], 'url' => 'sass:selector'],
         // sass:string
         'unquote' => ['overloads' => ['$string' => [StringFunctions::class, 'unquote']], 'url' => 'sass:string'],
         'quote' => ['overloads' => ['$string' => [StringFunctions::class, 'quote']], 'url' => 'sass:string'],

--- a/src/Function/FunctionRegistry.php
+++ b/src/Function/FunctionRegistry.php
@@ -24,6 +24,62 @@ class FunctionRegistry
      * @var array<string, array{overloads: array<string, callable(list<Value>): Value>, url: string}>
      */
     private const BUILTIN_FUNCTIONS = [
+        // sass:color
+        'red' => ['overloads' => ['$color' => [ColorFunctions::class, 'red']], 'url' => 'sass:color'],
+        'green' => ['overloads' => ['$color' => [ColorFunctions::class, 'green']], 'url' => 'sass:color'],
+        'blue' => ['overloads' => ['$color' => [ColorFunctions::class, 'blue']], 'url' => 'sass:color'],
+        'mix' => ['overloads' => ['$color1, $color2, $weight: 50%' => [ColorFunctions::class, 'mix']], 'url' => 'sass:color'],
+        'rgb' => ['overloads' => [
+            '$red, $green, $blue, $alpha' => [ColorFunctions::class, 'rgb'],
+            '$red, $green, $blue' => [ColorFunctions::class, 'rgb'],
+            '$color, $alpha' => [ColorFunctions::class, 'rgbTwoArgs'],
+            '$channels' => [ColorFunctions::class, 'rgbOneArgs'],
+        ], 'url' => 'sass:color'],
+        'rgba' => ['overloads' => [
+            '$red, $green, $blue, $alpha' => [ColorFunctions::class, 'rgba'],
+            '$red, $green, $blue' => [ColorFunctions::class, 'rgba'],
+            '$color, $alpha' => [ColorFunctions::class, 'rgbaTwoArgs'],
+            '$channels' => [ColorFunctions::class, 'rgbaOneArgs'],
+        ], 'url' => 'sass:color'],
+        'invert' => ['overloads' => ['$color, $weight: 100%' => [ColorFunctions::class, 'invert']], 'url' => 'sass:color'],
+        'hue' => ['overloads' => ['$color' => [ColorFunctions::class, 'hue']], 'url' => 'sass:color'],
+        'saturation' => ['overloads' => ['$color' => [ColorFunctions::class, 'saturation']], 'url' => 'sass:color'],
+        'lightness' => ['overloads' => ['$color' => [ColorFunctions::class, 'lightness']], 'url' => 'sass:color'],
+        'complement' => ['overloads' => ['$color' => [ColorFunctions::class, 'complement']], 'url' => 'sass:color'],
+        'hsl' => ['overloads' => [
+            '$hue, $saturation, $lightness, $alpha' => [ColorFunctions::class, 'hsl'],
+            '$hue, $saturation, $lightness' => [ColorFunctions::class, 'hsl'],
+            '$hue, $saturation' => [ColorFunctions::class, 'hslTwoArgs'],
+            '$channels' => [ColorFunctions::class, 'hslOneArgs'],
+        ], 'url' => 'sass:color'],
+        'hsla' => ['overloads' => [
+            '$hue, $saturation, $lightness, $alpha' => [ColorFunctions::class, 'hsla'],
+            '$hue, $saturation, $lightness' => [ColorFunctions::class, 'hsla'],
+            '$hue, $saturation' => [ColorFunctions::class, 'hslaTwoArgs'],
+            '$channels' => [ColorFunctions::class, 'hslaOneArgs'],
+        ], 'url' => 'sass:color'],
+        'grayscale' => ['overloads' => ['$color' => [ColorFunctions::class, 'grayscale']], 'url' => 'sass:color'],
+        'adjust-hue' => ['overloads' => ['$color, $degrees' => [ColorFunctions::class, 'adjustHue']], 'url' => 'sass:color'],
+        'lighten' => ['overloads' => ['$color, $amount' => [ColorFunctions::class, 'lighten']], 'url' => 'sass:color'],
+        'darken' => ['overloads' => ['$color, $amount' => [ColorFunctions::class, 'darken']], 'url' => 'sass:color'],
+        'saturate' => ['overloads' => [
+            '$amount' => [ColorFunctions::class, 'saturateCss'],
+            '$color, $amount' => [ColorFunctions::class, 'saturate'],
+        ], 'url' => 'sass:color'],
+        'desaturate' => ['overloads' => ['$color, $amount' => [ColorFunctions::class, 'desaturate']], 'url' => 'sass:color'],
+        'opacify' => ['overloads' => ['$color, $amount' => [ColorFunctions::class, 'opacify']], 'url' => 'sass:color'],
+        'fade-in' => ['overloads' => ['$color, $amount' => [ColorFunctions::class, 'opacify']], 'url' => 'sass:color'],
+        'transparentize' => ['overloads' => ['$color, $amount' => [ColorFunctions::class, 'transparentize']], 'url' => 'sass:color'],
+        'fade-out' => ['overloads' => ['$color, $amount' => [ColorFunctions::class, 'transparentize']], 'url' => 'sass:color'],
+        'alpha' => ['overloads' => [
+            '$color' => [ColorFunctions::class, 'alpha'],
+            '$args...' => [ColorFunctions::class, 'alphaMicrosoft'],
+        ], 'url' => 'sass:color'],
+        'opacity' => ['overloads' => ['$color' => [ColorFunctions::class, 'opacity']], 'url' => 'sass:color'],
+        'ie-hex-str' => ['overloads' => ['$color' => [ColorFunctions::class, 'ieHexStr']], 'url' => 'sass:color'],
+        'adjust-color' => ['overloads' => ['$color, $kwargs...' => [ColorFunctions::class, 'adjust']], 'url' => 'sass:color'],
+        'scale-color' => ['overloads' => ['$color, $kwargs...' => [ColorFunctions::class, 'scale']], 'url' => 'sass:color'],
+        'change-color' => ['overloads' => ['$color, $kwargs...' => [ColorFunctions::class, 'change']], 'url' => 'sass:color'],
         // sass:list
         'length' => ['overloads' => ['$list' => [ListFunctions::class, 'length']], 'url' => 'sass:list'],
         'nth' => ['overloads' => ['$list, $n' => [ListFunctions::class, 'nth']], 'url' => 'sass:list'],

--- a/src/Function/FunctionRegistry.php
+++ b/src/Function/FunctionRegistry.php
@@ -24,6 +24,18 @@ class FunctionRegistry
      * @var array<string, array{overloads: array<string, callable(list<Value>): Value>, url: string}>
      */
     private const BUILTIN_FUNCTIONS = [
+        // sass:math
+        'abs' => ['overloads' => ['$number' => [MathFunctions::class, 'abs']], 'url' => 'sass:math'],
+        'ceil' => ['overloads' => ['$number' => [MathFunctions::class, 'ceil']], 'url' => 'sass:math'],
+        'floor' => ['overloads' => ['$number' => [MathFunctions::class, 'floor']], 'url' => 'sass:math'],
+        'max' => ['overloads' => ['$numbers...' => [MathFunctions::class, 'max']], 'url' => 'sass:math'],
+        'min' => ['overloads' => ['$numbers...' => [MathFunctions::class, 'min']], 'url' => 'sass:math'],
+        'random' => ['overloads' => ['$limit: null' => [MathFunctions::class, 'random']], 'url' => 'sass:math'],
+        'percentage' => ['overloads' => ['$number' => [MathFunctions::class, 'percentage']], 'url' => 'sass:math'],
+        'round' => ['overloads' => ['$number' => [MathFunctions::class, 'round']], 'url' => 'sass:math'],
+        'unit' => ['overloads' => ['$number' => [MathFunctions::class, 'unit']], 'url' => 'sass:math'],
+        'comparable' => ['overloads' => ['$number1, $number2' => [MathFunctions::class, 'compatible']], 'url' => 'sass:math'],
+        'unitless' => ['overloads' => ['$number' => [MathFunctions::class, 'isUnitless']], 'url' => 'sass:math'],
         // sass:meta
         'feature-exists' => ['overloads' => ['$feature' => [MetaFunctions::class, 'featureExists']], 'url' => 'sass:meta'],
         'inspect' => ['overloads' => ['$value' => [MetaFunctions::class, 'inspect']], 'url' => 'sass:meta'],

--- a/src/Function/ListFunctions.php
+++ b/src/Function/ListFunctions.php
@@ -1,0 +1,183 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Function;
+
+use ScssPhp\ScssPhp\Exception\SassScriptException;
+use ScssPhp\ScssPhp\Util\IterableUtil;
+use ScssPhp\ScssPhp\Value\ListSeparator;
+use ScssPhp\ScssPhp\Value\SassBoolean;
+use ScssPhp\ScssPhp\Value\SassList;
+use ScssPhp\ScssPhp\Value\SassNull;
+use ScssPhp\ScssPhp\Value\SassNumber;
+use ScssPhp\ScssPhp\Value\SassString;
+use ScssPhp\ScssPhp\Value\Value;
+
+/**
+ * @internal
+ */
+class ListFunctions
+{
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function length(array $arguments): Value
+    {
+        return SassNumber::create(\count($arguments[0]->asList()));
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function nth(array $arguments): Value
+    {
+        $list = $arguments[0];
+        $index = $arguments[1];
+
+        return $list->asList()[$list->sassIndexToListIndex($index, 'n')];
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function setNth(array $arguments): Value
+    {
+        $list = $arguments[0];
+        $index = $arguments[1];
+        $value = $arguments[2];
+
+        $newList = $list->asList();
+        $newList[$list->sassIndexToListIndex($index, 'n')] = $value;
+        \assert(array_is_list($newList), 'The mutation is guaranteed to affect an existing index');
+
+        return $list->withListContents($newList);
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function join(array $arguments): Value
+    {
+        $list1 = $arguments[0];
+        $list2 = $arguments[1];
+        $separatorParam = $arguments[2]->assertString('separator');
+        $bracketedParam = $arguments[3];
+
+        $separator = match ($separatorParam->getText()) {
+            'auto' => self::getAutoJoinSeparator($list1->getSeparator(), $list2->getSeparator()),
+            'space' => ListSeparator::SPACE,
+            'comma' => ListSeparator::COMMA,
+            'slash' => ListSeparator::SLASH,
+            default => throw new SassScriptException('$separator: Must be "space", "comma", "slash", or "auto".')
+        };
+
+        $bracketed = $bracketedParam instanceof SassString && $bracketedParam->getText() === 'auto' ? $list1->hasBrackets() : $bracketedParam->isTruthy();
+
+        $newList = [...$list1->asList(), ...$list2->asList()];
+
+        return new SassList($newList, $separator, $bracketed);
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function append(array $arguments): Value
+    {
+        $list = $arguments[0];
+        $value = $arguments[1];
+        $separatorParam = $arguments[2]->assertString('separator');
+
+        $separator = match ($separatorParam->getText()) {
+            'auto' => $list->getSeparator() === ListSeparator::UNDECIDED ? ListSeparator::SPACE : $list->getSeparator(),
+            'space' => ListSeparator::SPACE,
+            'comma' => ListSeparator::COMMA,
+            'slash' => ListSeparator::SLASH,
+            default => throw new SassScriptException('$separator: Must be "space", "comma", "slash", or "auto".')
+        };
+
+        $newList = [...$list->asList(), $value];
+
+        return $list->withListContents($newList, $separator);
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function zip(array $arguments): Value
+    {
+        $lists = array_map(fn (Value $list) => $list->asList(), $arguments[0]->asList());
+
+        if (\count($lists) === 0) {
+            return SassList::createEmpty(ListSeparator::COMMA);
+        }
+
+        $i = 0;
+        $results = [];
+
+        while (IterableUtil::every($lists, fn ($list) => $i !== \count($lists))) {
+            $results[] = new SassList(array_map(fn ($list) => $list[$i], $lists), ListSeparator::SPACE);
+            $i++;
+        }
+
+        return new SassList($results, ListSeparator::COMMA);
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function index(array $arguments): Value
+    {
+        $list = $arguments[0]->asList();
+        $value = $arguments[1];
+
+        foreach ($list as $index => $item) {
+            if ($item->equals($value)) {
+                return SassNumber::create($index + 1);
+            }
+        }
+
+        return SassNull::create();
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function separator(array $arguments): Value
+    {
+        return match ($arguments[0]->getSeparator()) {
+            ListSeparator::COMMA => new SassString('comma', false),
+            ListSeparator::SLASH => new SassString('slash', false),
+            default => new SassString('space', false),
+        };
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function isBracketed(array $arguments): Value
+    {
+        return SassBoolean::create($arguments[0]->hasBrackets());
+    }
+
+    private static function getAutoJoinSeparator(ListSeparator $separator1, ListSeparator $separator2): ListSeparator
+    {
+        if ($separator1 === ListSeparator::UNDECIDED && $separator2 === ListSeparator::UNDECIDED) {
+            return ListSeparator::COMMA;
+        }
+
+        if ($separator1 === ListSeparator::UNDECIDED) {
+            return $separator2;
+        }
+
+        return $separator1;
+    }
+}

--- a/src/Function/MapFunctions.php
+++ b/src/Function/MapFunctions.php
@@ -1,0 +1,211 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Function;
+
+use ScssPhp\ScssPhp\Collection\Map;
+use ScssPhp\ScssPhp\Exception\SassScriptException;
+use ScssPhp\ScssPhp\Util\ListUtil;
+use ScssPhp\ScssPhp\Value\ListSeparator;
+use ScssPhp\ScssPhp\Value\SassBoolean;
+use ScssPhp\ScssPhp\Value\SassList;
+use ScssPhp\ScssPhp\Value\SassMap;
+use ScssPhp\ScssPhp\Value\SassNull;
+use ScssPhp\ScssPhp\Value\Value;
+
+/**
+ * @internal
+ */
+class MapFunctions
+{
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function get(array $arguments): Value
+    {
+        $map = $arguments[0]->assertMap('map');
+        $keys = [$arguments[1], ...$arguments[2]->asList()];
+
+        foreach (ListUtil::exceptLast($keys) as $key) {
+            $value = $map->getContents()->get($key);
+
+            if (!$value instanceof SassMap) {
+                return SassNull::create();
+            }
+
+            $map = $value;
+        }
+
+        return $map->getContents()->get(ListUtil::last($keys)) ?? SassNull::create();
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function mergeTwoArgs(array $arguments): Value
+    {
+        $map1 = $arguments[0]->assertMap('map1');
+        $map2 = $arguments[0]->assertMap('map2');
+
+        $result = Map::of($map1->getContents());
+
+        foreach ($map2->getContents() as $key => $value) {
+            $result->put($key, $value);
+        }
+
+        return SassMap::create($result);
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function mergeVariadic(array $arguments): Value
+    {
+        $map1 = $arguments[0]->assertMap('map1');
+        $args = $arguments[1]->asList();
+
+        if ($args === []) {
+            throw new SassScriptException('Expected $args to contain a key.');
+        }
+
+        if (\count($args) === 1) {
+            throw new SassScriptException('Expected $args to contain a map.');
+        }
+
+        $keys = ListUtil::exceptLast($args);
+        $map2 = ListUtil::last($args)->assertMap('map2');
+
+        return self::modify($map1, $keys, function (Value $oldValue) use ($map2) {
+            $nestedMap = $oldValue->tryMap();
+            if ($nestedMap === null) {
+                return $map2;
+            }
+
+            $result = Map::of($nestedMap->getContents());
+
+            foreach ($map2->getContents() as $key => $value) {
+                $result->put($key, $value);
+            }
+
+            return SassMap::create($result);
+        });
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function removeNoKeys(array $arguments): Value
+    {
+        return $arguments[0]->assertMap('map');
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function remove(array $arguments): Value
+    {
+        $map = $arguments[0]->assertMap('map');
+        $keys = [$arguments[1], ...$arguments[2]->asList()];
+
+        $mutableMap = Map::of($map->getContents());
+
+        foreach ($keys as $key) {
+            $mutableMap->remove($key);
+        }
+
+        return SassMap::create($mutableMap);
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function keys(array $arguments): Value
+    {
+        return new SassList($arguments[0]->assertMap('map')->getContents()->keys(), ListSeparator::COMMA);
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function values(array $arguments): Value
+    {
+        return new SassList($arguments[0]->assertMap('map')->getContents()->values(), ListSeparator::COMMA);
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function hasKey(array $arguments): Value
+    {
+        $map = $arguments[0]->assertMap('map');
+        $keys = [$arguments[1], ...$arguments[2]->asList()];
+
+        foreach (ListUtil::exceptLast($keys) as $key) {
+            $value = $map->getContents()->get($key);
+
+            if (!$value instanceof SassMap) {
+                return SassBoolean::create(false);
+            }
+
+            $map = $value;
+        }
+
+        return SassBoolean::create($map->getContents()->containsKey(ListUtil::last($keys)));
+    }
+
+    /**
+     * Updates the specified value in $map by applying the $modify callback to
+     * it, then returns the resulting map.
+     *
+     * If more than one key is provided, this means the map targeted for update is
+     * nested within $map. The multiple $keys form a path of nested maps that
+     * leads to the targeted value, which is passed to $modify.
+     *
+     * If any value along the path (other than the last one) is not a map and
+     * $addNesting is `true`, this creates nested maps to match $keys and passes
+     * {@see SassNull} to $modify. Otherwise, this fails and returns $map with no
+     * changes.
+     *
+     * If no keys are provided, this passes $map directly to modify and returns
+     * the result.
+     *
+     * @param Value[] $keys
+     * @param callable(Value $old): Value $modify
+     */
+    private static function modify(SassMap $map, array $keys, callable $modify, bool $addNesting = true): Value
+    {
+        $iterator = new \ArrayIterator($keys);
+
+        $modifyNestedMap = function (SassMap $map) use ($iterator, $modify, $addNesting, &$modifyNestedMap): SassMap {
+            $mutableMap = Map::of($map->getContents());
+            $key = $iterator->current();
+
+            $iterator->next();
+            if (!$iterator->valid()) {
+                $mutableMap->put($key, $modify($mutableMap->get($key) ?? SassNull::create()));
+                return SassMap::create($mutableMap);
+            }
+
+            $nestedMap = $mutableMap->get($key)?->tryMap();
+            if ($nestedMap === null && !$addNesting) {
+                return SassMap::create($mutableMap);
+            }
+
+            $mutableMap->put($key, $modifyNestedMap($nestedMap ?? SassMap::createEmpty()));
+            return SassMap::create($mutableMap);
+        };
+
+        $iterator->rewind();
+
+        return $iterator->valid() ? $modifyNestedMap($map) : $modify($map);
+    }
+}

--- a/src/Function/MathFunctions.php
+++ b/src/Function/MathFunctions.php
@@ -1,0 +1,203 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Function;
+
+use ScssPhp\ScssPhp\Deprecation;
+use ScssPhp\ScssPhp\Exception\SassScriptException;
+use ScssPhp\ScssPhp\Value\SassBoolean;
+use ScssPhp\ScssPhp\Value\SassNull;
+use ScssPhp\ScssPhp\Value\SassNumber;
+use ScssPhp\ScssPhp\Value\SassString;
+use ScssPhp\ScssPhp\Value\Value;
+use ScssPhp\ScssPhp\Warn;
+
+/**
+ * @internal
+ */
+final class MathFunctions
+{
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function abs(array $arguments): Value
+    {
+        $number = $arguments[0]->assertNumber('number');
+        // TODO implement the deprecation for the % unit once modules are implemented to provided the replacement
+
+        return SassNumber::withUnits(abs($number->getValue()), $number->getNumeratorUnits(), $number->getDenominatorUnits());
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function ceil(array $arguments): Value
+    {
+        return self::numberFunction($arguments, ceil(...));
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function floor(array $arguments): Value
+    {
+        return self::numberFunction($arguments, floor(...));
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function max(array $arguments): Value
+    {
+        $max = null;
+
+        foreach ($arguments[0]->asList() as $value) {
+            $number = $value->assertNumber();
+
+            if ($max === null || $max->lessThan($number)->isTruthy()) {
+                $max = $number;
+            }
+        }
+
+        if ($max !== null) {
+            return $max;
+        }
+
+        throw new SassScriptException('At least one argument must be passed.');
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function min(array $arguments): Value
+    {
+        $min = null;
+
+        foreach ($arguments[0]->asList() as $value) {
+            $number = $value->assertNumber();
+
+            if ($min === null || $min->greaterThan($number)->isTruthy()) {
+                $min = $number;
+            }
+        }
+
+        if ($min !== null) {
+            return $min;
+        }
+
+        throw new SassScriptException('At least one argument must be passed.');
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function round(array $arguments): Value
+    {
+        return self::numberFunction($arguments, round(...));
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function compatible(array $arguments): Value
+    {
+        $number1 = $arguments[0]->assertNumber('number1');
+        $number2 = $arguments[1]->assertNumber('number2');
+
+        return SassBoolean::create($number1->isComparableTo($number2));
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function isUnitless(array $arguments): Value
+    {
+        $number = $arguments[0]->assertNumber('number');
+
+        return SassBoolean::create(!$number->hasUnits());
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function unit(array $arguments): Value
+    {
+        $number = $arguments[0]->assertNumber('number');
+
+        return new SassString($number->getUnitString(), false);
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function percentage(array $arguments): Value
+    {
+        $number = $arguments[0]->assertNumber('number');
+        $number->assertNoUnits('number');
+
+        return SassNumber::create($number->getValue() * 100, '%');
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function random(array $arguments): Value
+    {
+        if ($arguments[0] instanceof SassNull) {
+            // TODO use a better algorithm to generate a random float.
+            $max = mt_getrandmax();
+
+            return SassNumber::create(mt_rand(0, $max - 1) / $max);
+        }
+
+        $limit = $arguments[0]->assertNumber('limit');
+
+        if ($limit->hasUnits()) {
+            $unitString = $limit->getUnitString();
+
+            // TODO update the message when implementing modules and deprecating division.
+            Warn::forDeprecation(
+                <<<TXT
+                random() will no longer ignore \$limit units ($limit) in a future release.
+
+                Recommendation: random(\$limit / 1$unitString) * 1$unitString
+
+                To preserve current behavior: random(\$limit / 1$unitString)
+
+                More info: https://sass-lang.com/d/random-with-units
+                TXT,
+                Deprecation::functionUnits
+            );
+        }
+
+        $limitScalar = $limit->assertInt('limit');
+        if ($limitScalar < 1) {
+            throw new SassScriptException("\$limit: Must be greater than 0, was $limit.");
+        }
+
+        return SassNumber::create(mt_rand(1, $limitScalar));
+    }
+
+    /**
+     * Implements a callable that transforms a number's value
+     * using $transform and preserves its units.
+     *
+     * @param list<Value> $arguments
+     * @param callable(float): float $transform
+     */
+    private static function numberFunction(array $arguments, callable $transform): Value
+    {
+        $number = $arguments[0]->assertNumber('number');
+
+        return SassNumber::withUnits($transform($number->getValue()), $number->getNumeratorUnits(), $number->getDenominatorUnits());
+    }
+}

--- a/src/Function/MetaFunctions.php
+++ b/src/Function/MetaFunctions.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Function;
+
+use ScssPhp\ScssPhp\Collection\Map;
+use ScssPhp\ScssPhp\Exception\SassScriptException;
+use ScssPhp\ScssPhp\Value\SassArgumentList;
+use ScssPhp\ScssPhp\Value\SassBoolean;
+use ScssPhp\ScssPhp\Value\SassCalculation;
+use ScssPhp\ScssPhp\Value\SassColor;
+use ScssPhp\ScssPhp\Value\SassFunction;
+use ScssPhp\ScssPhp\Value\SassList;
+use ScssPhp\ScssPhp\Value\SassMap;
+use ScssPhp\ScssPhp\Value\SassMixin;
+use ScssPhp\ScssPhp\Value\SassNull;
+use ScssPhp\ScssPhp\Value\SassNumber;
+use ScssPhp\ScssPhp\Value\SassString;
+use ScssPhp\ScssPhp\Value\Value;
+
+/**
+ * @internal
+ */
+final class MetaFunctions
+{
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function featureExists(array $arguments): Value
+    {
+        $feature = $arguments[0]->assertString('feature');
+
+        return SassBoolean::create(\in_array($feature->getText(), ['global-variable-shadowing', 'extend-selector-pseudoclass', 'units-level-3', 'at-error', 'custom-property'], true));
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function inspect(array $arguments): Value
+    {
+        return new SassString((string) $arguments[0], false);
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function typeof(array $arguments): Value
+    {
+        $value = $arguments[0];
+
+        return new SassString(match (true) {
+            $value instanceof SassArgumentList => 'arglist',
+            $value instanceof SassBoolean => 'bool',
+            $value instanceof SassColor => 'color',
+            $value instanceof SassList => 'list',
+            $value instanceof SassMap => 'map',
+            $value instanceof SassNull => 'null',
+            $value instanceof SassNumber => 'number',
+            $value instanceof SassFunction => 'function',
+            $value instanceof SassMixin => 'mixin',
+            $value instanceof SassCalculation => 'calculation',
+            $value instanceof SassString => 'string',
+            default => throw new SassScriptException("[BUG] Unknown value type $value"),
+        }, false);
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function keywords(array $arguments): Value
+    {
+        if ($arguments[0] instanceof SassArgumentList) {
+            $map = new Map();
+            foreach ($arguments[0]->getKeywords() as $key => $value) {
+                $map->put(new SassString($key, false), $value);
+            }
+
+            return SassMap::create($map);
+        }
+
+        throw SassScriptException::forArgument("${arguments[0]} is not an argument list.", 'args');
+    }
+}

--- a/src/Function/SelectorFunctions.php
+++ b/src/Function/SelectorFunctions.php
@@ -1,0 +1,204 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Function;
+
+use ScssPhp\ScssPhp\Ast\Selector\ComplexSelector;
+use ScssPhp\ScssPhp\Ast\Selector\ComplexSelectorComponent;
+use ScssPhp\ScssPhp\Ast\Selector\CompoundSelector;
+use ScssPhp\ScssPhp\Ast\Selector\ParentSelector;
+use ScssPhp\ScssPhp\Ast\Selector\SelectorList;
+use ScssPhp\ScssPhp\Ast\Selector\SimpleSelector;
+use ScssPhp\ScssPhp\Ast\Selector\TypeSelector;
+use ScssPhp\ScssPhp\Ast\Selector\UniversalSelector;
+use ScssPhp\ScssPhp\Evaluation\EvaluationContext;
+use ScssPhp\ScssPhp\Exception\SassScriptException;
+use ScssPhp\ScssPhp\Extend\ConcreteExtensionStore;
+use ScssPhp\ScssPhp\Util\ArrayUtil;
+use ScssPhp\ScssPhp\Value\ListSeparator;
+use ScssPhp\ScssPhp\Value\SassBoolean;
+use ScssPhp\ScssPhp\Value\SassList;
+use ScssPhp\ScssPhp\Value\SassNull;
+use ScssPhp\ScssPhp\Value\SassString;
+use ScssPhp\ScssPhp\Value\Value;
+
+/**
+ * @internal
+ */
+final class SelectorFunctions
+{
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function nest(array $arguments): Value
+    {
+        $selectors = $arguments[0]->asList();
+
+        if (\count($selectors) === 0) {
+            throw new SassScriptException('$selectors: At least one selector must be passed.');
+        }
+
+        $first = true;
+
+        return ArrayUtil::reduce(array_map(function (Value $selector) use (&$first) {
+            $result = $selector->assertSelector(allowParent: !$first);
+            $first = false;
+
+            return $result;
+        }, $selectors), fn (SelectorList $parent, SelectorList $child) => $child->nestWithin($parent))->asSassList();
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function append(array $arguments): Value
+    {
+        $selectors = $arguments[0]->asList();
+
+        if (\count($selectors) === 0) {
+            throw new SassScriptException('$selectors: At least one selector must be passed.');
+        }
+
+        $span = EvaluationContext::getCurrent()->getCurrentCallableSpan();
+
+        return ArrayUtil::reduce(array_map(fn(Value $selector) => $selector->assertSelector(), $selectors), function (SelectorList $parent, SelectorList $child) use ($span) {
+            return new SelectorList(array_map(function (ComplexSelector $complex) use ($span, $parent) {
+                if (\count($complex->getLeadingCombinators()) > 0) {
+                    throw new SassScriptException("Can't append $complex to $parent.");
+                }
+
+                $component = $complex->getComponents()[0];
+                $rest = array_slice($complex->getComponents(), 1);
+                $newCompound = self::prependParent($component->getSelector());
+
+                if ($newCompound === null) {
+                    throw new SassScriptException("Can't append $complex to $parent.");
+                }
+
+                return new ComplexSelector([], [
+                    new ComplexSelectorComponent($newCompound, $component->getCombinators(), $span),
+                    ...$rest,
+                ], $span);
+            }, $child->getComponents()), $span);
+        })->asSassList();
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function extend(array $arguments): Value
+    {
+        $selector = $arguments[0]->assertSelector('selector');
+        $selector->assertNotBogus('selector');
+        $target = $arguments[1]->assertSelector('extendee');
+        $target->assertNotBogus('extendee');
+        $source = $arguments[2]->assertSelector('extender');
+        $source->assertNotBogus('extender');
+
+        return ConcreteExtensionStore::extend($selector, $source, $target, EvaluationContext::getCurrent()->getCurrentCallableSpan())->asSassList();
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function replace(array $arguments): Value
+    {
+        $selector = $arguments[0]->assertSelector('selector');
+        $selector->assertNotBogus('selector');
+        $target = $arguments[1]->assertSelector('original');
+        $target->assertNotBogus('original');
+        $source = $arguments[2]->assertSelector('replacement');
+        $source->assertNotBogus('replacement');
+
+        return ConcreteExtensionStore::replace($selector, $source, $target, EvaluationContext::getCurrent()->getCurrentCallableSpan())->asSassList();
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function unify(array $arguments): Value
+    {
+        $selector1 = $arguments[0]->assertSelector('selector1');
+        $selector1->assertNotBogus('selector1');
+
+        $selector2 = $arguments[1]->assertSelector('selector2');
+        $selector2->assertNotBogus('selector2');
+
+        return $selector1->unify($selector2)?->asSassList() ?? SassNull::create();
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function isSuperselector(array $arguments): Value
+    {
+        $selector1 = $arguments[0]->assertSelector('super');
+        $selector1->assertNotBogus('super');
+
+        $selector2 = $arguments[1]->assertSelector('sub');
+        $selector2->assertNotBogus('sub');
+
+        return SassBoolean::create($selector1->isSuperselector($selector2));
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function simpleSelectors(array $arguments): Value
+    {
+        $selector = $arguments[0]->assertCompoundSelector('selector');
+
+        return new SassList(
+            array_map(fn (SimpleSelector $simple) => new SassString((string) $simple, false), $selector->getComponents()),
+            ListSeparator::COMMA
+        );
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function parse(array $arguments): Value
+    {
+        return $arguments[0]->assertSelector('selector')->asSassList();
+    }
+
+    /**
+     * Adds a {@see ParentSelector} to the beginning of $compound, or returns `null` if
+     * that wouldn't produce a valid selector.
+     */
+    private static function prependParent(CompoundSelector $compound): ?CompoundSelector
+    {
+        $span = EvaluationContext::getCurrent()->getCurrentCallableSpan();
+
+        $firstComponent = $compound->getComponents()[0];
+
+        if ($firstComponent instanceof UniversalSelector) {
+            return null;
+        }
+
+        if ($firstComponent instanceof TypeSelector && $firstComponent->getName()->getNamespace() !== null) {
+            return null;
+        }
+
+        if ($firstComponent instanceof TypeSelector) {
+            return new CompoundSelector([
+                new ParentSelector($span, $firstComponent->getName()->getName()),
+                ...array_slice($compound->getComponents(), 1),
+            ], $span);
+        }
+
+        return new CompoundSelector([
+            new ParentSelector($span),
+            ...$compound->getComponents(),
+        ], $span);
+    }
+}

--- a/src/Function/StringFunctions.php
+++ b/src/Function/StringFunctions.php
@@ -1,0 +1,219 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Function;
+
+use ScssPhp\ScssPhp\Util\StringUtil;
+use ScssPhp\ScssPhp\Value\SassNull;
+use ScssPhp\ScssPhp\Value\SassNumber;
+use ScssPhp\ScssPhp\Value\SassString;
+use ScssPhp\ScssPhp\Value\Value;
+
+/**
+ * @internal
+ */
+final class StringFunctions
+{
+    private static ?int $previousId = null;
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function unquote(array $arguments): Value
+    {
+        $string = $arguments[0]->assertString('string');
+
+        if (!$string->hasQuotes()) {
+            return $string;
+        }
+
+        return new SassString($string->getText(), false);
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function quote(array $arguments): Value
+    {
+        $string = $arguments[0]->assertString('string');
+
+        if ($string->hasQuotes()) {
+            return $string;
+        }
+
+        return new SassString($string->getText(), true);
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function length(array $arguments): Value
+    {
+        $string = $arguments[0]->assertString('string');
+
+        return SassNumber::create($string->getSassLength());
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function insert(array $arguments): Value
+    {
+        $string = $arguments[0]->assertString('string');
+        $insert = $arguments[1]->assertString('insert');
+        $index = $arguments[2]->assertNumber('index');
+        $index->assertNoUnits('index');
+
+        $indexInt = $index->assertInt('index');
+
+        // str-insert has unusual behavior for negative inputs. It guarantees that
+        // the `$insert` string is at `$index` in the result, which means that we
+        // want to insert before `$index` if it's positive and after if it's
+        // negative.
+        if ($indexInt < 0) {
+            // +1 because negative indexes start counting from -1 rather than 0, and
+            // another +1 because we want to insert *after* that index.
+            $indexInt = max($string->getSassLength() + $indexInt + 2, 0);
+        }
+
+        $codepointIndex = self::codepointForIndex($indexInt, $string->getSassLength());
+
+        return new SassString(
+            mb_substr($string->getText(), 0, $codepointIndex) . $insert->getText() . mb_substr($string->getText(), $codepointIndex),
+            $string->hasQuotes()
+        );
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function index(array $arguments): Value
+    {
+        $string = $arguments[0]->assertString('string');
+        $substring = $arguments[1]->assertString('substring');
+
+        $codepointIndex = mb_strpos($string->getText(), $substring->getText());
+
+        if ($codepointIndex === false) {
+            return SassNull::create();
+        }
+
+        return SassNumber::create($codepointIndex + 1);
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function slice(array $arguments): Value
+    {
+        $string = $arguments[0]->assertString('string');
+        $start = $arguments[1]->assertNumber('start-at');
+        $end = $arguments[2]->assertNumber('end-at');
+        $start->assertNoUnits('start-at');
+        $end->assertNoUnits('end-at');
+
+        $lengthInCodepoints = $string->getSassLength();
+
+        // No matter what the start index is, an end index of 0 will produce an
+        // empty string.
+        $endInt = $end->assertInt('end-at');
+        if ($endInt === 0) {
+            return new SassString('', $string->hasQuotes());
+        }
+
+        $startCodepoint = self::codepointForIndex($start->assertInt('start-at'), $lengthInCodepoints);
+        $endCodepoint = self::codepointForIndex($endInt, $lengthInCodepoints, true);
+
+        if ($endCodepoint === $lengthInCodepoints) {
+            $endCodepoint--;
+        }
+
+        if ($endCodepoint < $startCodepoint) {
+            return new SassString('', $string->hasQuotes());
+        }
+
+        return new SassString(
+            mb_substr($string->getText(), $startCodepoint, $endCodepoint - $startCodepoint),
+            $string->hasQuotes()
+        );
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function toUpperCase(array $arguments): Value
+    {
+        $string = $arguments[0]->assertString('string');
+
+        return new SassString(StringUtil::toAsciiUpperCase($string->getText()), $string->hasQuotes());
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function toLowerCase(array $arguments): Value
+    {
+        $string = $arguments[0]->assertString('string');
+
+        return new SassString(StringUtil::toAsciiLowerCase($string->getText()), $string->hasQuotes());
+    }
+
+    /**
+     * @param list<Value> $arguments
+     */
+    public static function uniqueId(array $arguments): Value
+    {
+        if (self::$previousId === null) {
+            self::$previousId = random_int(0, 36 ** 6);
+        }
+
+        // Make it difficult to guess the next ID by randomizing the increase.
+        self::$previousId += random_int(0, 36) + 1;
+
+        if (self::$previousId > 36 ** 6) {
+            self::$previousId %= 36 ** 6;
+        }
+
+        // The leading "u" ensures that the result is a valid identifier.
+        return new SassString('u' . str_pad(base_convert((string) self::$previousId, 10, 36), 6, '0', STR_PAD_LEFT), false);
+    }
+
+    /**
+     * Converts a Sass string index into a codepoint index into a string which
+     * has length $lengthInCodepoints measured in codepoints (with `mb_strlen`).
+     *
+     * A Sass string index is one-based, and uses negative numbers to count
+     * backwards from the end of the string.
+     *
+     * If $index is negative and it points before the beginning of
+     * $lengthInCodepoints, this will return `0` if $allowNegative is `false` and
+     * the index if it's `true`.
+     */
+    private static function codepointForIndex(int $index, int $lengthInCodepoints, bool $allowNegative = false): int
+    {
+        if ($index === 0) {
+            return 0;
+        }
+
+        if ($index > 0) {
+            return min($index - 1, $lengthInCodepoints);
+        }
+
+        $result = $lengthInCodepoints + $index;
+
+        if ($result < 0 && !$allowNegative) {
+            return 0;
+        }
+
+        return $result;
+    }
+}

--- a/src/Util/ArrayUtil.php
+++ b/src/Util/ArrayUtil.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Util;
+
+/**
+ * @internal
+ */
+final class ArrayUtil
+{
+    /**
+     * Reduces a collection to a single value by iteratively combining elements
+     * of the collection using the provided function.
+     *
+     * The array must have at least one element.
+     * If it has only one element, that element is returned.
+     *
+     * Otherwise this method starts with the first element from the array,
+     * and then combines it with the remaining elements in iteration order.
+     *
+     * @template T
+     *
+     * @param non-empty-array<T> $items
+     * @param callable(T, T): T $combine
+     * @return T
+     */
+    public static function reduce(array $items, callable $combine)
+    {
+        if (\count($items) === 0) {
+            throw new \LogicException('Cannot reduce an empty array');
+        }
+
+        $first = array_shift($items);
+
+        return array_reduce($items, $combine, $first);
+    }
+}

--- a/src/Util/Character.php
+++ b/src/Util/Character.php
@@ -18,6 +18,14 @@ namespace ScssPhp\ScssPhp\Util;
 final class Character
 {
     /**
+     * The difference between upper- and lowercase ASCII letters.
+     *
+     * `0b100000` can be bitwise-ORed with uppercase ASCII letters to get their
+     * lowercase equivalents.
+     */
+    private const ASCII_CASE_BIT = 0x20;
+
+    /**
      * Returns whether $character is an ASCII whitespace character.
      */
     public static function isWhitespace(?string $character): bool
@@ -139,5 +147,23 @@ final class Character
             '[' => ']',
             default => throw new \InvalidArgumentException(sprintf('Expected a brace character. Got "%s"', $character)),
         };
+    }
+
+    public static function equalsIgnoreCase(string $character1, string $character2): bool
+    {
+        if ($character1 === $character2) {
+            return true;
+        }
+
+        // If this check fails, the characters are definitely different. If it
+        // succeeds *and* either character is an ASCII letter, they're equivalent.
+        if ((\ord($character1) ^ \ord($character2)) !== self::ASCII_CASE_BIT) {
+            return false;
+        }
+
+        // Now we just need to verify that one of the characters is an ASCII letter.
+        $upperCase1 = \ord($character1) & ~self::ASCII_CASE_BIT;
+
+        return $upperCase1 >= \ord('A') && $upperCase1 <= \ord('Z');
     }
 }

--- a/src/Util/NumberUtil.php
+++ b/src/Util/NumberUtil.php
@@ -35,6 +35,19 @@ final class NumberUtil
     private const EPSILON = 10 ** (-SassNumber::PRECISION - 1);
     private const INVERSE_EPSILON = 10 ** (SassNumber::PRECISION + 1);
 
+    public static function clamp(float $value, float $lowerLimit, float $upperLimit): float
+    {
+        if ($value < $lowerLimit) {
+            return $lowerLimit;
+        }
+
+        if ($value > $upperLimit) {
+            return $upperLimit;
+        }
+
+        return $value;
+    }
+
     public static function fuzzyEquals(float $number1, float $number2): bool
     {
         if ($number1 == $number2) {

--- a/src/Util/StringUtil.php
+++ b/src/Util/StringUtil.php
@@ -104,7 +104,7 @@ final class StringUtil
     /**
      * Converts all ASCII chars to lowercase in the input string.
      *
-     * This does not uses `strtolower` because `strtolower` is locale-dependant
+     * This does not use `strtolower` because `strtolower` is locale-dependant
      * rather than operating on ASCII.
      * Passing an input string in an encoding that it is not ASCII compatible is
      * unsupported, and will probably generate garbage.
@@ -112,5 +112,18 @@ final class StringUtil
     public static function toAsciiLowerCase(string $string): string
     {
         return strtr($string, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz');
+    }
+
+    /**
+     * Converts all ASCII chars to uppercase in the input string.
+     *
+     * This does not use `strtoupper` because `strtoupper` is locale-dependant
+     * rather than operating on ASCII.
+     * Passing an input string in an encoding that it is not ASCII compatible is
+     * unsupported, and will probably generate garbage.
+     */
+    public static function toAsciiUpperCase(string $string): string
+    {
+        return strtr($string, 'abcdefghijklmnopqrstuvwxyz', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ');
     }
 }

--- a/src/Util/StringUtil.php
+++ b/src/Util/StringUtil.php
@@ -102,6 +102,24 @@ final class StringUtil
     }
 
     /**
+     * Returns whether $string starts with $prefix, ignoring ASCII case.
+     */
+    public static function startsWithIgnoreCase(string $string, string $prefix): bool
+    {
+        if (\strlen($string) < \strlen($prefix)) {
+            return false;
+        }
+
+        for ($i = 0; $i < \strlen($prefix); $i++) {
+            if (!Character::equalsIgnoreCase($string[$i], $prefix[$i])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
      * Converts all ASCII chars to lowercase in the input string.
      *
      * This does not use `strtolower` because `strtolower` is locale-dependant

--- a/src/Warn.php
+++ b/src/Warn.php
@@ -74,6 +74,7 @@ final class Warn
 
     private static function reportWarning(string $message, ?Deprecation $deprecation): void
     {
+        // TODO replace this with \ScssPhp\ScssPhp\Evaluation\EvaluationContext::warn when migrating to the new evaluation system
         if (self::$callback === null) {
             throw new \BadMethodCallException('The warning Reporter may only be called within a custom function or importer callback.');
         }


### PR DESCRIPTION
This implements all the global functions of the core (functions that are only exposed from built-in modules have not been ported from dart-sass yet as modules are not implemented for now), except for the special functions of `sass:meta` that require being implemented in the evaluator itself because they access its internals (those are implemented in #709).

Each sass module is implemented as a separate internal class with static methods for each callable (one per function generally, but overloaded functions will have several associated callables).
The `FunctionRegistry` is our registry of core functions, allowing us to lazy-load the `BuiltInCallable` only when a function is used for the first time (for now, the  `FunctionRegistry` does not perform any caching of those SassCallable objects because I kept that in the evaluator instead, but I might revisit that decision in the future). 