### PR TITLE
Add a `--trace` option in our CLI

### DIFF
--- a/bin/pscss
+++ b/bin/pscss
@@ -29,6 +29,7 @@ $encoding = false;
 $sourceMap = false;
 $embedSources = false;
 $embedSourceMap = false;
+$trace = false;
 
 /**
  * Parse argument
@@ -74,6 +75,7 @@ Options include:
     --embed-sources     Embed source file contents in source maps
     --embed-source-map  Embed the source map contents in CSS (default if writing to stdout)
     --style=FORMAT      Set the output style (compressed or expanded) [-s, -t]
+    --trace             Show the full PHP stack trace of exceptions
     --version           Print the version [-v]
 
 EOT;
@@ -96,6 +98,11 @@ EOT;
 
     if ($argv[$i] === '--embed-source-map') {
         $embedSourceMap = true;
+        continue;
+    }
+
+    if ($argv[$i] === '--trace') {
+        $trace = true;
         continue;
     }
 
@@ -177,6 +184,13 @@ try {
     }
 } catch (SassException $e) {
     fwrite(STDERR, 'Error: '.$e->getMessage() . "\n");
+    if ($trace) {
+        fwrite(STDERR, "\n" . $e::class . ' in ' . $e->getFile() . '(' . $e->getLine() . ")\n\n" . $e->getTraceAsString() . "\n");
+
+        while ($e = $e->getPrevious()) {
+            fwrite(STDERR, "\n\nCaused by " . $e::class . ' in ' . $e->getFile() . '(' . $e->getLine() . '): ' . $e->getMessage() . "\n\n" . $e->getTraceAsString() . "\n");
+        }
+    }
     exit(1);
 }
 


### PR DESCRIPTION
This option (inspired by the equivalent option of dart-sass) will display the PHP stack trace for any `SassException` reported during the execution, to make it easier to debug issues when we don't actually expect to get this exception.

This is not enabled by default to keep our (contributor-only) CLI in sync with the expectations of the upstream sass-spec runner, to be able to run the official sass-spec through the official runner if needed (not yet working due to our custom skipping of module-based tests).