### PR TITLE
Sync ported code from dart-sass

### DIFF
--- a/src/Ast/Css/CssDeclaration.php
+++ b/src/Ast/Css/CssDeclaration.php
@@ -13,6 +13,7 @@
 namespace ScssPhp\ScssPhp\Ast\Css;
 
 use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+use ScssPhp\ScssPhp\StackTrace\Trace;
 use ScssPhp\ScssPhp\Value\Value;
 
 /**
@@ -35,6 +36,27 @@ interface CssDeclaration extends CssNode
      * @return CssValue<Value>
      */
     public function getValue(): CssValue;
+
+    /**
+     * A list of style rules that appeared before this declaration in the Sass
+     * input but after it in the CSS output.
+     *
+     * These are used to emit mixed declaration deprecation warnings during
+     * serialization, so we can check based on specificity whether the warnings
+     * are really necessary without worrying about `@extend` potentially changing
+     * things up.
+     *
+     * @return list<CssStyleRule>
+     */
+    public function getInterleavedRules(): array;
+
+    /**
+     * The stack trace indicating where this node was created.
+     *
+     * This is used to emit interleaved declaration warnings, and only needs to be set if
+     * {@see getInterleavedRules} isn't empty.
+     */
+    public function getTrace(): ?Trace;
 
     /**
      * The span for {@see getValue} that should be emitted to the source map.

--- a/src/Ast/Css/CssNode.php
+++ b/src/Ast/Css/CssNode.php
@@ -23,6 +23,11 @@ use ScssPhp\ScssPhp\Visitor\CssVisitor;
 interface CssNode extends AstNode
 {
     /**
+     * The node that contains this, or `null` for the root {@see CssStylesheet} node.
+     */
+    public function getParent(): ?CssParentNode;
+
+    /**
      * Whether this was generated from the last node in a nested Sass tree that
      * got flattened during evaluation.
      */

--- a/src/Ast/Css/ModifiableCssDeclaration.php
+++ b/src/Ast/Css/ModifiableCssDeclaration.php
@@ -13,6 +13,7 @@
 namespace ScssPhp\ScssPhp\Ast\Css;
 
 use ScssPhp\ScssPhp\SourceSpan\FileSpan;
+use ScssPhp\ScssPhp\StackTrace\Trace;
 use ScssPhp\ScssPhp\Value\SassString;
 use ScssPhp\ScssPhp\Value\Value;
 use ScssPhp\ScssPhp\Visitor\ModifiableCssVisitor;
@@ -34,6 +35,13 @@ final class ModifiableCssDeclaration extends ModifiableCssNode implements CssDec
      */
     private readonly CssValue $value;
 
+    /**
+     * @var list<CssStyleRule>
+     */
+    private readonly array $interleavedRules;
+
+    private readonly ?Trace $trace;
+
     private readonly bool $parsedAsCustomProperty;
 
     private readonly FileSpan $valueSpanForMap;
@@ -43,12 +51,15 @@ final class ModifiableCssDeclaration extends ModifiableCssNode implements CssDec
     /**
      * @param CssValue<string> $name
      * @param CssValue<Value> $value
+     * @param list<CssStyleRule> $interleavedRules
      */
-    public function __construct(CssValue $name, CssValue $value, FileSpan $span, bool $parsedAsCustomProperty, ?FileSpan $valueSpanForMap = null)
+    public function __construct(CssValue $name, CssValue $value, FileSpan $span, bool $parsedAsCustomProperty, array $interleavedRules = [], ?Trace $trace = null, ?FileSpan $valueSpanForMap = null)
     {
         $this->name = $name;
         $this->value = $value;
         $this->parsedAsCustomProperty = $parsedAsCustomProperty;
+        $this->interleavedRules = $interleavedRules;
+        $this->trace = $trace;
         $this->valueSpanForMap = $valueSpanForMap ?? $value->getSpan();
         $this->span = $span;
 
@@ -71,6 +82,16 @@ final class ModifiableCssDeclaration extends ModifiableCssNode implements CssDec
     public function getValue(): CssValue
     {
         return $this->value;
+    }
+
+    public function getInterleavedRules(): array
+    {
+        return $this->interleavedRules;
+    }
+
+    public function getTrace(): ?Trace
+    {
+        return $this->trace;
     }
 
     public function isParsedAsCustomProperty(): bool

--- a/src/Ast/Sass/Expression/StringExpression.php
+++ b/src/Ast/Sass/Expression/StringExpression.php
@@ -58,6 +58,15 @@ final class StringExpression implements Expression
         return $buffer;
     }
 
