### PR TITLE
Fix exponentation deprecation for PHP 8.4

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -187,6 +187,12 @@ parameters:
 			path: src/Serializer/SerializeVisitor.php
 
 		-
+			message: '#^Strict comparison using \=\=\= between ''\-0'' and ''0'' will always evaluate to false\.$#'
+			identifier: identical.alwaysFalse
+			count: 1
+			path: src/Util/NumberUtil.php
+
+		-
 			message: '#^Method ScssPhp\\ScssPhp\\Value\\SassMap\:\:tryMap\(\) never returns null so it can be removed from the return type\.$#'
 			identifier: return.unusedType
 			count: 1

--- a/src/Util/NumberUtil.php
+++ b/src/Util/NumberUtil.php
@@ -286,11 +286,11 @@ final class NumberUtil
     public static function signIncludingZero(float $num): int
     {
         // In PHP, negative 0 and positive 0 are equal even for strict equality, so we need a different detection
-        if ($num ** -1 === -INF) {
-            return -1;
-        }
-
         if ($num === 0.0) {
+            if ('-0' === (string) $num) {
+                return -1;
+            }
+
             return 1;
         }
 

--- a/src/Util/NumberUtil.php
+++ b/src/Util/NumberUtil.php
@@ -257,7 +257,13 @@ final class NumberUtil
         $base->assertNoUnits('base');
         $exponent->assertNoUnits('exponent');
 
-        return SassNumber::create($base->getValue() ** $exponent->getValue());
+        if (\PHP_VERSION_ID >= 80400) {
+            $value = fpow($base->getValue(), $exponent->getValue());
+        } else {
+            $value = $base->getValue() ** $exponent->getValue();
+        }
+
+        return SassNumber::create($value);
     }
 
     public static function atan2(SassNumber $y, SassNumber $x): SassNumber

--- a/vendor-bin/phpstan/composer.json
+++ b/vendor-bin/phpstan/composer.json
@@ -6,5 +6,8 @@
         "jiripudil/phpstan-sealed-classes": "^1.3",
         "phpstan/phpstan": "^2.0",
         "phpstan/phpstan-deprecation-rules": "^2.0"
+    },
+    "require-dev": {
+        "symfony/polyfill-php84": "^1.32@dev"
     }
 }


### PR DESCRIPTION
PHP 8.4 has deprecated the usage of the exponentiation operator with 0 as base and a negative exponent, to be consistent with the behavior of `pow` for integers. It also introduces a new `fpow` function to expose the standard behavior for floats (which we want to keep, as Sass numbers are floats).