### PR TITLE
feat: Import parsing through an ImportParser

### DIFF
--- a/src/Importer/ImportCache.php
+++ b/src/Importer/ImportCache.php
@@ -32,6 +32,8 @@ final class ImportCache
 
     private readonly LoggerInterface $logger;
 
+    private ImportParserInterface $importParser;
+
     /**
      * The canonicalized URLs for each non-canonical URL.
      *
@@ -75,10 +77,11 @@ final class ImportCache
     /**
      * @param list<Importer> $importers
      */
-    public function __construct(array $importers, LoggerInterface $logger)
+    public function __construct(array $importers, LoggerInterface $logger, ImportParserInterface $importParser)
     {
         $this->importers = $importers;
         $this->logger = $logger;
+        $this->importParser = $importParser;
         $this->perImporterCanonicalizeCache = new \SplObjectStorage();
     }
 
@@ -256,7 +259,7 @@ final class ImportCache
 
         $this->resultsCache[(string) $canonicalUrl] = $result;
 
-        return Stylesheet::parse($result->getContents(), $result->getSyntax(), $quiet ? new QuietLogger() : $this->logger, self::resolveUri($originalUrl, $canonicalUrl));
+        return ($this->importParser)::parse($result->getContents(), $result->getSyntax(), $quiet ? new QuietLogger() : $this->logger, self::resolveUri($originalUrl, $canonicalUrl));
     }
 
     public function humanize(UriInterface $canonicalUrl): UriInterface

--- a/src/Importer/ImportParser.php
+++ b/src/Importer/ImportParser.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Importer;
+
+use League\Uri\Contracts\UriInterface;
+use League\Uri\Uri;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\Stylesheet;
+use ScssPhp\ScssPhp\Exception\SassFormatException;
+use ScssPhp\ScssPhp\Logger\LoggerInterface;
+use ScssPhp\ScssPhp\Syntax;
+
+final class ImportParser implements ImportParserInterface
+{
+
+    /**
+     * @throws SassFormatException when parsing fails
+     */
+    public static function parse(string $contents, Syntax $syntax, ?LoggerInterface $logger = null, ?UriInterface $sourceUrl = null): Stylesheet
+    {
+        return Stylesheet::parse($contents, $syntax, $logger, $sourceUrl);
+    }
+}

--- a/src/Importer/ImportParserInterface.php
+++ b/src/Importer/ImportParserInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * SCSSPHP
+ *
+ * @copyright 2012-2020 Leaf Corcoran
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @link http://scssphp.github.io/scssphp
+ */
+
+namespace ScssPhp\ScssPhp\Importer;
+
+use League\Uri\Contracts\UriInterface;
+use League\Uri\Uri;
+use ScssPhp\ScssPhp\Ast\Sass\Statement\Stylesheet;
+use ScssPhp\ScssPhp\Exception\SassFormatException;
+use ScssPhp\ScssPhp\Logger\LoggerInterface;
+use ScssPhp\ScssPhp\Syntax;
+
+
+interface ImportParserInterface
+{
+
+    /**
+     * @throws SassFormatException when parsing fails
+     */
+    public static function parse(string $contents, Syntax $syntax, ?LoggerInterface $logger = null, ?UriInterface $sourceUrl = null): Stylesheet;
+
+}


### PR DESCRIPTION
The ImportParser can be changed in the compiler with the `setImportParser` method before compilation.
This allow to implement an alternative ImportParser that can integrate a cache on parsed files.

See https://git.spip.net/spip-contrib-extensions/scssphp/-/merge_requests/20 for an example of usage.

This proposal follows !800 and the discussion there