+    /**
+     * Interpolation that, when evaluated, produces the contents of this string.
+     *
+     * Unlike {@see asInterpolation}, escapes are resolved and quotes are not
+     * included.
+     * If this is a quoted string, escapes are resolved and quotes are not
+     * included in this text (unlike {@see asInterpolation}). If it's an unquoted
+     * string, escapes are *not* resolved.
+     */
     public function getText(): Interpolation
     {
         return $this->text;

--- a/src/Ast/Selector/SelectorList.php
+++ b/src/Ast/Selector/SelectorList.php
@@ -44,7 +44,7 @@ final class SelectorList extends Selector
      *
      * This is never empty.
      *
-     * @var list<ComplexSelector>
+     * @var non-empty-list<ComplexSelector>
      */
     private readonly array $components;
 
@@ -80,7 +80,7 @@ final class SelectorList extends Selector
     }
 
     /**
-     * @return list<ComplexSelector>
+     * @return non-empty-list<ComplexSelector>
      */
     public function getComponents(): array
     {

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -13,6 +13,7 @@
 namespace ScssPhp\ScssPhp;
 
 use League\Uri\Uri;
+use ScssPhp\ScssPhp\Ast\Css\CssParentNode;
 use ScssPhp\ScssPhp\Ast\Sass\Statement\Stylesheet;
 use ScssPhp\ScssPhp\Collection\Map;
 use ScssPhp\ScssPhp\Compiler\LegacyValueVisitor;
@@ -430,7 +431,8 @@ final class Compiler
      */
     public function compileFile(string $path): CompilationResult
     {
-        // Force loading the CssVisitor before using the AST classes because of a weird PHP behavior.
+        // Force loading the CssParentNode and CssVisitor before using the AST classes because of a weird PHP behavior.
+        class_exists(CssParentNode::class);
         class_exists(CssVisitor::class);
 
         $logger = new DeprecationProcessingLogger($this->logger, $this->silenceDeprecations, $this->fatalDeprecations, $this->futureDeprecations, !$this->verbose);
@@ -465,7 +467,8 @@ final class Compiler
      */
     public function compileString(string $source, ?string $path = null): CompilationResult
     {
-        // Force loading the CssVisitor before using the AST classes because of a weird PHP behavior.
+        // Force loading the CssParentNode and CssVisitor before using the AST classes because of a weird PHP behavior.
+        class_exists(CssParentNode::class);
         class_exists(CssVisitor::class);
 
         $logger = new DeprecationProcessingLogger($this->logger, $this->silenceDeprecations, $this->fatalDeprecations, $this->futureDeprecations, !$this->verbose);
@@ -545,7 +548,7 @@ final class Compiler
 
         $evaluateResult = (new EvaluateVisitor($importCache, $functions, $logger, $this->quietDeps, sourceMap: $wantsSourceMap))->run($importer, $stylesheet, $initialVariables);
 
-        $serializeResult = Serializer::serialize($evaluateResult->getStylesheet(), style: $this->outputStyle, sourceMap: $wantsSourceMap, charset: $this->charset);
+        $serializeResult = Serializer::serialize($evaluateResult->getStylesheet(), style: $this->outputStyle, sourceMap: $wantsSourceMap, charset: $this->charset, logger: $logger);
 
         $css = $serializeResult->css;
         $sourceMap = null;

--- a/src/Deprecation.php
+++ b/src/Deprecation.php
@@ -81,6 +81,11 @@ enum Deprecation: string
     case mixedDecls = 'mixed-decls';
 
     /**
+     * Deprecation for meta.feature-exists.
+     */
+    case featureExists = 'feature-exists';
+
+    /**
      * Used for deprecations coming from user-authored code.
      */
     case userAuthored = 'user-authored';
@@ -100,6 +105,7 @@ enum Deprecation: string
             self::absPercent => 'Passing percentages to the Sass abs() function.',
             self::cssFunctionMixin => 'Function and mixin names beginning with --.',
             self::mixedDecls => 'Declarations after or between nested rules.',
+            self::featureExists => 'meta.feature-exists',
             self::userAuthored => null,
         };
     }
@@ -122,6 +128,7 @@ enum Deprecation: string
             self::absPercent => '2.0.0',
             self::cssFunctionMixin => '2.0.0',
             self::mixedDecls => '2.0.0',
+            self::featureExists => '2.0.0',
             self::userAuthored => null,
         };
     }

