### PR TITLE
Use explicit nullable types

### DIFF
--- a/src/Ast/Sass/Expression/StringExpression.php
+++ b/src/Ast/Sass/Expression/StringExpression.php
@@ -78,7 +78,7 @@ final class StringExpression implements Expression
         return $visitor->visitStringExpression($this);
     }
 
-    public function asInterpolation(bool $static = false, string $quote = null): Interpolation
+    public function asInterpolation(bool $static = false, ?string $quote = null): Interpolation
     {
         if (!$this->quotes) {
             return $this->text;

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -4770,7 +4770,7 @@ EOL;
      *
      * @return array
      */
-    private function multiplyMedia(Environment $env = null, ?array $childQueries = null): array
+    private function multiplyMedia(?Environment $env = null, ?array $childQueries = null): array
     {
         if (
             ! isset($env) ||
@@ -4862,7 +4862,7 @@ EOL;
      *
      * @return Environment
      */
-    private function pushEnv(Block $block = null): Environment
+    private function pushEnv(?Block $block = null): Environment
     {
         $env = new Environment();
         $env->parent = $this->env;
@@ -4926,7 +4926,7 @@ EOL;
      *
      * @return void
      */
-    private function set(string $name, $value, bool $shadow = false, Environment $env = null, $valueUnreduced = null): void
+    private function set(string $name, $value, bool $shadow = false, ?Environment $env = null, $valueUnreduced = null): void
     {
         $name = $this->normalizeName($name);
 
@@ -5095,7 +5095,7 @@ EOL;
      *
      * @return bool
      */
-    private function has(string $name, Environment $env = null): bool
+    private function has(string $name, ?Environment $env = null): bool
     {
         return ! \is_null($this->get($name, false, $env));
     }

--- a/src/Exception/SassFormatException.php
+++ b/src/Exception/SassFormatException.php
@@ -31,7 +31,7 @@ final class SassFormatException extends \Exception implements SassException
      */
     private $span;
 
-    public function __construct(string $message, FileSpan $span, \Throwable $previous = null)
+    public function __construct(string $message, FileSpan $span, ?\Throwable $previous = null)
     {
         $this->originalMessage = $message;
         $this->span = $span;

--- a/src/Exception/SassRuntimeException.php
+++ b/src/Exception/SassRuntimeException.php
@@ -35,7 +35,7 @@ final class SassRuntimeException extends \Exception implements SassException
 
     private readonly Trace $sassTrace;
 
-    public function __construct(string $message, FileSpan $span, ?Trace $sassTrace = null, \Throwable $previous = null)
+    public function __construct(string $message, FileSpan $span, ?Trace $sassTrace = null, ?\Throwable $previous = null)
     {
         $this->originalMessage = $message;
         $this->span = $span;

--- a/src/Formatter.php
+++ b/src/Formatter.php
@@ -264,7 +264,7 @@ abstract class Formatter
      *
      * @return string
      */
-    public function format(OutputBlock $block, SourceMapGenerator $sourceMapGenerator = null): string
+    public function format(OutputBlock $block, ?SourceMapGenerator $sourceMapGenerator = null): string
     {
         $this->sourceMapGenerator = null;
 

--- a/src/Logger/AdaptingDeprecationAwareLogger.php
+++ b/src/Logger/AdaptingDeprecationAwareLogger.php
@@ -48,7 +48,7 @@ final class AdaptingDeprecationAwareLogger implements DeprecationAwareLoggerInte
         $this->logger->warn($message, $deprecation, $span, $trace);
     }
 
-    public function debug(string $message, FileSpan $span = null): void
+    public function debug(string $message, ?FileSpan $span = null): void
     {
         $this->logger->debug($message, $span);
     }

--- a/src/Logger/AdaptingLogger.php
+++ b/src/Logger/AdaptingLogger.php
@@ -62,7 +62,7 @@ final class AdaptingLogger implements LocationAwareLoggerInterface
         $this->logger->warn($formattedMessage, $deprecation);
     }
 
-    public function debug(string $message, FileSpan $span = null)
+    public function debug(string $message, ?FileSpan $span = null)
     {
         $location = '';
         if ($span !== null) {

--- a/src/Logger/QuietLogger.php
+++ b/src/Logger/QuietLogger.php
@@ -32,7 +32,7 @@ final class QuietLogger implements LocationAwareLoggerInterface, DeprecationAwar
     {
     }
 
-    public function debug(string $message, FileSpan $span = null): void
+    public function debug(string $message, ?FileSpan $span = null): void
     {
     }
 }

--- a/src/Node/Number.php
+++ b/src/Node/Number.php
@@ -572,7 +572,7 @@ final class Number extends Node implements \ArrayAccess, \JsonSerializable
      *
      * @return string
      */
-    public function output(Compiler $compiler = null)
+    public function output(?Compiler $compiler = null)
     {
         $dimension = round($this->dimension, self::PRECISION);
 

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -136,7 +136,7 @@ final class Parser
      * @param bool                 $cssOnly
      * @param LoggerInterface|null $logger
      */
-    public function __construct(?string $sourceName, int $sourceIndex = 0, Cache $cache = null, bool $cssOnly = false, LoggerInterface $logger = null)
+    public function __construct(?string $sourceName, int $sourceIndex = 0, ?Cache $cache = null, bool $cssOnly = false, ?LoggerInterface $logger = null)
     {
         $this->sourceName       = $sourceName ?: '(stdin)';
         $this->sourceIndex      = $sourceIndex;

--- a/src/Value/ComplexSassNumber.php
+++ b/src/Value/ComplexSassNumber.php
@@ -34,7 +34,7 @@ final class ComplexSassNumber extends SassNumber
      * @param list<string>                       $denominatorUnits
      * @param array{SassNumber, SassNumber}|null $asSlash
      */
-    public function __construct(float $value, array $numeratorUnits, array $denominatorUnits, array $asSlash = null)
+    public function __construct(float $value, array $numeratorUnits, array $denominatorUnits, ?array $asSlash = null)
     {
         assert(\count($numeratorUnits) > 1 || \count($denominatorUnits) > 0);
 

--- a/src/Value/SassColor.php
+++ b/src/Value/SassColor.php
@@ -102,7 +102,7 @@ final class SassColor extends Value
      *
      * @throws \OutOfRangeException if values are outside the expected range.
      */
-    public static function hslInternal(float $hue, float $saturation, float $lightness, float $alpha = 1.0, ColorFormat $format = null): SassColor
+    public static function hslInternal(float $hue, float $saturation, float $lightness, float $alpha = 1.0, ?ColorFormat $format = null): SassColor
     {
         $alpha = NumberUtil::fuzzyAssertRange($alpha, 0, 1, 'alpha');
 

--- a/src/Value/SassNumber.php
+++ b/src/Value/SassNumber.php
@@ -114,7 +114,7 @@ abstract class SassNumber extends Value
     /**
      * @param array{SassNumber, SassNumber}|null $asSlash
      */
-    protected function __construct(float $value, array $asSlash = null)
+    protected function __construct(float $value, ?array $asSlash = null)
     {
         $this->value = $value;
         $this->asSlash = $asSlash;
@@ -826,7 +826,7 @@ abstract class SassNumber extends Value
      *
      * @throws SassScriptException if this number's units are not compatible with $newNumeratorUnits and $newDenominatorUnits
      */
-    private function convertOrCoerceValue(array $newNumeratorUnits, array $newDenominatorUnits, bool $coerceUnitless, ?string $name = null, SassNumber $other = null, ?string $otherName = null): float
+    private function convertOrCoerceValue(array $newNumeratorUnits, array $newDenominatorUnits, bool $coerceUnitless, ?string $name = null, ?SassNumber $other = null, ?string $otherName = null): float
     {
         assert($other === null || ($other->getNumeratorUnits() === $newNumeratorUnits && $other->getDenominatorUnits() === $newDenominatorUnits), sprintf("Expected %s to have units %s.", $other, self::buildUnitString($newNumeratorUnits, $newDenominatorUnits)));
 

--- a/src/Value/SingleUnitSassNumber.php
+++ b/src/Value/SingleUnitSassNumber.php
@@ -96,7 +96,7 @@ final class SingleUnitSassNumber extends SassNumber
     /**
      * @param array{SassNumber, SassNumber}|null $asSlash
      */
-    public function __construct(float $value, string $unit, array $asSlash = null)
+    public function __construct(float $value, string $unit, ?array $asSlash = null)
     {
         parent::__construct($value, $asSlash);
         $this->unit = $unit;

--- a/src/Value/UnitlessSassNumber.php
+++ b/src/Value/UnitlessSassNumber.php
@@ -24,7 +24,7 @@ final class UnitlessSassNumber extends SassNumber
     /**
      * @param array{SassNumber, SassNumber}|null $asSlash
      */
-    public function __construct(float $value, array $asSlash = null)
+    public function __construct(float $value, ?array $asSlash = null)
     {
         parent::__construct($value, $asSlash);
     }

--- a/src/Warn.php
+++ b/src/Warn.php
@@ -64,7 +64,7 @@ final class Warn
      *
      * @internal
      */
-    public static function setCallback(callable $callback = null): ?callable
+    public static function setCallback(?callable $callback = null): ?callable
     {
         $previousCallback = self::$callback;
         self::$callback = $callback;


### PR DESCRIPTION
Implicit nullable types will be deprecated in PHP 8.4.

This is not applied on the 1.x branch because explicit nullable types are not compatible with PHP 5.6.
The diff of this PR is entirely automated using `php-cs-fixer.phar fix --rules=nullable_type_declaration_for_default_null_value src`