### PR TITLE
Fix compatibility with PHP 8.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [ '8.2', '8.3' ]
+                php: [ '8.1', '8.2', '8.3' ]
                 extensions: [ '' ]
                 os: [ubuntu-latest]
                 include:

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "psr-4": { "ScssPhp\\ScssPhp\\Tests\\": "tests/" }
     },
     "require": {
-        "php": ">=8.2",
+        "php": ">=8.1",
         "ext-ctype": "*",
         "ext-json": "*",
         "league/uri": "^7.4",

--- a/src/Value/SassNumber.php
+++ b/src/Value/SassNumber.php
@@ -597,7 +597,8 @@ abstract class SassNumber extends Value
         }
 
         try {
-            $this->greaterThan($other);
+            $other->coerceValueToMatch($this);
+
             return true;
         } catch (SassScriptException) {
             return false;


### PR DESCRIPTION
The combination of first-class callables and Exceptions may cause a crash in PHP 8.1 that is fixed for PHP 8.2+ in
php/php-src@b3e26c3036a54e9821ea7119c26cdabe484fe36d.

It specifically can be triggered by the use of `SaasNumber::isComparableTo()` for incomparable numbers and is caused by the
`NumberUtil::fuzzyGreaterThan(...)` FCC as used in `SaasNumber::greaterThan()`.

Fix this issue by calling `$other->coerceValueToMatch($this);` directly, which is the function that is responsible for throwing the `SassScriptException` inside of `SaasNumber::greaterThan()`.

see scssphp/scssphp#746
see scssphp/scssphp#751
see https://github.com/scssphp/scssphp/issues/752#issuecomment-2423857568