--- a/src/Evaluation/EvaluateVisitor.php
+++ b/src/Evaluation/EvaluateVisitor.php
@@ -1469,7 +1469,13 @@ class EvaluateVisitor implements StatementVisitor, ExpressionVisitor
             $this->endOfImports++;
         }
 
-        $this->getParent()->addChild(new ModifiableCssComment($this->performInterpolation($node->getText()), $node->getSpan()));
+        $text = $this->performInterpolation($node->getText());
+        // Indented syntax doesn't require */
+        if (!str_ends_with($text, '*/')) {
+            $text .= ' */';
+        }
+
+        $this->getParent()->addChild(new ModifiableCssComment($text, $node->getSpan()));
 
         return null;
     }

--- a/src/Evaluation/EvaluateVisitor.php
+++ b/src/Evaluation/EvaluateVisitor.php
@@ -967,23 +967,48 @@ class EvaluateVisitor implements StatementVisitor, ExpressionVisitor
         }
 
         \assert($this->getParent()->getParent() !== null);
-        $sibling = ListUtil::last($this->getParent()->getParent()->getChildren());
+        $siblings = $this->getParent()->getParent()->getChildren();
+        $interleavedRules = [];
 
-        if ($sibling !== $this->getParent()) {
-            $this->warn(
-                <<<'MESSAGE'
-                Sass's behavior for declarations that appear after nested
-                rules will be changing to match the behavior specified by CSS in an upcoming
-                version. To keep the existing behavior, move the declaration above the nested
-                rule. To opt into the new behavior, wrap the declaration in `& {}`.
+        if (
+            ListUtil::last($siblings) !== $this->getParent()
+            // Reproduce this condition from {@see warn} so that we don't add anything to
+            // $interleavedRules for declarations in dependencies.
+            && !($this->quietDeps && ($this->inDependency || ($this->currentCallable?->isInDependency() ?? false)))
+        ) {
+            $parentOffset = array_search($this->getParent(), $siblings, true);
+            if ($parentOffset === false) {
+                $parentOffset = -1;
+            }
+            foreach (array_slice($siblings, $parentOffset + 1) as $sibling) {
+                if ($sibling instanceof CssComment) {
+                    continue;
+                }
 
-                More info: https://sass-lang.com/d/mixed-decls
-                MESSAGE,
-                new MultiSpan($node->getSpan(), 'declaration', [
-                    'nested rule' => $sibling->getSpan(),
-                ]),
-                Deprecation::mixedDecls
-            );
+                if ($sibling instanceof CssStyleRule) {
+                    $interleavedRules[] = $sibling;
+                    continue;
+                }
+
+                // Always warn for siblings that aren't style rules, because they
+                // add no specificity and they're nested in the same parent as this
+                // declaration.
+                $this->warn(
+                    <<<'MESSAGE'
+                    Sass's behavior for declarations that appear after nested
+                    rules will be changing to match the behavior specified by CSS in an upcoming
+                    version. To keep the existing behavior, move the declaration above the nested
+                    rule. To opt into the new behavior, wrap the declaration in `& {}`.
+
+                    More info: https://sass-lang.com/d/mixed-decls
+                    MESSAGE,
+                    new MultiSpan($node->getSpan(), 'declaration', [
+                        'nested rule' => $sibling->getSpan(),
+                    ]),
+                    Deprecation::mixedDecls
+                );
+                $interleavedRules = [];
+            }
         }
 
         $name = $this->interpolationToValue($node->getName(), true);
@@ -1005,7 +1030,15 @@ class EvaluateVisitor implements StatementVisitor, ExpressionVisitor
                     $valueSpanForMap = $this->expressionNode($node->getValue())->getSpan();
                 }
 
