### PR TITLE
Fix the version of league/uri used in CI

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,8 @@
         "php": ">=8.1",
         "ext-ctype": "*",
         "ext-json": "*",
-        "league/uri": "^7.4@dev",
-        "league/uri-interfaces": "^7.3",
+        "league/uri": "^7.4",
+        "league/uri-interfaces": "^7.4",
         "symfony/filesystem": "^5.4 || ^6.0 || ^7.0"
     },
     "suggest": {


### PR DESCRIPTION
Mixing a dev stability for `league/uri` while forcing stable versions for `league/uri-interfaces` does not work well because `league/uri` does not properly define the min version it requires (at least in its dev version)