### PR TITLE
Refactor the CssParser to use the FunctionRegistry for known functions

### DIFF
--- a/src/Evaluation/EvaluateVisitor.php
+++ b/src/Evaluation/EvaluateVisitor.php
@@ -375,6 +375,7 @@ class EvaluateVisitor implements StatementVisitor, ExpressionVisitor
         $sassMetaUri = Uri::new('sass:meta');
         // These functions are defined in the context of the evaluator because
         // they need access to the environment or other local state.
+        // When adding a new function here, its name must also be added in {@see FunctionRegistry::SPECIAL_META_GLOBAL_FUNCTIONS}.
         $metaFunctions = [
             BuiltInCallable::function('global-variable-exists', '$name, $module: null', function ($arguments) {
                 $variable = $arguments[0]->assertString('name');

--- a/src/Function/FunctionRegistry.php
+++ b/src/Function/FunctionRegistry.php
@@ -147,6 +147,20 @@ class FunctionRegistry
         'str-slice' => ['overloads' => ['$string, $start-at, $end-at: -1' => [StringFunctions::class, 'slice']], 'url' => 'sass:string'],
     ];
 
+    /**
+     * Special meta functions defined directly in the {@see EvaluateVisitor} constructor
+     */
+    private const SPECIAL_META_GLOBAL_FUNCTIONS = [
+        'global-variable-exists',
+        'variable-exists',
+        'function-exists',
+        'mixin-exists',
+        'content-exists',
+        'get-function',
+        'get-mixin',
+        'call',
+    ];
+
     public static function has(string $name): bool
     {
         return isset(self::BUILTIN_FUNCTIONS[$name]);
@@ -159,5 +173,10 @@ class FunctionRegistry
         }
 
         return BuiltInCallable::overloadedFunction($name, self::BUILTIN_FUNCTIONS[$name]['overloads'], Uri::new(self::BUILTIN_FUNCTIONS[$name]['url']));
+    }
+
+    public static function isBuiltinFunction(string $name): bool
+    {
+        return isset(self::BUILTIN_FUNCTIONS[$name]) || \in_array($name, self::SPECIAL_META_GLOBAL_FUNCTIONS, true);
     }
 }

--- a/src/Parser/CssParser.php
+++ b/src/Parser/CssParser.php
@@ -21,7 +21,7 @@ use ScssPhp\ScssPhp\Ast\Sass\Import\StaticImport;
 use ScssPhp\ScssPhp\Ast\Sass\Interpolation;
 use ScssPhp\ScssPhp\Ast\Sass\Statement;
 use ScssPhp\ScssPhp\Ast\Sass\Statement\ImportRule;
-use ScssPhp\ScssPhp\Compiler;
+use ScssPhp\ScssPhp\Function\FunctionRegistry;
 
 /**
  * A parser for imported CSS files.
@@ -167,7 +167,7 @@ final class CssParser extends ScssParser
             $this->scanner->expectChar(')');
         }
 
-        if ($plain === 'if' || (!isset(self::CSS_ALLOWED_FUNCTIONS[$plain]) && Compiler::isNativeFunction($plain))) {
+        if ($plain === 'if' || (!isset(self::CSS_ALLOWED_FUNCTIONS[$plain]) && FunctionRegistry::isBuiltinFunction($plain))) {
             $this->error("This function isn't allowed in plain CSS.", $this->scanner->spanFrom($start));
         }
 


### PR DESCRIPTION
When implementing the parser initially, the FunctionRegistry was not implemented yet so I reused the API of the old compiler to identify Sass functions. This refactors that code to be ready for the removal of the old compiler.