### PR TITLE
Fix compatibility with `league/uri` v7.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,8 @@
         "php": ">=8.1",
         "ext-ctype": "*",
         "ext-json": "*",
-        "league/uri": "^7.4",
-        "league/uri-interfaces": "^7.4",
+        "league/uri": "dev-master",
+        "league/uri-interfaces": "dev-master",
         "scssphp/source-span": "^1.0",
         "symfony/filesystem": "^5.4 || ^6.0 || ^7.0",
         "symfony/polyfill-mbstring": "^1.30"

--- a/src/Util/Path.php
+++ b/src/Util/Path.php
@@ -2,7 +2,6 @@
 
 namespace ScssPhp\ScssPhp\Util;
 
-use League\Uri\BaseUri;
 use League\Uri\Contracts\UriInterface;
 use League\Uri\Uri;
 use Symfony\Component\Filesystem\Exception\InvalidArgumentException;
@@ -29,10 +28,10 @@ final class Path
     public static function fromUri(UriInterface $uri): string
     {
         if (\DIRECTORY_SEPARATOR === '\\') {
-            return BaseUri::from($uri)->windowsPath() ?? throw new \InvalidArgumentException("Uri $uri must have scheme 'file:'.");
+            return Uri::new($uri)->toWindowsPath() ?? throw new \InvalidArgumentException("Uri $uri must have scheme 'file:'.");
         }
 
-        return BaseUri::from($uri)->unixPath() ?? throw new \InvalidArgumentException("Uri $uri must have scheme 'file:'.");
+        return Uri::new($uri)->toUnixPath() ?? throw new \InvalidArgumentException("Uri $uri must have scheme 'file:'.");
     }
 
     public static function isAbsolute(string $path): bool

--- a/src/Util/UriUtil.php
+++ b/src/Util/UriUtil.php
@@ -12,8 +12,8 @@
 
 namespace ScssPhp\ScssPhp\Util;
 
-use League\Uri\BaseUri;
 use League\Uri\Contracts\UriInterface;
+use League\Uri\Uri;
 
 /**
  * @internal
@@ -22,19 +22,19 @@ final class UriUtil
 {
     public static function resolve(UriInterface $baseUrl, string $reference): UriInterface
     {
-        $resolvedUri = BaseUri::from($baseUrl)->resolve($reference)->getUri();
+        $baseUri = Uri::new($baseUrl);
 
-        \assert($resolvedUri instanceof UriInterface);
-
-        return $resolvedUri;
+        return !$baseUri->isAbsolute()
+            ? Uri::new($reference)
+            : $baseUri->resolve($reference);
     }
 
     public static function resolveUri(UriInterface $baseUrl, UriInterface $url): UriInterface
     {
-        $resolvedUri = BaseUri::from($baseUrl)->resolve($url)->getUri();
+        $baseUri = Uri::new($baseUrl);
 
-        \assert($resolvedUri instanceof UriInterface);
-
-        return $resolvedUri;
+        return !$baseUri->isAbsolute()
+            ? $url
+            : $baseUri->resolve($url);
     }
 }


### PR DESCRIPTION
To be able to activte PHP 8.5 in the CI matrix, the `league/uri` component will have to be updated to v7.6, to fix the following issue:
```
Indirect deprecation triggered by ScssPhp\ScssPhp\Tests\ApiTest::testImportCustomCallback:
Using null as an array offset is deprecated, use an empty string instead
Stack trace:
#0 vendor/league/uri/Uri.php(372): Symfony\Bridge\PhpUnit\DeprecationErrorHandler->handleError(8192, 'Using null as a...', '/home/runner/wo...', 372)
#1 vendor/league/uri/Uri.php(227): League\Uri\Uri->formatPort(NULL)
#2 vendor/league/uri/Uri.php(391): League\Uri\Uri->__construct(NULL, NULL, Object(SensitiveParameterValue), NULL, NULL, 'variables.foo', NULL, NULL)
#3 src/Parser/StylesheetParser.php(1280): League\Uri\Uri::new('variables.foo')
[...]
```

The problem is that a change made on this future version triggers many `The base URI must be an absolute URI or null; If the base URI is null the URI must be an absolute URI.` error, and some code used by `scssphp` is deprecated. Therefore, the code needs to be adapted, and is incompatible with earlier versions of the component.