### PR TITLE
Remove check redundant with static analysis

### DIFF
--- a/src/Ast/Sass/Interpolation.php
+++ b/src/Ast/Sass/Interpolation.php
@@ -60,9 +60,7 @@ final class Interpolation implements SassNode
     public function __construct(array $contents, FileSpan $span)
     {
         for ($i = 0; $i < \count($contents); $i++) {
-            if (!\is_string($contents[$i]) && !$contents[$i] instanceof Expression) {
-                throw new \TypeError('The contents of an Interpolation may only contain strings or Expression instances.');
-            }
+            // Dart-sass has a validation on the type of elements here. This is useless for us because phpstan supports union types, unlike the Dart type system
 
             if ($i != 0 && \is_string($contents[$i]) && \is_string($contents[$i - 1])) {
                 throw new \InvalidArgumentException('The contents of an Interpolation may not contain adjacent strings.');


### PR DESCRIPTION
dart-sass performs some checks for the types of elements in an Interpolation because Dart does not support union types (and so this is not checked by the compiler).
This check is redundant in our case because we use a union type for the precise type, and phpstan detects this as dead code due to the condition always being false.

I kept a comment here to simplify updates with dart-sass changes.