### PR TITLE
Fix the serialization of values when using them outside the compiler

### DIFF
--- a/src/Serializer/Serializer.php
+++ b/src/Serializer/Serializer.php
@@ -13,11 +13,14 @@
 namespace ScssPhp\ScssPhp\Serializer;
 
 use ScssPhp\ScssPhp\Ast\Css\CssNode;
+use ScssPhp\ScssPhp\Ast\Css\CssParentNode;
 use ScssPhp\ScssPhp\Ast\Selector\Selector;
 use ScssPhp\ScssPhp\Exception\SassScriptException;
 use ScssPhp\ScssPhp\Logger\LoggerInterface;
 use ScssPhp\ScssPhp\OutputStyle;
 use ScssPhp\ScssPhp\Value\Value;
+use ScssPhp\ScssPhp\Visitor\CssVisitor;
+use ScssPhp\ScssPhp\Visitor\ModifiableCssVisitor;
 
 /**
  * @internal
@@ -58,6 +61,10 @@ final class Serializer
      */
     public static function serializeValue(Value $value, bool $inspect = false, bool $quote = true): string
     {
+        // Force loading the CssParentNode and CssVisitor before using the visitor because of a weird PHP behavior.
+        class_exists(CssParentNode::class);
+        class_exists(CssVisitor::class);
+
         $visitor = new SerializeVisitor($inspect, $quote);
         $value->accept($visitor);
 
@@ -74,6 +81,10 @@ final class Serializer
      */
     public static function serializeSelector(Selector $selector, bool $inspect = false): string
     {
+        // Force loading the CssParentNode and CssVisitor before using the visitor because of a weird PHP behavior.
+        class_exists(CssParentNode::class);
+        class_exists(CssVisitor::class);
+
         $visitor = new SerializeVisitor($inspect);
         $selector->accept($visitor);
 


### PR DESCRIPTION
The contravariant rules related to the `CssVisitor` and the `ModifiableCssNode` layers trigger a bug in PHP where some loading orders for classes are working while others fail at resolving the classes properly, saying they don't exist.

The Compiler was already applying a workaround for this issue before using the AST classes. However, the `Value` API relies on the `SerializeVisitor` for its string representations. When using values outside the compiler (for instance when testing custom functions in unit tests), the same issue could be triggered. The workaround is now also applied in the Serializer for those usages.

Closes https://github.com/scssphp/scssphp/issues/812