### PR TITLE
Update the signature of `compileString` to allow passing an importer

### DIFF
--- a/bin/pscss
+++ b/bin/pscss
@@ -173,7 +173,7 @@ try {
             $data .= fread(STDIN, 8192);
         }
 
-        $result = $compiler->compileString($data, $inputFile);
+        $result = $compiler->compileString($data);
     }
 } catch (SassException $e) {
     fwrite(STDERR, 'Error: '.$e->getMessage() . "\n");


### PR DESCRIPTION
This makes the signature of the method compatible with the equivalent API in dart-sass.
Passing an importer allows to handle the case where the source being compiled corresponds to a canonical URL handled by an importer that is not a filesystem importer.