### PR TITLE
Fix issues reported by phpstan 2.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     },
     "require-dev": {
         "jgthms/bulma": "~0.9.4",
-        "phpstan/phpstan": "^2.1.42",
+        "phpstan/phpstan": "^2.2.13",
         "phpstan/phpstan-deprecation-rules": "^2.0.4",
         "phpunit/phpunit": "^9.5.6",
         "sass/sass-spec": "*",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -175,16 +175,16 @@ parameters:
 			path: src/Importer/FilesystemImporter.php
 
 		-
+			rawMessage: Offset int on string on left side of ?? always exists and is not nullable.
+			identifier: nullCoalesce.offset
+			count: 1
+			path: src/Parser/InterpolationMap.php
+
+		-
 			rawMessage: 'Call to function assert() with false and ''unknown format'' will always evaluate to false.'
 			identifier: function.impossibleType
 			count: 1
 			path: src/Serializer/SerializeVisitor.php
-
-		-
-			rawMessage: 'Call to function method_exists() with League\Uri\Contracts\UriInterface and ''resolve'' will always evaluate to true.'
-			identifier: function.alreadyNarrowedType
-			count: 1
-			path: src/Util/UriUtil.php
 
 		-
 			rawMessage: 'Method ScssPhp\ScssPhp\Value\SassMap::tryMap() never returns null so it can be removed from the return type.'

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -360,8 +360,8 @@ final class Compiler
     public function compileFile(string $path): CompilationResult
     {
         // Force loading the CssParentNode and CssVisitor before using the AST classes because of a weird PHP behavior.
-        class_exists(CssParentNode::class);
-        class_exists(CssVisitor::class);
+        interface_exists(CssParentNode::class);
+        interface_exists(CssVisitor::class);
 
         $logger = new DeprecationProcessingLogger($this->logger, $this->silenceDeprecations, $this->fatalDeprecations, $this->futureDeprecations, !$this->verbose);
         $logger->validate();
@@ -401,8 +401,8 @@ final class Compiler
     public function compileString(string $source, UriInterface|string|null $url = null, ?Importer $importer = null, Syntax $syntax = Syntax::SCSS): CompilationResult
     {
         // Force loading the CssParentNode and CssVisitor before using the AST classes because of a weird PHP behavior.
-        class_exists(CssParentNode::class);
-        class_exists(CssVisitor::class);
+        interface_exists(CssParentNode::class);
+        interface_exists(CssVisitor::class);
 
         $logger = new DeprecationProcessingLogger($this->logger, $this->silenceDeprecations, $this->fatalDeprecations, $this->futureDeprecations, !$this->verbose);
         $logger->validate();

--- a/src/Serializer/Serializer.php
+++ b/src/Serializer/Serializer.php
@@ -62,8 +62,8 @@ final class Serializer
     public static function serializeValue(Value $value, bool $inspect = false, bool $quote = true): string
     {
         // Force loading the CssParentNode and CssVisitor before using the visitor because of a weird PHP behavior.
-        class_exists(CssParentNode::class);
-        class_exists(CssVisitor::class);
+        interface_exists(CssParentNode::class);
+        interface_exists(CssVisitor::class);
 
         $visitor = new SerializeVisitor($inspect, $quote);
         $value->accept($visitor);
@@ -82,8 +82,8 @@ final class Serializer
     public static function serializeSelector(Selector $selector, bool $inspect = false): string
     {
         // Force loading the CssParentNode and CssVisitor before using the visitor because of a weird PHP behavior.
-        class_exists(CssParentNode::class);
-        class_exists(CssVisitor::class);
+        interface_exists(CssParentNode::class);
+        interface_exists(CssVisitor::class);
 
         $visitor = new SerializeVisitor($inspect);
         $selector->accept($visitor);


### PR DESCRIPTION
One new issue is added in the baseline for InterpolationMap. This seems to be a phpstan false positive which I reported at https://github.com/phpstan/phpstan/issues/15194