### PR TITLE
Fix more mistakes in ported code

### DIFF
--- a/src/Evaluation/EvaluateVisitor.php
+++ b/src/Evaluation/EvaluateVisitor.php
@@ -2395,7 +2395,7 @@ WARNING;
         $first = $textBetweenOperands[0];
         $last = $textBetweenOperands[\strlen($textBetweenOperands) - 1];
 
-        if (!(Character::isWhitespace($first) || $first === '/') && !(Character::isWhitespace($last) || $last === '/')) {
+        if (!(Character::isWhitespace($first) || $first === '/') || !(Character::isWhitespace($last) || $last === '/')) {
             throw $this->exception('"+" and "-" must be surrounded by whitespace in calculations.', $node->getOperatorSpan());
         }
     }

--- a/src/Parser/Parser.php
+++ b/src/Parser/Parser.php
@@ -585,6 +585,10 @@ class Parser
             $value = mb_ord($valueText, 'UTF-8');
         }
 
+        if ($valueText === false) {
+            $this->scanner->error('Invalid Unicode code point.', $start);
+        }
+
         if ($identifierStart ? Character::isNameStart($valueText) : Character::isName($valueText)) {
             if ($value > 0x10ffff) {
                 $this->scanner->error('Invalid Unicode code point.', $start);

--- a/src/Parser/Parser.php
+++ b/src/Parser/Parser.php
@@ -21,7 +21,6 @@ use ScssPhp\ScssPhp\Logger\QuietLogger;
 use ScssPhp\ScssPhp\SourceSpan\FileLocation;
 use ScssPhp\ScssPhp\SourceSpan\FileSpan;
 use ScssPhp\ScssPhp\SourceSpan\LazyFileSpan;
-use ScssPhp\ScssPhp\Util;
 use ScssPhp\ScssPhp\Util\Character;
 use ScssPhp\ScssPhp\Util\ParserUtil;
 
@@ -580,10 +579,10 @@ class Parser
             }
 
             $this->scanCharIf(Character::isWhitespace(...));
-            $valueText = Util::mbChr($value);
+            $valueText = mb_chr($value, 'UTF-8');
         } else {
             $valueText = $this->scanner->readUtf8Char();
-            $value = Util::mbOrd($valueText);
+            $value = mb_ord($valueText, 'UTF-8');
         }
 
         if ($identifierStart ? Character::isNameStart($valueText) : Character::isName($valueText)) {

--- a/src/Serializer/SerializeVisitor.php
+++ b/src/Serializer/SerializeVisitor.php
@@ -45,7 +45,6 @@ use ScssPhp\ScssPhp\OutputStyle;
 use ScssPhp\ScssPhp\Parser\LineScanner;
 use ScssPhp\ScssPhp\Parser\Parser;
 use ScssPhp\ScssPhp\Parser\StringScanner;
-use ScssPhp\ScssPhp\Util;
 use ScssPhp\ScssPhp\Util\Character;
 use ScssPhp\ScssPhp\Util\NumberUtil;
 use ScssPhp\ScssPhp\Util\SpanUtil;
@@ -1366,7 +1365,7 @@ final class SerializeVisitor implements CssVisitor, ValueVisitor, SelectorVisito
 
         if ($extraBytes) {
             $fullChar = substr($string, $i, $extraBytes + 1);
-            $charCode = Util::mbOrd($fullChar);
+            $charCode = mb_ord($fullChar, 'UTF-8');
         } else {
             $fullChar = $char;
             $charCode = $firstByteCode;
@@ -1395,7 +1394,7 @@ final class SerializeVisitor implements CssVisitor, ValueVisitor, SelectorVisito
     private function writeEscape(StringBuffer $buffer, string $character, string $string, int $i): void
     {
         $buffer->writeChar('\\');
-        $buffer->write(dechex(Util::mbOrd($character)));
+        $buffer->write(dechex(mb_ord($character, 'UTF-8')));
 
         if (\strlen($string) === $i + 1) {
             return;

--- a/src/Serializer/SerializeVisitor.php
+++ b/src/Serializer/SerializeVisitor.php
@@ -1723,7 +1723,8 @@ final class SerializeVisitor implements CssVisitor, ValueVisitor, SelectorVisito
             return false;
         }
 
-        $endOffset = strrpos($previous->getSpan()->getText(), '{', $searchFrom);
+        $previousSpanText = $previous->getSpan()->getText();
+        $endOffset = strrpos($previousSpanText, '{', $searchFrom - \strlen($previousSpanText));
         if ($endOffset === false) {
             $endOffset = 0;
         }

--- a/src/Serializer/Serializer.php
+++ b/src/Serializer/Serializer.php
@@ -16,7 +16,6 @@ use ScssPhp\ScssPhp\Ast\Css\CssNode;
 use ScssPhp\ScssPhp\Ast\Selector\Selector;
 use ScssPhp\ScssPhp\Exception\SassScriptException;
 use ScssPhp\ScssPhp\OutputStyle;
-use ScssPhp\ScssPhp\Util;
 use ScssPhp\ScssPhp\Value\Value;
 
 /**
@@ -35,7 +34,7 @@ final class Serializer
 
         $prefix = '';
 
-        if ($charset && strlen($css) !== Util::mbStrlen($css)) {
+        if ($charset && strlen($css) !== mb_strlen($css, 'UTF-8')) {
             if ($style === OutputStyle::COMPRESSED) {
                 $prefix = "\u{FEFF}";
             } else {

--- a/src/Util/ParserUtil.php
+++ b/src/Util/ParserUtil.php
@@ -13,7 +13,6 @@
 namespace ScssPhp\ScssPhp\Util;
 
 use ScssPhp\ScssPhp\Parser\StringScanner;
-use ScssPhp\ScssPhp\Util;
 
 /**
  * @internal
@@ -61,7 +60,7 @@ final class ParserUtil
                 return "\u{FFFD}";
             }
 
-            return Util::mbChr($value);
+            return mb_chr($value, 'UTF-8');
         }
 
         return $scanner->readUtf8Char();

--- a/src/Value/SassNumber.php
+++ b/src/Value/SassNumber.php
@@ -669,7 +669,7 @@ abstract class SassNumber extends Value
         }
 
         if (!$other instanceof SassColor) {
-            return parent::plus($other);
+            return parent::minus($other);
         }
 
         throw new SassScriptException("Undefined operation \"$this - $other\".");

--- a/src/Value/SassString.php
+++ b/src/Value/SassString.php
@@ -13,7 +13,6 @@
 namespace ScssPhp\ScssPhp\Value;
 
 use ScssPhp\ScssPhp\Exception\SassScriptException;
-use ScssPhp\ScssPhp\Util;
 use ScssPhp\ScssPhp\Visitor\ValueVisitor;
 
 /**
@@ -63,7 +62,7 @@ final class SassString extends Value
 
     public function getSassLength(): int
     {
-        return Util::mbStrlen($this->text);
+        return mb_strlen($this->text, 'UTF-8');
     }
 
     public function isSpecialNumber(): bool
@@ -175,7 +174,7 @@ final class SassString extends Value
             return 0;
         }
 
-        return \strlen(Util::mbSubstr($this->text, 0, $codepointIndex));
+        return \strlen(mb_substr($this->text, 0, $codepointIndex, 'UTF-8'));
     }
 
     /**


### PR DESCRIPTION
The issue with the escape sequence detection was at least partially hidden by the usage of ponyfills because `Util::mbChr` has a return type `string` while `mb_chr` returns `string|false` (which for some reason is not reported by phpstan either)