### PR TITLE
Ensure that the URI resolution semantic is consistent with Dart

### DIFF
--- a/src/Util/UriUtil.php
+++ b/src/Util/UriUtil.php
@@ -14,6 +14,7 @@ namespace ScssPhp\ScssPhp\Util;
 
 use League\Uri\BaseUri;
 use League\Uri\Contracts\UriInterface;
+use League\Uri\Uri;
 
 /**
  * @internal
@@ -22,19 +23,105 @@ final class UriUtil
 {
     public static function resolve(UriInterface $baseUrl, string $reference): UriInterface
     {
-        $resolvedUri = BaseUri::from($baseUrl)->resolve($reference)->getUri();
-
-        \assert($resolvedUri instanceof UriInterface);
-
-        return $resolvedUri;
+        return self::resolveUri($baseUrl, Uri::new($reference));
     }
 
     public static function resolveUri(UriInterface $baseUrl, UriInterface $url): UriInterface
+    {
+        // Relative path reference handling
+        if ($url->getScheme() === null && $url->getAuthority() === null && $url->getPath() !== '' && $url->getPath()[0] !== '/') {
+            // non-RFC3986 behavior in Dart-Sass when resolving relative reference with a base url with no authority and a relative path (where they consider the base path as absolute)
+            if ($baseUrl->getScheme() !== null && $baseUrl->getAuthority() === null && $baseUrl->getPath() !== '' && $baseUrl->getPath()[0] !== '/') {
+                return self::resolveLeagueUri($baseUrl->withPath('/' . $baseUrl->getPath()), $url);
+            }
+
+            // Pure path resolution between 2 relative path URLs
+            if ($baseUrl->getScheme() === null && $baseUrl->getAuthority() === null && $baseUrl->getPath() !== '' && $baseUrl->getPath()[0] !== '/') {
+                $mergedPath = self::normalizeRelativePath(self::mergePaths($baseUrl->getPath(), $url->getPath()));
+
+                return $url->withPath($mergedPath);
+            }
+        }
+
+        return self::resolveLeagueUri($baseUrl, $url);
+    }
+
+    private static function resolveLeagueUri(UriInterface $baseUrl, UriInterface $url): UriInterface
     {
         $resolvedUri = BaseUri::from($baseUrl)->resolve($url)->getUri();
 
         \assert($resolvedUri instanceof UriInterface);
 
         return $resolvedUri;
+    }
+
+    /**
+     * @param non-empty-string $base
+     * @param non-empty-string $reference
+     *
+     * @return non-empty-string
+     */
+    private static function mergePaths(string $base, string $reference): string
+    {
+        \assert($reference[0] !== '/');
+
+        $baseEnd = strrpos($base, '/');
+
+        if ($baseEnd === false) {
+            return $reference;
+        }
+
+        return substr($base, 0, $baseEnd + 1) . $reference;
+    }
+
+    /**
+     * Removes all `.` segments and any non-leading `..` segments.
+     *
+     * Removing the ".." from a "bar/foo/.." sequence results in "bar/"
+     * (trailing "/"). If the entire path is removed (because it contains as
+     * many ".." segments as real segments), the result is "./".
+     * This is different from an empty string, which represents "no path"
+     * when you resolve it against a base URI with a path with a non-empty
+     * final segment.
+     *
+     * @param non-empty-string $path
+     */
+    private static function normalizeRelativePath(string $path): string
+    {
+        \assert($path[0] !== '/');
+
+        if ($path[0] !== '.' && !str_contains($path, '/.')) {
+            return $path;
+        }
+
+        $output = [];
+        $appendSlash = false;
+
+        foreach (explode('/', $path) as $segment) {
+            $appendSlash = false;
+
+            if ('..' === $segment) {
+                if ($output !== [] && ListUtil::last($output) !== '..') {
+                    array_pop($output);
+                    $appendSlash = true;
+                } else {
+                    $output[] = '..';
+                }
+            } elseif ('.' === $segment) {
+                $appendSlash = true;
+            } else {
+                $output[] = $segment;
+            }
+        }
+
+        if ($output === [] || $output === ['']) {
+            return './';
+        }
+
+        if ($appendSlash || ListUtil::last($output) === '..') {
+            $output[] = '';
+        }
+
+        return implode('/', $output);
     }
 }

