### PR TITLE
Add a test covering the highlighting of non-contiguous spans

### DIFF
--- a/tests/SourceSpan/MultipleHighlightTest.php
+++ b/tests/SourceSpan/MultipleHighlightTest.php
@@ -58,6 +58,27 @@ TXT,
         );
     }
 
+    public function testHighlightsNonContiguousSpans(): void
+    {
+        self::assertEquals(
+            <<<'TXT'
+    ,
+1   | foo bar baz
+    |     === three
+2   | whiz bang boom
+    |      ^^^^ one
+... |
+5   | argle bargle boo
+    |       ====== two
+    '
+TXT,
+            $this->file->span(17, 21)->highlightMultiple('one', [
+                'two' => $this->file->span(60, 66),
+                'three' => $this->file->span(4, 7),
+            ])
+        );
+    }
+
     public function testHighlightsSpansOnTheSameLine(): void
     {
         self::assertEquals(


### PR DESCRIPTION
This test has also been submitted upstream at https://github.com/dart-lang/source_span/pull/116