### PR TITLE
Add a make recipe to run phpstan in verbose mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,9 @@ vendor: composer.json
 phpstan: vendor-bin/phpstan/vendor
 	vendor-bin/phpstan/vendor/bin/phpstan analyse
 
+phpstan-verbose: vendor-bin/phpstan/vendor
+	vendor-bin/phpstan/vendor/bin/phpstan analyse -v
+
 phpstan-baseline: vendor-bin/phpstan/vendor
 	vendor-bin/phpstan/vendor/bin/phpstan analyse --generate-baseline
 


### PR DESCRIPTION
The verbose mode allows to see error identifiers, which is helpful when wanting to ignore them.