### PR TITLE
Make the SourceSpan namespace standalone

### DIFF
--- a/src/SourceSpan/ConcreteFileSpan.php
+++ b/src/SourceSpan/ConcreteFileSpan.php
@@ -13,8 +13,6 @@
 namespace ScssPhp\ScssPhp\SourceSpan;
 
 use League\Uri\Contracts\UriInterface;
-use ScssPhp\ScssPhp\Util\ErrorUtil;
-use ScssPhp\ScssPhp\Util\Path;
 
 /**
  * @internal
@@ -167,7 +165,7 @@ final class ConcreteFileSpan extends SourceSpanMixin implements FileSpan
 
     public function subspan(int $start, ?int $end = null): FileSpan
     {
-        ErrorUtil::checkValidRange($start, $end, $this->getLength());
+        Util::checkValidRange($start, $end, $this->getLength());
 
         if ($start === 0 && ($end === null || $end === $this->getLength())) {
             return $this;

--- a/src/SourceSpan/Highlighter/Highlighter.php
+++ b/src/SourceSpan/Highlighter/Highlighter.php
@@ -15,10 +15,6 @@ namespace ScssPhp\ScssPhp\SourceSpan\Highlighter;
 use League\Uri\Contracts\UriInterface;
 use ScssPhp\ScssPhp\SourceSpan\SourceSpan;
 use ScssPhp\ScssPhp\SourceSpan\Util;
-use ScssPhp\ScssPhp\Util\IterableUtil;
-use ScssPhp\ScssPhp\Util\ListUtil;
-use ScssPhp\ScssPhp\Util\Path;
-use stdClass;
 
 /**
  * A class for writing a chunk of text with a particular span highlighted.
@@ -100,7 +96,7 @@ final class Highlighter
     {
         $this->lines = $lines;
         $this->paddingBeforeSidebar = 1 + max(
-            \strlen((string) (ListUtil::last($lines)->number + 1)),
+            \strlen((string) (Util::listLast($lines)->number + 1)),
             // If $lines aren't contiguous, we'll write "..." in place of a
             // line number.
             self::contiguous($lines) ? 0 : 3
@@ -144,7 +140,7 @@ final class Highlighter
         $highlightsByUrl = [];
         $urls = [];
         foreach ($highlights as $highlight) {
-            $url = $highlight->span->getSourceUrl() ?? new stdClass();
+            $url = $highlight->span->getSourceUrl() ?? new \stdClass();
             $key = $url instanceof UriInterface ? $url->toString() : spl_object_hash($url);
             $highlightsByUrl[$key][] = $highlight;
             $urls[$key] = $url;
@@ -172,7 +168,7 @@ final class Highlighter
 
                 foreach (explode("\n", $context) as $line) {
                     // Only add a line if it hasn't already been added for a previous span
-                    if ($lines === [] || $lineNumber > ListUtil::last($lines)->number) {
+                    if ($lines === [] || $lineNumber > Util::listLast($lines)->number) {
                         $lines[] = new Line($line, $lineNumber, $urls[$urlKey]);
                     }
                     $lineNumber++;
@@ -288,7 +284,7 @@ final class Highlighter
         } else {
             $this->writeSidebar(end: AsciiGlyph::topLeftCorner);
             $this->buffer .= str_repeat(AsciiGlyph::horizontalLine, 2) . '> ';
-            $this->buffer .= Path::prettyUri($url);
+            $this->buffer .= Util::prettyUri($url);
         }
 
         $this->buffer .= "\n";

--- a/src/SourceSpan/LazyFileSpan.php
+++ b/src/SourceSpan/LazyFileSpan.php
@@ -13,7 +13,6 @@
 namespace ScssPhp\ScssPhp\SourceSpan;
 
 use League\Uri\Contracts\UriInterface;
-use ScssPhp\ScssPhp\SourceSpan\FileSpan;
 
 /**
  * A wrapper for {@see FileSpan} that allows an expensive creation process to be

--- a/src/SourceSpan/SimpleSourceSpan.php
+++ b/src/SourceSpan/SimpleSourceSpan.php
@@ -12,8 +12,6 @@
 
 namespace ScssPhp\ScssPhp\SourceSpan;
 
-use ScssPhp\ScssPhp\Util\ErrorUtil;
-
 /**
  * @internal
  */
