### PR TITLE
Add bulma in the tested frameworks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,6 +9,6 @@ charset = utf-8
 [Makefile]
 indent_style = tab
 
-[*.php]
+[{*.php,composer.json}]
 indent_style = space
 indent_size = 4

--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,7 @@
         "ext-mbstring": "For best performance, mbstring should be installed as it is faster than the polyfill"
     },
     "require-dev": {
+        "jgthms/bulma": "~0.9.4",
         "jiripudil/phpstan-sealed-classes": "^1.3",
         "phpstan/phpstan": "^2.1.31",
         "phpstan/phpstan-deprecation-rules": "^2.0",
@@ -86,6 +87,24 @@
                     "type": "zip",
                     "url": "https://api.github.com/repos/thoughtbot/bourbon/zipball/fbe338ee6807e7f7aa996d82c8a16f248bb149b3",
                     "reference": "fbe338ee6807e7f7aa996d82c8a16f248bb149b3",
+                    "shasum": ""
+                }
+            }
+        },
+        {
+            "type": "package",
+            "package": {
+                "name": "jgthms/bulma",
+                "version": "v0.9.4",
+                "source": {
+                    "type": "git",
+                    "url": "https://github.com/jgthms/bulma.git",
+                    "reference": "3e00a8e6d0d0e566d507328f0185ef84854effba"
+                },
+                "dist": {
+                    "type": "zip",
+                    "url": "https://api.github.com/repos/jgthms/bulma/zipball/3e00a8e6d0d0e566d507328f0185ef84854effba",
+                    "reference": "3e00a8e6d0d0e566d507328f0185ef84854effba",
                     "shasum": ""
                 }
             }

--- a/tests/FrameworkTest.php
+++ b/tests/FrameworkTest.php
@@ -109,4 +109,17 @@ SCSS;
             yield substr($file->getRealPath(), strlen($baseDir) + 1) => [$file->getRealPath()];
         }
     }
+
+    public function testBulma(): void
+    {
+        $compiler = new Compiler();
+        $compiler->setLogger(new QuietLogger());
+        $compiler->setSourceMap(Compiler::SOURCE_MAP_INLINE);
+
+        $entrypoint = \dirname(__DIR__) . '/vendor/jgthms/bulma/bulma.sass';
+
+        $result = $compiler->compileFile($entrypoint);
+
+        $this->assertNotEmpty($result->getCss());
+    }
 }


### PR DESCRIPTION
This framework is also used in the dart-sass CI (although we use the 0.9.x release for now as version 1.0 requires Sass modules). This framework uses the Sass indented syntax.