### PR TITLE
Add a test covering the generation of inline source maps

### DIFF
--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -329,6 +329,30 @@ SCSS;
         $this->assertNotEmpty($result->getSourceMap());
     }
 
+    public function testInlineSourceMap()
+    {
+        $source = <<<'SCSS'
+@import "test.css";
+
+body {
+  background-color: orange;
+
+  h1 {
+    border: 2rem dashed black;
+  }
+}
+
+SCSS;
+
+        $compiler = new Compiler();
+        $compiler->setSourceMap(Compiler::SOURCE_MAP_INLINE);
+
+        $result = $compiler->compileString($source);
+
+        $this->assertStringContainsString('/*# sourceMappingURL=data:application/json;charset=utf-8,', $result->getCss());
+        $this->assertNotEmpty($result->getSourceMap());
+    }
+
     public function testGetStringText()
     {
         $compiler = new Compiler();


### PR DESCRIPTION
This adds a test covering the fix done in #787 to prevent future regressions.