@@ -55,7 +53,7 @@ final class SimpleSourceSpan extends SourceSpanMixin
 
     public function subspan(int $start, ?int $end = null): SourceSpan
     {
-        ErrorUtil::checkValidRange($start, $end, $this->getLength());
+        Util::checkValidRange($start, $end, $this->getLength());
 
         if ($start === 0 && ($end === null || $end === $this->getLength())) {
             return $this;

--- a/src/SourceSpan/SimpleSourceSpanWithContext.php
+++ b/src/SourceSpan/SimpleSourceSpanWithContext.php
@@ -12,8 +12,6 @@
 
 namespace ScssPhp\ScssPhp\SourceSpan;
 
-use ScssPhp\ScssPhp\Util\ErrorUtil;
-
 /**
  * @internal
  */
@@ -70,7 +68,7 @@ final class SimpleSourceSpanWithContext extends SourceSpanMixin implements Sourc
 
     public function subspan(int $start, ?int $end = null): SourceSpanWithContext
     {
-        ErrorUtil::checkValidRange($start, $end, $this->getLength());
+        Util::checkValidRange($start, $end, $this->getLength());
 
         if ($start === 0 && ($end === null || $end === $this->getLength())) {
             return $this;

--- a/src/SourceSpan/SourceFile.php
+++ b/src/SourceSpan/SourceFile.php
@@ -13,7 +13,6 @@
 namespace ScssPhp\ScssPhp\SourceSpan;
 
 use League\Uri\Contracts\UriInterface;
-use ScssPhp\ScssPhp\Util\ListUtil;
 
 /**
  * @internal
@@ -151,7 +150,7 @@ final class SourceFile
             return -1;
         }
 
-        if ($offset >= ListUtil::last($this->lineStarts)) {
+        if ($offset >= Util::listLast($this->lineStarts)) {
             return \count($this->lineStarts) - 1;
         }
 

--- a/src/SourceSpan/SourceSpanMixin.php
+++ b/src/SourceSpan/SourceSpanMixin.php
@@ -14,7 +14,6 @@ namespace ScssPhp\ScssPhp\SourceSpan;
 
 use League\Uri\Contracts\UriInterface;
 use ScssPhp\ScssPhp\SourceSpan\Highlighter\Highlighter;
-use ScssPhp\ScssPhp\Util\Path;
 
 /**
  * A mixin for easily implementing {@see SourceSpan}.
@@ -86,7 +85,7 @@ abstract class SourceSpanMixin implements SourceSpan
         $buffer = "line $startLine, column $startColumn";
 
         if ($sourceUrl !== null) {
-            $prettyUri = Path::prettyUri($sourceUrl);
+            $prettyUri = Util::prettyUri($sourceUrl);
             $buffer .= " of $prettyUri";
         }
 
@@ -110,7 +109,7 @@ abstract class SourceSpanMixin implements SourceSpan
         $buffer = "line $startLine, column $startColumn";
 
         if ($sourceUrl !== null) {
-            $prettyUri = Path::prettyUri($sourceUrl);
+            $prettyUri = Util::prettyUri($sourceUrl);
             $buffer .= " of $prettyUri";
         }
 


### PR DESCRIPTION
This copies the few utilities used in that namespace in its dedicated `Util` class to make it independent from the rest of the repository.
This prepares extracting the source_span port in a dedicated package.

As I have ported the full source_span package now (since #742), I'm fine with providing BC on the ported code. And I have a use case when this SourceSpan package would allow me to provide better error messages so I might reuse it.