-                $this->getParent()->addChild(new ModifiableCssDeclaration($name, new CssValue($value, $expression->getSpan()), $node->getSpan(), $node->isCustomProperty(), $valueSpanForMap));
+                $this->getParent()->addChild(new ModifiableCssDeclaration(
+                    $name,
+                    new CssValue($value, $expression->getSpan()),
+                    $node->getSpan(),
+                    $node->isCustomProperty(),
+                    $interleavedRules,
+                    $interleavedRules === [] ? null : $this->stackTrace($node->getSpan()),
+                    $valueSpanForMap,
+                ));
             } elseif (str_starts_with($name->getValue(), '--')) {
                 throw $this->exception('Custom property values may not be empty.', $expression->getSpan());
             }

--- a/src/Function/MetaFunctions.php
+++ b/src/Function/MetaFunctions.php
@@ -13,6 +13,7 @@
 namespace ScssPhp\ScssPhp\Function;
 
 use ScssPhp\ScssPhp\Collection\Map;
+use ScssPhp\ScssPhp\Deprecation;
 use ScssPhp\ScssPhp\Exception\SassScriptException;
 use ScssPhp\ScssPhp\Value\SassArgumentList;
 use ScssPhp\ScssPhp\Value\SassBoolean;
@@ -26,6 +27,7 @@ use ScssPhp\ScssPhp\Value\SassNull;
 use ScssPhp\ScssPhp\Value\SassNumber;
 use ScssPhp\ScssPhp\Value\SassString;
 use ScssPhp\ScssPhp\Value\Value;
+use ScssPhp\ScssPhp\Warn;
 
 /**
  * @internal
@@ -37,6 +39,8 @@ final class MetaFunctions
      */
     public static function featureExists(array $arguments): Value
     {
+        Warn::forDeprecation("The feature-exists() function is deprecated.\n\nMore info: https://sass-lang.com/d/feature-exists", Deprecation::featureExists);
+
         $feature = $arguments[0]->assertString('feature');
 
         return SassBoolean::create(\in_array($feature->getText(), ['global-variable-shadowing', 'extend-selector-pseudoclass', 'units-level-3', 'at-error', 'custom-property'], true));

--- a/src/Parser/SassParser.php
+++ b/src/Parser/SassParser.php
@@ -355,10 +355,6 @@ final class SassParser extends StylesheetParser
             $this->readIndentation();
         }
 
-        if (!str_ends_with(rtrim($buffer->getTrailingString()), '*/')) {
-            $buffer->write(' */');
-        }
-
         return new LoudComment($buffer->buildInterpolation($this->scanner->spanFrom($start)));
     }
 

--- a/src/Parser/StylesheetParser.php
+++ b/src/Parser/StylesheetParser.php
@@ -927,12 +927,12 @@ abstract class StylesheetParser extends Parser
         $buffer->write('(');
         $this->whitespace();
 