--- a/tests/Util/UriUtilTest.php
+++ b/tests/Util/UriUtilTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace ScssPhp\ScssPhp\Tests\Util;
+
+use League\Uri\Contracts\UriInterface;
+use League\Uri\Uri;
+use ScssPhp\ScssPhp\Util\UriUtil;
+use PHPUnit\Framework\TestCase;
+
+class UriUtilTest extends TestCase
+{
+    /**
+     * @dataProvider provideResolveUriCases
+     */
+    public function testResolve(UriInterface $base, string $expected, string $relative): void
+    {
+        self::assertEquals($expected, UriUtil::resolve($base, $relative)->toString());
+    }
+
+    /**
+     * @dataProvider provideResolveUriCases
+     */
+    public function testResolveUri(UriInterface $base, string $expected, string $relative): void
+    {
+        self::assertEquals($expected, UriUtil::resolve($base, Uri::new($relative))->toString());
+    }
+
+    /**
+     * Test cases from https://github.com/dart-lang/sdk/blob/eaa7368470e2570bab8c9526803f8f20bdf29906/tests/corelib/uri_test.dart#L80
+     *
+     * @return iterable<array{UriInterface, string, string}>
+     */
+    public static function provideResolveUriCases(): iterable
+    {
+        $base = Uri::new('http://a/b/c/d;p?q');
+        // From RFC 3986.
+        yield [$base, 'g:h', 'g:h'];
+        yield [$base, 'http://a/b/c/g', 'g'];
+        yield [$base, 'http://a/b/c/g', './g'];
+        yield [$base, 'http://a/b/c/g/', 'g/'];
+        yield [$base, 'http://a/g', '/g'];
+        yield [$base, 'http://g', '//g'];
+        yield [$base, 'http://a/b/c/d;p?y', '?y'];
+        yield [$base, 'http://a/b/c/g?y', 'g?y'];
+        yield [$base, 'http://a/b/c/d;p?q#s', '#s'];
+        yield [$base, 'http://a/b/c/g#s', 'g#s'];
+        yield [$base, 'http://a/b/c/g?y#s', 'g?y#s'];
+        yield [$base, 'http://a/b/c/;x', ';x'];
+        yield [$base, 'http://a/b/c/g;x', 'g;x'];
+        yield [$base, 'http://a/b/c/g;x?y#s', 'g;x?y#s'];
+        yield [$base, 'http://a/b/c/d;p?q', ''];
+        yield [$base, 'http://a/b/c/', '.'];
+        yield [$base, 'http://a/b/c/', './'];
+        yield [$base, 'http://a/b/', '..'];
+        yield [$base, 'http://a/b/', '../'];
+        yield [$base, 'http://a/b/g', '../g'];
+        yield [$base, 'http://a/', '../..'];
+        yield [$base, 'http://a/', '../../'];
+        yield [$base, 'http://a/g', '../../g'];
+        yield [$base, 'http://a/g', '../../../g'];
+        yield [$base, 'http://a/g', '../../../../g'];
+        yield [$base, 'http://a/g', '/./g'];
+        yield [$base, 'http://a/g', '/../g'];
+        yield [$base, 'http://a/b/c/g.', 'g.'];
+        yield [$base, 'http://a/b/c/.g', '.g'];
+        yield [$base, 'http://a/b/c/g..', 'g..'];
+        yield [$base, 'http://a/b/c/..g', '..g'];
+        yield [$base, 'http://a/b/g', './../g'];
+        yield [$base, 'http://a/b/c/g/', './g/.'];
+        yield [$base, 'http://a/b/c/g/h', 'g/./h'];
+        yield [$base, 'http://a/b/c/h', 'g/../h'];
+        yield [$base, 'http://a/b/c/g;x=1/y', 'g;x=1/./y'];
+        yield [$base, 'http://a/b/c/y', 'g;x=1/../y'];
+        yield [$base, 'http://a/b/c/g?y/./x', 'g?y/./x'];
+        yield [$base, 'http://a/b/c/g?y/../x', 'g?y/../x'];
+        yield [$base, 'http://a/b/c/g#s/./x', 'g#s/./x'];
+        yield [$base, 'http://a/b/c/g#s/../x', 'g#s/../x'];
+        // yield [$base, 'http:g', 'http:g']; // league/uri validates the usage of hierarchical vs non-hierarchical URIs for some known schemes. Replaced by a test using a "foo" scheme below.
+
+        // Additional tests (not from RFC 3986).
+        yield [Uri::new('foo://a/b/c/d;p?q'), 'foo:g', 'foo:g'];
+        yield [$base, 'http://a/b/g;p/h;s', '../g;p/h;s'];
+
+        // Test non-URI base (no scheme, no authority, relative path).
+        $base = Uri::new('a/b/c?_#_');
+        yield [$base, 'a/b/g?q#f', 'g?q#f'];
+        yield [$base, '../', '../../..'];
+        yield [$base, 'a/b/', '.'];
+        yield [$base, 'c', '../../c'];
+
+        $base = Uri::new('s:a/b');
+        yield [$base, 's:/c', '../c'];
+    }
+}


### PR DESCRIPTION
`Uri.resolveUri` in Dart implements some behavior that is not part of the "Transform reference" algorithm of the RFC 3986 (which leaves some cases undefined behavior): https://github.com/dart-lang/sdk/blob/eaa7368470e2570bab8c9526803f8f20bdf29906/sdk/lib/core/uri.dart#L810-L823

We need to ensure that our `UrlUtil` implements the Dart semantic for this algorithm to keep our porting work simple (encapsulating that logic in a single place), including when upgrading `league/uri` (as discussed in https://github.com/scssphp/scssphp/pull/808, version 7.6 will become stricter).

The dart `Uri.resolve` API implements 3 behaviors that differ from the RFC3986 resolution algorithm:
1. when resolving a relative path reference against a base URI with a scheme, no authority and a relative path, it treats it as if the base URI path was absolute (which seems to violate the behavior of the RFC)
2. it supports resolving a relative path reference against a relative path base URL (instead of being an error case in the RFC3986) by merging the relative paths together to produce a new relative path (which preserves leading `..` segments, unlike usual path resolution on absolute URLs)
3. it supports resolving any kind of reference against a base URI without a scheme (for cases other than the previous case) by applying the algorithm of RFC3986 with an undefined scheme instead of a defined scheme (producing an undefined scheme in the result).

Case 1 and 2 are now implemented in our `UriUtil` to match the Dart behavior. The case 3 is covered already by the logic available in `league/uri` 7.5, which is why this inconsistency was not discovered until now.
Making that logic compatible with `league/uri` 7.6 (which performs strict validation of the RFC3986 algorithm) will be done separately.