### PR TITLE
Clean dead code

### DIFF
--- a/src/Ast/Sass/Interpolation.php
+++ b/src/Ast/Sass/Interpolation.php
@@ -30,31 +30,6 @@ final class Interpolation implements SassNode
     private readonly FileSpan $span;
 
     /**
-     * Creates a new {@see Interpolation} by concatenating a sequence of strings,
-     * {@see Expression}s, or nested {@see Interpolation}s.
-     *
-     * @param array<string|Expression|Interpolation> $contents
-     */
-    public static function concat(array $contents, FileSpan $span): Interpolation
-    {
-        $buffer = new InterpolationBuffer();
-
-        foreach ($contents as $element) {
-            if (\is_string($element)) {
-                $buffer->write($element);
-            } elseif ($element instanceof Expression) {
-                $buffer->add($element);
-            } elseif ($element instanceof Interpolation) {
-                $buffer->addInterpolation($element);
-            } else {
-                throw new \InvalidArgumentException(sprintf('The elements in $contents may only contains strings, Expressions, or Interpolations, "%s" given.', get_debug_type($element)));
-            }
-        }
-
-        return $buffer->buildInterpolation($span);
-    }
-
-    /**
      * @param list<string|Expression> $contents
      */
     public function __construct(array $contents, FileSpan $span)

--- a/src/Util/ErrorUtil.php
+++ b/src/Util/ErrorUtil.php
@@ -64,34 +64,4 @@ final class ErrorUtil
 
         return $formattedMessage;
     }
-
-    /**
-     * Check that a range represents a slice of an indexable object.
-     *
-     * Throws if the range is not valid for an indexable object with
-     * the given length.
-     * A range is valid for an indexable object with a given $length
-     * if `0 <= $start <= $end <= $length`.
-     * An `end` of `null` is considered equivalent to `length`.
-     *
-     * @throws \OutOfRangeException
-     */
-    public static function checkValidRange(int $start, ?int $end, int $length, ?string $startName = null, ?string $endName = null): void
-    {
-        if ($start < 0 || $start > $length) {
-            $startName ??= 'start';
-            $startNameDisplay = $startName ? " $startName" : '';
-
-            throw new \OutOfRangeException("Invalid value:$startNameDisplay must be between 0 and $length: $start.");
-        }
-
-        if ($end !== null) {
-            if ($end < $start || $end > $length) {
-                $endName ??= 'end';
-                $endNameDisplay = $endName ? " $endName" : '';
-
-                throw new \OutOfRangeException("Invalid value:$endNameDisplay must be between $start and $length: $end.");
-            }
-        }
-    }
 }


### PR DESCRIPTION
- `ErrorUtil::checkValidRange` was used only in the implementation of source spans, and so became unused when this was extracted into a separate package (which has the equivalent utility)
- `Interpolation::concat` was dead code in dart-sass (due to changing the implementation of a feature in response to a review, without properly cleaning the code added for the old solution), which has also been cleaned upstream in the meantime.