-        $buffer->add($this->expression());
+        $this->addOrInject($buffer, $this->expression());
 
         if ($this->scanner->scanChar(':')) {
             $this->whitespace();
             $buffer->write(': ');
-            $buffer->add($this->expression());
+            $this->addOrInject($buffer, $this->expression());
         }
 
         $this->scanner->expectChar(')');
@@ -4252,6 +4252,19 @@ WARNING;
         }
 
         $this->error("Private members can't be accessed from outside their modules.", $span());
+    }
+
+    /**
+     * Adds $expression to $buffer, or if it's an unquoted string adds the
+     * interpolation it contains instead.
+     */
+    private function addOrInject(InterpolationBuffer $buffer, Expression $expression): void
+    {
+        if ($expression instanceof StringExpression && !$expression->hasQuotes()) {
+            $buffer->addInterpolation($expression->getText());
+        } else {
+            $buffer->add($expression);
+        }
     }
 
     /**

--- a/src/Parser/StylesheetParser.php
+++ b/src/Parser/StylesheetParser.php
@@ -907,7 +907,7 @@ abstract class StylesheetParser extends Parser
             return $this->withChildren($this->statement(...), $start, fn(array $children, FileSpan $span) => new AtRootRule($children, $span, $query));
         }
 
-        if ($this->lookingAtChildren()) {
+        if ($this->lookingAtChildren() || ($this->isIndented() && $this->atEndOfStatement())) {
             return $this->withChildren($this->statement(...), $start, fn(array $children, FileSpan $span) => new AtRootRule($children, $span));
         }
 

--- a/src/Serializer/Serializer.php
+++ b/src/Serializer/Serializer.php
@@ -15,6 +15,7 @@ namespace ScssPhp\ScssPhp\Serializer;
 use ScssPhp\ScssPhp\Ast\Css\CssNode;
 use ScssPhp\ScssPhp\Ast\Selector\Selector;
 use ScssPhp\ScssPhp\Exception\SassScriptException;
+use ScssPhp\ScssPhp\Logger\LoggerInterface;
 use ScssPhp\ScssPhp\OutputStyle;
 use ScssPhp\ScssPhp\Value\Value;
 
@@ -23,9 +24,9 @@ use ScssPhp\ScssPhp\Value\Value;
  */
 final class Serializer
 {
-    public static function serialize(CssNode $node, bool $inspect = false, OutputStyle $style = OutputStyle::EXPANDED, bool $sourceMap = false, bool $charset = true): SerializeResult
+    public static function serialize(CssNode $node, bool $inspect = false, OutputStyle $style = OutputStyle::EXPANDED, bool $sourceMap = false, bool $charset = true, ?LoggerInterface $logger = null): SerializeResult
     {
-        $visitor = new SerializeVisitor($inspect, true, $style, $sourceMap);
+        $visitor = new SerializeVisitor($inspect, true, $style, $sourceMap, $logger);
         $node->accept($visitor);
         $css = (string) $visitor->getBuffer();
 

--- a/tests/SassSpecTest.php
+++ b/tests/SassSpecTest.php
@@ -201,7 +201,11 @@ class SassSpecTest extends TestCase
 
         $compiler = new Compiler();
         $compiler->setVerbose(true);
-        $compiler->setSilenceDeprecations([Deprecation::mixedDecls]);
+        // Silence deprecations that don't exist yet in the version of sass-spec that we use.
+        $compiler->setSilenceDeprecations([
+            Deprecation::mixedDecls,
+            Deprecation::featureExists,
+        ]);
 
         list($options, $scss, $includes, $inputDir, $indented) = $input;
         list($css, $warning, $error, $alternativeCssOutputs, $alternativeWarnings) = $testCaseOutput;


### PR DESCRIPTION
A few changes have been excluded from this update:

- the implementation of the `global-builtin` future deprecation, as that deprecation only makes sense when Sass modules are supported (for the same reason, we don't implement yet the `import` future deprecation)
- the implementation of the new Color API for color spaces (as it relies on modules to be usable)