### PR TITLE
Refactor the CLI tool

### DIFF
--- a/bin/pscss
+++ b/bin/pscss
@@ -122,33 +122,26 @@ EOT;
 }
 
 
-if (isset($arguments[0]) && file_exists($arguments[0])) {
+if (isset($arguments[0])) {
     $inputFile = $arguments[0];
-    $data = file_get_contents($inputFile);
-} else {
-    $data = '';
-
-    while (! feof(STDIN)) {
-        $data .= fread(STDIN, 8192);
-    }
 }
 
-$scss = new Compiler();
+$compiler = new Compiler();
 
 if ($loadPaths) {
-    $scss->setImportPaths($loadPaths);
+    $compiler->setImportPaths($loadPaths);
 }
 
 if ($style) {
     if ($style === OutputStyle::COMPRESSED || $style === OutputStyle::EXPANDED) {
-        $scss->setOutputStyle($style);
+        $compiler->setOutputStyle($style);
     } else {
         fwrite(STDERR, "Error: the $style style is invalid.\n");
         exit(1);
     }
 }
 
-$outputFile = isset($arguments[1]) ? $arguments[1] : null;
+$outputFile = $arguments[1] ?? null;
 $sourceMapFile = null;
 
 if ($sourceMap) {
@@ -156,33 +149,42 @@ if ($sourceMap) {
         'outputSourceFiles' => $embedSources,
     );
     if ($embedSourceMap || $outputFile === null) {
-        $scss->setSourceMap(Compiler::SOURCE_MAP_INLINE);
+        $compiler->setSourceMap(Compiler::SOURCE_MAP_INLINE);
     } else {
         $sourceMapFile = $outputFile . '.map';
-        $sourceMapOptions['sourceMapWriteTo'] = $sourceMapFile;
         $sourceMapOptions['sourceMapURL'] = basename($sourceMapFile);
         $sourceMapOptions['sourceMapBasepath'] = getcwd();
         $sourceMapOptions['sourceMapFilename'] = basename($outputFile);
 
-        $scss->setSourceMap(Compiler::SOURCE_MAP_FILE);
+        $compiler->setSourceMap(Compiler::SOURCE_MAP_FILE);
     }
 
-    $scss->setSourceMapOptions($sourceMapOptions);
+    $compiler->setSourceMapOptions($sourceMapOptions);
 }
 
 try {
-    $result = $scss->compileString($data, $inputFile);
+    if ($inputFile !== null) {
+        $result = $compiler->compileFile($inputFile);
+    } else {
+        $data = '';
+
+        while (! feof(STDIN)) {
+            $data .= fread(STDIN, 8192);
+        }
+
+        $result = $compiler->compileString($data, $inputFile);
+    }
 } catch (SassException $e) {
-    fwrite(STDERR, 'Error: '.$e->getMessage()."\n");
+    fwrite(STDERR, 'Error: '.$e->getMessage() . "\n");
     exit(1);
 }
 
 if ($outputFile) {
-    file_put_contents($outputFile, $result->getCss());
+    file_put_contents($outputFile, $result->getCss() . "\n");
 
     if ($sourceMapFile !== null && $result->getSourceMap() !== null) {
         file_put_contents($sourceMapFile, $result->getSourceMap());
     }
 } else {
-    echo $result->getCss();
+    echo $result->getCss() . "\n";
 }


### PR DESCRIPTION
- Ensure that the CSS is written with a final EOL
- Use `Compiler::compileFile` when using a file as input
- Rename the variable holding the compiler to make the code clearer