### PR TITLE
Deprecate the second argument passed to custom functions

### DIFF
--- a/docs/docs/extending/custom-functions.md
+++ b/docs/docs/extending/custom-functions.md
@@ -61,7 +61,7 @@ reporting.
 
 The callable receives 2 arguments. However, the second one is passed only for
 historical reasons (and for some special internal usages) and should not be used
-anymore.
+anymore. Registering a function that requires 2 parameters to be passed is deprecated.
 
 The first argument is an array of Sass values, with one value per declared
 arguments. The compiler guarantees that all arguments are always provided to the

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -5703,7 +5703,33 @@ EOL;
             @trigger_error('Omitting the argument declaration when registering custom function is deprecated and won\'t be supported in ScssPhp 2.0 anymore.', E_USER_DEPRECATED);
         }
 
+        if ($this->reflectCallable($callback)->getNumberOfRequiredParameters() > 1) {
+            @trigger_error('The second argument passed to the callback of custom functions is deprecated and won\'t be supported in ScssPhp 2.0 anymore. Register a callback accepting only 1 parameter instead.', E_USER_DEPRECATED);
+        }
+
         $this->userFunctions[$this->normalizeName($name)] = [$callback, $argumentDeclaration];
+    }
+
+    /**
+     * @return \ReflectionFunctionAbstract
+     */
+    private function reflectCallable(callable $c)
+    {
+        if (\is_object($c) && !$c instanceof \Closure) {
+            $c = [$c, '__invoke'];
+        }
+
+        if (\is_string($c) && false !== strpos($c, '::')) {
+            $c = explode('::', $c, 2);
+        }
+
+        if (\is_array($c)) {
+            return new \ReflectionMethod($c[0], $c[1]);
+        }
+
+        \assert(\is_string($c) || $c instanceof \Closure);
+
+        return new \ReflectionFunction($c);
     }
 
     /**

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -110,9 +110,14 @@ class ApiTest extends TestCase
         }, []);
     }
 
+    /**
+     * @group legacy
+     */
     public function testUserFunctionKwargs()
     {
         $this->scss = new Compiler();
+
+        $this->expectDeprecation('The second argument passed to the callback of custom functions is deprecated and won\'t be supported in ScssPhp 2.0 anymore. Register a callback accepting only 1 parameter instead.');
 
         $this->scss->registerFunction(
             'divide',


### PR DESCRIPTION
Supporting this second argument in the 2.x codebase will be a pain for the BC layer. It is easier to drop support for it.

The only usages of this argument in core are for cases of overloaded functions where it allows us to distinguish which signature was selected. However, there is no such case for custom function as they don't support overloads. All valid cases can be implemented using only the first argument (and this is what the documentation shows).