### PR TITLE
PHP 8.4 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [ '8.1', '8.2', '8.3' ]
+                php: [ '8.1', '8.2', '8.3', '8.4' ]
                 extensions: [ '' ]
                 os: [ubuntu-latest]
                 include:


### PR DESCRIPTION
Implicitly nullable parameter declarations are deprecated in PHP 8.4. The proposed change is safe and is not considered by PHP as a signature change, see https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated

I did not see other changes required for PHP 8.4 support.